### PR TITLE
Fix for issue 384

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -145,7 +145,7 @@ END
         end
 
         @tab_up = nil
-        process_line(@line.text, @line.index) unless @line.text.empty? || @haml_comment
+        process_line(@line.text, @line.index) unless @line.text.empty?
         if block_opened? || @tab_up
           @template_tabs += 1
           @parent = @parent.children.last


### PR DESCRIPTION
Lines weren't being processed inside a nested comment which meant that
the parent node ended up being nil for the child lines. This broke
things when popping back up the stack. Since a push never happens for
the line and therefore the children were empty.

This fix makes comments be processed. That might not be the desired
result since there isn't much point in processing silent comments. But
it is a quick fix :)
