### PR TITLE
Automatically convert -'s (hyphens) in HTML comments to something that doesn't result in an invalid comment 

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -365,6 +365,14 @@ END
       line.strip!
       conditional << ">" if conditional
 
+      if line =~ /--+>/
+        line = line.gsub(/--+>/, "--><!--")
+      elsif line =~ /<!--+/
+        line = line.gsub(/<!--+/, "--><!--")
+      elsif line =~ /-(-+)/
+        line = line.gsub(/-(-+)/, '-' + ' ' * $1.length)
+      end  
+
       if block_opened? && !line.empty?
         raise SyntaxError.new('Illegal nesting: nesting within a tag that already has content is illegal.', @next_line.index)
       end

--- a/test/haml/results/helpers.xhtml
+++ b/test/haml/results/helpers.xhtml
@@ -31,6 +31,9 @@
       <h1>Big!</h1>
       <p>Small</p>
       <!-- Invisible -->
+      <!-- Invisible -   invisible -->
+      <!-- -                     invisible -                     -->
+      <!-- --><!-- -->
     </div>
     <div class='dilly'>
       <p>foo</p>

--- a/test/haml/templates/helpers.haml
+++ b/test/haml/templates/helpers.haml
@@ -19,6 +19,9 @@
         %h1 Big!
         %p Small
         / Invisible
+        / Invisible --- invisible
+        /--------------------- invisible -----
+        /<!--
     = capture do
       .dilly
         %p foo


### PR DESCRIPTION
Pacth for a very minor issue with hyphens in comments.

This is my first (ever) contribution to an open source project so if anything seems incorrect please let me know.

I've fixed the issue and added it to the test document.

Thanks for maintaining HAML,
Tony
