### PR TITLE
Allow arbitrary objects to be placed into the sass cache.

### DIFF
--- a/lib/sass/cache_store.rb
+++ b/lib/sass/cache_store.rb
@@ -45,13 +45,14 @@ module Sass
     #
     # @param key [String] The key to store it under.
     # @param sha [String] The checksum for the contents that are being stored.
-    # @param root [Sass::Tree::RootNode] The root of the tree to be stored.
+    # @param root [Sass::Tree::RootNode, Object] The root of the tree to be stored
+    #   or an arbitrary object that is coupled to stylesheet generation.
     def store(key, sha, root)
-      orig_options = root.options
+      orig_options = root.options if root.respond_to?(:options)
       begin
         _store(key, Sass::VERSION, sha, Sass::Util.dump(root))
       ensure
-        root.options = orig_options
+        root.options = orig_options if root.respond_to?(:options=)
       end
     end
 
@@ -59,7 +60,8 @@ module Sass
     #
     # @param key [String] The key the root element was stored under.
     # @param sha [String] The checksum of the root element's content.
-    # @return [Sass::Tree::RootNode] The root node.
+    # @return [Sass::Tree::RootNode, Object] The root node or the
+    #   object that was stored under key.
     def retrieve(key, sha)
       contents = _retrieve(key, Sass::VERSION, sha)
       Sass::Util.load(contents) if contents

--- a/test/sass/cache_test.rb
+++ b/test/sass/cache_test.rb
@@ -57,6 +57,13 @@ class CacheTest < Test::Unit::TestCase
     end
   end
 
+  def test_arbitrary_objects_can_go_into_cache
+    cache = Sass::InMemoryCacheStore.new
+    an_object = {:foo => :bar}
+    cache.store("an_object", "", an_object)
+    assert_equal an_object, cache.retrieve("an_object", "")
+  end
+
   private
   def root_node
     Sass::Engine.new(<<-SCSS, :syntax => :scss).to_tree


### PR DESCRIPTION
This allow lemonade to persist arbitrary data across compiles to optimize when sprites need to be rebuilt.
