### PR TITLE
Fixed broken links. Hashes are #options and #encodings

### DIFF
--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -20,7 +20,7 @@ module Haml
     include Compiler
 
     # The options hash.
-    # See {file:HAML_REFERENCE.md#haml_options the Haml options documentation}.
+    # See {file:HAML_REFERENCE.md#options the Haml options documentation}.
     #
     # @return [{Symbol => Object}]
     attr_accessor :options
@@ -55,7 +55,7 @@ module Haml
     # The source code that is evaluated to produce the Haml document.
     #
     # In Ruby 1.9, this is automatically converted to the correct encoding
-    # (see {file:HAML_REFERENCE.md#encoding-option the `:encoding` option}).
+    # (see {file:HAML_REFERENCE.md#encodings the `:encoding` option}).
     #
     # @return [String]
     def precompiled
@@ -69,7 +69,7 @@ module Haml
     #
     # @param template [String] The Haml template
     # @param options [{Symbol => Object}] An options hash;
-    #   see {file:HAML_REFERENCE.md#haml_options the Haml options documentation}
+    #   see {file:HAML_REFERENCE.md#options the Haml options documentation}
     # @raise [Haml::Error] if there's a Haml syntax error in the template
     def initialize(template, options = {})
       @options = {
@@ -285,7 +285,7 @@ module Haml
     # All of the values here are such that when `#inspect` is called on the hash,
     # it can be `Kernel#eval`ed to get the same result back.
     #
-    # See {file:HAML_REFERENCE.md#haml_options the Haml options documentation}.
+    # See {file:HAML_REFERENCE.md#options the Haml options documentation}.
     #
     # @return [{Symbol => Object}] The options hash
     def options_for_buffer


### PR DESCRIPTION
I recognized that the links to the documentation are broken. This patch should fix the ones I found so far.
