### PR TITLE
Fix link in HAML_REFERENCE.md.

### DIFF
--- a/doc-src/HAML_REFERENCE.md
+++ b/doc-src/HAML_REFERENCE.md
@@ -96,7 +96,7 @@ Haml doesn't escape Ruby strings by default.
 However, if a string marked HTML-safe is passed to [Haml's escaping syntax](#escaping_html),
 it won't be escaped.
 
-Finally, all the {file:Haml/Helpers.html Haml helpers} that return strings
+Finally, all the {Haml::Helpers Haml helpers} that return strings
 that are known to be HTML safe are marked as such.
 In addition, string input is escaped unless it's HTML safe.
 


### PR DESCRIPTION
I noticed a link in the docs isn't working, this patch fixes it.

Use yard "object" link rather than "file" link so that link to Helpers
module works.
