### PR TITLE
Revert change that breaks ruby 1.8.6 support

### DIFF
--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -37,7 +37,7 @@ module Haml
     # @param arr [Array<(Object, Object)>] An array of pairs
     # @return [Hash] A hash
     def to_hash(arr)
-      Hash[arr.compact]
+      arr.compact.inject({}) {|h, (k, v)| h[k] = v; h}
     end
 
     # Maps the keys in a hash according to a block.


### PR DESCRIPTION
Ruby 1.8.6 doesn't have the Hash[array] constructor,
Therefore the cosmetical change in 0bf222 breaks support
for 1.8.6 without providing any advantage (beside the neater
looking syntax).

This reverts commit 0bf222677f919efe17d6bf1ae0ff32a7fdb7aed6.
