### PR TITLE
jruby --1.9 issue with shadowed *args

### DIFF
--- a/lib/haml/helpers/action_view_mods.rb
+++ b/lib/haml/helpers/action_view_mods.rb
@@ -164,7 +164,7 @@ module ActionView
           wrap_block = block_given? && is_haml? && block_is_haml?(proc)
           if wrap_block
             oldproc = proc
-            proc = proc {|*args| with_tabs(1) {oldproc.call(*args)}}
+            proc = proc {|*moreargs| with_tabs(1) {oldproc.call(*moreargs)} }
           end
           res = form_for_without_haml(object_name, *args, &proc)
           res << "\n" if wrap_block
@@ -224,9 +224,9 @@ module ActionView
           wrap_block = block_given? && is_haml? && block_is_haml?(proc)
           if wrap_block
             oldproc = proc
-            proc = haml_bind_proc do |*args|
+            proc = haml_bind_proc do |*moreargs|
               tab_up
-              oldproc.call(*args)
+              oldproc.call(*moreargs)
               tab_down
               concat haml_indent
             end


### PR DESCRIPTION
Jruby 1.6 RC1 with ruby 1.9 support enabled does not like shadowed *args variables.  I generated this pull request against stable hoping for another micro release before the haml / sass split is finished if possible :)
