### PR TITLE
added :include filter

### DIFF
--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -379,5 +379,15 @@ END
         ::Maruku.new(text).to_html
       end
     end
+
+    module Include
+      include Base
+
+      def render(path)
+        File.open(path.strip, 'r') do |fi|
+          fi.read
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
There was a question on StackOverflow about how to do a here-to type document in Haml. That got me thinking how we'd do an include without having to add Ruby code to the view. The Haml filter mechanism seemed like a good fit.

I didn't add any restrictions to the path allowed. I wasn't sure whether only allowing a known folder, or the immediate folder used by the app, would be too restrictive, but it'd be easy to add. I'm sure we're all aware of the potential for a security hole but being able to include static text seemed useful.
