### PR TITLE
Html2haml default output

### DIFF
--- a/lib/haml/exec.rb
+++ b/lib/haml/exec.rb
@@ -109,7 +109,10 @@ module Haml
             @options[:filename] = filename
             open_file(filename) || $stdin
           end
-        output ||= open_file(args.shift, 'w') || $stdout
+        output ||=
+          open_file(args.shift, 'w') ||
+          open_file(filename.gsub(File.extname(filename), "") + '.haml', 'w') ||
+          $stdout
 
         @options[:input], @options[:output] = input, output
       end


### PR DESCRIPTION
When introducing new developers to Haml, I've noticed a tendency for people to assume passing no output arguments to html2haml will provide some sort of default. I've added a default output to support this.
Now running `html2haml path/to/my/file.html.erb path/to/my/file.html.haml` will work as it always has, but running `html2haml path/to/my/file.html.erb` will create a new Haml file at path/to/my/file.html.haml (the html extension is optional and will be handled appropriately).
