### PR TITLE
Escape with key codes instead of named HTML entities (for IE support) #418

### DIFF
--- a/doc-src/HAML_CHANGELOG.md
+++ b/doc-src/HAML_CHANGELOG.md
@@ -14,6 +14,8 @@
 
 * Fix an issue where destructive modification was sometimes performed on Rails SafeBuffers.
 
+* Use character code entities for attribute value replacements instead of named/keyword entities.
+
 ## 3.1.1
 
 * Update the vendored Sass to version 3.1.0.

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -346,7 +346,7 @@ END
 
     # This is a class method so it can be accessed from Buffer.
     def self.build_attributes(is_html, attr_wrapper, escape_attrs, attributes = {})
-      quote_escape = attr_wrapper == '"' ? "&quot;" : "&apos;"
+      quote_escape = attr_wrapper == '"' ? "&#34;" : "&#39;"
       other_quote_char = attr_wrapper == '"' ? "'" : '"'
 
       if attributes['data'].is_a?(Hash)
@@ -379,7 +379,7 @@ END
         value = Haml::Helpers.preserve(escaped)
         if escape_attrs
           # We want to decide whether or not to escape quotes
-          value = value.gsub('&quot;', '"')
+          value = value.gsub('&quot;', '"').gsub('&#34;', '"')
           this_attr_wrapper = attr_wrapper
           if value.include? attr_wrapper
             if value.include? other_quote_char

--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -1094,7 +1094,7 @@ HAML
     assert_equal("<p strange=*attrs*></p>\n", render("%p{ :strange => 'attrs'}", :attr_wrapper => '*'))
     assert_equal("<p escaped='quo\"te'></p>\n", render("%p{ :escaped => 'quo\"te'}", :attr_wrapper => '"'))
     assert_equal("<p escaped=\"quo'te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped=\"q'uo&quot;te\"></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"q'uo&#34;te\"></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
     assert_equal("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n", render("!!! XML", :attr_wrapper => '"'))
   end
 
@@ -1466,7 +1466,7 @@ HAML
     assert_equal("<div data-one_plus_one='2'></div>\n",
       render("%div{:data => {:one_plus_one => 1+1}}"))
 
-    assert_equal("<div data-foo='Here&apos;s a \"quoteful\" string.'></div>\n",
+    assert_equal("<div data-foo='Here&#39;s a \"quoteful\" string.'></div>\n",
       render(%{%div{:data => {:foo => %{Here's a "quoteful" string.}}}})) #'
   end
 


### PR DESCRIPTION
When attribute values contain both an apostrophe and a double quote,
we should substitute the character being used to wrap the value with
its key code instead of named/keyword entities (for IE support).

Fixes #418.
