### PR TITLE
Hi, found issue with jruby 

### DIFF
--- a/lib/haml/helpers/action_view_mods.rb
+++ b/lib/haml/helpers/action_view_mods.rb
@@ -164,7 +164,7 @@ module ActionView
           wrap_block = block_given? && is_haml? && block_is_haml?(proc)
           if wrap_block
             oldproc = proc
-            proc = proc {|*args| with_tabs(1) {oldproc.call(*args)}}
+            proc = proc {|*args_local| with_tabs(1) {oldproc.call(*args_local)}}
           end
           res = form_for_without_haml(object_name, *args, &proc)
           res << "\n" if wrap_block
@@ -224,9 +224,9 @@ module ActionView
           wrap_block = block_given? && is_haml? && block_is_haml?(proc)
           if wrap_block
             oldproc = proc
-            proc = haml_bind_proc do |*args|
+            proc = haml_bind_proc do |*args_local|
               tab_up
-              oldproc.call(*args)
+              oldproc.call(*args_local)
               tab_down
               concat haml_indent
             end


### PR DESCRIPTION
When I tried running our app with JRuby Head ruby 1.9 mode I get the following error:

My fix was changing the *args to *args_local in action_view_mods.rb

/Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/actionmailer-2.3.8/lib/action_mailer/vendor/tmail-1.2.7/tmail/net.rb:146 warning: optional boolean argument is obsoleted
/Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/actionmailer-2.3.8/lib/action_mailer/vendor/tmail-1.2.7/tmail/net.rb:165 warning: optional boolean argument is obsoleted
org/jruby/RubyKernel.java:1050:in `require19': /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/haml-3.0.25/lib/haml/helpers/action_view_mods.rb:167: duplicate rest argument name            proc = proc {|*args| with_tabs(1) {oldproc.call(*args)}} (SyntaxError)
                              ^
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/activesupport-2.3.8/lib/active_support/dependencies.rb:156:in`require'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/haml-3.0.25/lib/haml/helpers/action_view_mods.rb:521:in `new_constants_in'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/activesupport-2.3.8/lib/active_support/dependencies.rb:156:in`require'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/haml-3.0.25/lib/haml/template.rb:3:in `(root)'
    from org/jruby/RubyKernel.java:1076:in`load19'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/haml-3.0.25/lib/haml/template.rb:380:in `load_file'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/activesupport-2.3.8/lib/active_support/dependencies.rb:521:in`new_constants_in'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/activesupport-2.3.8/lib/active_support/dependencies.rb:379:in `load_file'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/activesupport-2.3.8/lib/active_support/dependencies.rb:259:in`require_or_load'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/activesupport-2.3.8/lib/active_support/dependencies.rb:425:in `load_missing_constant'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/activesupport-2.3.8/lib/active_support/dependencies.rb:80:in`const_missing_with_dependencies'
    from /Users/francisco/realtravel/rtsite/realtravel.com/config/environments/development.rb:473:in `load_environment'
    from org/jruby/RubyKernel.java:1096:in`eval19'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/rails-2.3.8/lib/initializer.rb:386:in `load_environment'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/activesupport-2.3.8/lib/active_support/core_ext/kernel/reporting.rb:11:in`silence_warnings'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/rails-2.3.8/lib/initializer.rb:379:in `load_environment'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/rails-2.3.8/lib/initializer.rb:137:in`process'
    from org/jruby/RubyBasicObject.java:1650:in `send19'
    from org/jruby/RubyObject.java:1372:in`send19'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/rails-2.3.8/lib/initializer.rb:113:in `run'
    from /Users/francisco/realtravel/rtsite/realtravel.com/config/environment.rb:21:in`(root)'
    from org/jruby/RubyKernel.java:1050:in `require19'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/activesupport-2.3.8/lib/active_support/dependencies.rb:156:in`require'
    from /Users/francisco/realtravel/rtsite/realtravel.com/config/environment.rb:521:in `new_constants_in'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/activesupport-2.3.8/lib/active_support/dependencies.rb:156:in`require'
    from /Users/francisco/realtravel/rtsite/realtravel.com/gems/jruby/1.9/gems/rails-2.3.8/lib/commands/server.rb:84:in `(root)'
    from org/jruby/RubyKernel.java:1050:in`require19'
