### PR TITLE
Fix compatibility problem with ruby 1.8

### DIFF
--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -105,8 +105,10 @@ module Haml
         raise Haml::Error, "Invalid output format #{@options[:format].inspect}"
       end
 
-      if @options[:encoding] && @options[:encoding].is_a?(Encoding)
-        @options[:encoding] = @options[:encoding].name
+      unless ruby1_8?
+        if @options[:encoding] && @options[:encoding].is_a?(Encoding)
+          @options[:encoding] = @options[:encoding].name
+        end
       end
 
       # :eod is a special end-of-document marker


### PR DESCRIPTION
Patch to make haml work on ruby 1.8 even when :encoding option is used
