### PR TITLE
Offer an option for hyphen separators in object reference identifiers

### DIFF
--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -268,30 +268,31 @@ RUBY
       ref = ref[0]
       # Let's make sure the value isn't nil. If it is, return the default Hash.
       return {} if ref.nil?
+      # DISCUSS: switch default from :underscore to :hyphen?
+      separator = (@options[:object_ref_format] == :hyphen ? '-' : '_')
       class_name =
         if ref.respond_to?(:haml_object_ref)
           ref.haml_object_ref
         else
-          underscore(ref.class)
+          reformat(ref.class, separator)
         end
-      id = "#{class_name}_#{ref.id || 'new'}"
+      id = "#{class_name}#{separator}#{ref.id || 'new'}"
       if prefix
-        class_name = "#{ prefix }_#{ class_name}"
-        id = "#{ prefix }_#{ id }"
+        class_name = "#{prefix}#{separator}#{class_name}"
+        id = "#{prefix}#{separator}#{id}"
       end
 
       {'id' => id, 'class' => class_name}
     end
 
-    # Changes a word from camel case to underscores.
-    # Based on the method of the same name in Rails' Inflector,
-    # but copied here so it'll run properly without Rails.
-    def underscore(camel_cased_word)
-      camel_cased_word.to_s.gsub(/::/, '_').
-        gsub(/([A-Z]+)([A-Z][a-z])/,'\1_\2').
-        gsub(/([a-z\d])([A-Z])/,'\1_\2').
-        tr("-", "_").
+    # Changes a word from camel case to a format using a given separator.
+    # Based on the method of the same name in Rails' Inflector.
+    def reformat(camel_cased_word, separator)
+      camel_cased_word.to_s.gsub(/::/, separator).
+        gsub(/([A-Z]+)([A-Z][a-z])/, '\1' + separator + '\2').
+        gsub(/([a-z\d])([A-Z])/, '\1' + separator + '\2').
         downcase
     end
+    
   end
 end

--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -87,6 +87,7 @@ module Haml
         :format => :xhtml,
         :escape_html => false,
         :escape_attrs => true,
+        :object_ref_format => :underscore
       }
 
 
@@ -298,6 +299,7 @@ module Haml
         :encoding => @options[:encoding],
         :escape_html => @options[:escape_html],
         :escape_attrs => @options[:escape_attrs],
+        :object_ref_format => @options[:object_ref_format]
       }
     end
 

--- a/lib/haml/exec.rb
+++ b/lib/haml/exec.rb
@@ -222,6 +222,11 @@ END
           @options[:for_engine][:attr_wrapper] = '"'
         end
 
+        opts.on('-o', '--object-ref-format FORMAT',
+                'Separator format for the object reference operator "[]". Can be underscore (default) or hyphen.') do |format|
+          @options[:for_engine][:object_ref_format] = format.to_sym
+        end
+
         opts.on('-r', '--require FILE', "Same as 'ruby -r'.") do |file|
           @options[:requires] << file
         end

--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -1282,6 +1282,16 @@ HAML
                  render("%p[user]{:style => 'width: 100px;'} New User", :locals => {:user => user}))
   end
 
+  def test_object_ref_with_format_hyphen
+    user = User.new 42
+    assert_equal("<p class='struct-user' id='struct-user-42'>New User</p>\n",
+                 render("%p[user] New User", :locals => {:user => user}, :object_ref_format => :hyphen))
+    
+    user = User.new
+    assert_equal("<p class='struct-user' id='struct-user-new'>New User</p>\n",
+                 render("%p[user] New User", :locals => {:user => user}, :object_ref_format => :hyphen))
+  end
+
   def test_object_ref_with_custom_haml_class
     custom = CustomHamlClass.new 42
     assert_equal("<p class='my_thing' id='my_thing_42' style='width: 100px;'>My Thing</p>\n",


### PR DESCRIPTION
CSS and HTML support two formats for classes and ids: underscore separators (class="my_class") and hyphen separators (class="my-class"). However, Haml's object reference operator ([ ]) has a hardcoded underscore separator. 

This patch adds an template engine option that allows for choosing between :underscore and :hyphen format (test case and option for haml executable included).

At the moment, :underscore is still the default for the sake of backward compatibility. However, I think :hyphen would be the more appropriate default option nowadays. The hyphen-separated format is considered to be better readable, cleaner, easier to type and fits to CSS attributes (font-size), pseudo selectors (:last-child) and e.g. Compass mixins (border-radius).
