### PR TITLE
Handle records with multiple IDs in object reference #438

### DIFF
--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -274,7 +274,14 @@ RUBY
         else
           underscore(ref.class)
         end
-      id = "#{class_name}_#{ref.id || 'new'}"
+      ref_id =
+        if ref.respond_to?(:to_key)
+          key = ref.to_key
+          key.join('_') unless key.nil? #TODO further sanitize each key like dom_id
+        else
+          ref.id
+        end
+      id = "#{class_name}_#{ref_id || 'new'}"
       if prefix
         class_name = "#{ prefix }_#{ class_name}"
         id = "#{ prefix }_#{ id }"

--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -100,7 +100,6 @@ MESSAGE
       [*self.id] unless id.nil?
     end
   end
-      
 
   def render(text, options = {}, &block)
     scope  = options.delete(:scope)  || Object.new


### PR DESCRIPTION
See issue #438

`parse_object_ref` checks for `to_key` method, which (as defined by ActiveModel) should return an array. If referenced object responds to that method, its unique ID is generated from it. Otherwise it'll fall back to `ref.id` (current behaviour).
