### PR TITLE
Recognize haml context with form_for

### DIFF
--- a/lib/haml/helpers/action_view_mods.rb
+++ b/lib/haml/helpers/action_view_mods.rb
@@ -177,7 +177,7 @@ module ActionView
           wrap_block = block_given? && is_haml? && block_is_haml?(proc)
           if wrap_block
             oldproc = proc
-            proc = proc {|*args| with_tabs(1) {oldproc.call(*args)}}
+            proc = haml_bind_proc {|*args| with_tabs(1) {oldproc.call(*args)}}
           end
           res = form_for_without_haml(object_name, *args, &proc)
           res << "\n" if wrap_block


### PR DESCRIPTION
Hi Hampton, Nathan, Chris,

I ran across this while working on https://github.com/infbio/haml_assets which is a way to use haml with the Rails 3.1 asset pipeline and have all the Rails helpers available.

There is no test. It would be great if there was a setup your dev environment how-to so that folks like me can just pop in, get an environment working and write patches with tests.

Thanks for the great work with haml!
