### PR TITLE
PHP Support

### DIFF
--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -204,7 +204,7 @@ module Haml
       def render(text)
         <<END
 <?php
-  #{text}
+  #{text.rstrip.gsub("\n", "\n  ")}
 ?>
 END
       end


### PR DESCRIPTION
Added a `:php` filter into `filters.rb` to surround filtered text with `<?php ?>` tags.
