### PR TITLE
Fix signature of InstanceTag#content_tag. (again)

### DIFF
--- a/lib/haml/helpers/action_view_mods.rb
+++ b/lib/haml/helpers/action_view_mods.rb
@@ -130,7 +130,8 @@ module ActionView
     end
 
     class InstanceTag
-      # Includes TagHelper
+      # Already includes TagHelper
+      include Haml::Helpers
 
       def haml_buffer
         @template_object.send :haml_buffer
@@ -140,8 +141,8 @@ module ActionView
         @template_object.send :is_haml?
       end
 
-      def content_tag(*args)
-        html_tag = content_tag_with_haml(*args)
+      def content_tag(*args, &block)
+        html_tag = content_tag_with_haml(*args, &block)
         return html_tag unless respond_to?(:error_wrapping)
         return error_wrapping(html_tag) if method(:error_wrapping).arity == 1
         return html_tag unless object.respond_to?(:errors) && object.errors.respond_to?(:on)

--- a/test/haml/template_test.rb
+++ b/test/haml/template_test.rb
@@ -297,6 +297,22 @@ HAML
     end
   end
 
+  if ActionPack::VERSION::MAJOR >= 3
+    # Rails 3's #label helper can take a block.
+    def test_form_builder_label_with_block
+      assert_equal(<<HTML, render(<<HAML, :action_view))
+<form #{rails_form_attr}action="" method="post">#{rails_form_opener}
+  <label for="article_title">Block content
+  </label>
+</form>
+HTML
+#{rails_block_helper_char} form_for #{form_for_calling_convention(:article)}, :url => '' do |f|
+  = f.label :title do
+    Block content
+HAML
+    end
+  end
+
   ## XSS Protection Tests
 
   # In order to enable these, either test against Rails 3.0


### PR DESCRIPTION
This is from #441, with a guard clause now added to protect against pre-3.0 versions of Rails which did not support a block syntax for the label helper.
