### PR TITLE
[Haml] Add support for Redcarpet markdown

### DIFF
--- a/doc-src/HAML_CHANGELOG.md
+++ b/doc-src/HAML_CHANGELOG.md
@@ -14,6 +14,9 @@
 
 * Fix an issue where destructive modification was sometimes performed on Rails SafeBuffers.
 
+* Add support for [Redcarpet](https://github.com/tanoku/redcarpet)
+  markdown.
+
 ## 3.1.1
 
 * Update the vendored Sass to version 3.1.0.

--- a/doc-src/HAML_REFERENCE.md
+++ b/doc-src/HAML_REFERENCE.md
@@ -1270,7 +1270,8 @@ Parses the filtered text with [Markdown](http://daringfireball.net/projects/mark
 Only works if [RDiscount](http://github.com/rtomayko/rdiscount),
 [RPeg-Markdown](http://github.com/rtomayko/rpeg-markdown),
 [Maruku](http://maruku.rubyforge.org),
-or [BlueCloth](www.deveiate.org/projects/BlueCloth) are installed.
+[BlueCloth](www.deveiate.org/projects/BlueCloth),
+or [Redcarpet](https://github.com/tanoku/redcarpet) are installed.
 
 {#maruku-filter}
 ### `:maruku`

--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -352,7 +352,7 @@ END
     # or [BlueCloth](www.deveiate.org/projects/BlueCloth) are installed.
     module Markdown
       include Base
-      lazy_require 'rdiscount', 'peg_markdown', 'maruku', 'bluecloth'
+      lazy_require 'rdiscount', 'peg_markdown', 'maruku', 'bluecloth', 'redcarpet'
 
       # @see Base#render
       def render(text)
@@ -365,6 +365,8 @@ END
                    ::Maruku
                  when 'bluecloth'
                    ::BlueCloth
+                 when 'redcarpet'
+                   ::Redcarpet
                  end
         engine.new(text).to_html
       end


### PR DESCRIPTION
[Redcarpet](https://github.com/tanoku/redcarpet) is a ruby wrapper for the [Upskirt](https://github.com/tanoku/upskirt) C markdown library. I've made these changes locally and used Recarpet to render using :markdown in a Sinatra and Rails app. 

I grepped around for tests which were testing rdiscount or similar markdown parsers and didn't find any. Let me know if I've overlooked them.
