### PR TITLE
RedCarpet support notation added to HAML_CHANGELOG

### DIFF
--- a/doc-src/HAML_CHANGELOG.md
+++ b/doc-src/HAML_CHANGELOG.md
@@ -6,6 +6,7 @@
 ## 3.2.0 (Unreleased)
 
 * Add Kramdown support to Markdown filter.
+* Add RedCarpet support to Markdown filter.
 
 ## 3.1.4 (Unreleased)
 


### PR DESCRIPTION
[This pull](https://github.com/nex3/haml/pull/383) added support for RedCarpet. Just notating it in the Changelog.
