### PR TITLE
Correct invocation of the Redcarpet engine

### DIFF
--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -1,4 +1,3 @@
-
 module Haml
   # The module containing the default Haml filters,
   # as well as the base module, {Haml::Filters::Base}.
@@ -399,7 +398,11 @@ END
 
       # @see Base#render
       def render(text)
-        ::Redcarpet::Markdown.new(::Redcarpet::Render::HTML.new).render(text)
+        if Gem.loaded_specs['redcarpet'].version >= Gem::Version.create('2.0')
+          ::Redcarpet::Markdown.new(::Redcarpet::Render::HTML.new).render(text)
+        else
+          ::Redcarpet.new(text).to_html
+        end
       end
     end
 


### PR DESCRIPTION
This was discussed in #381 and [just pulled in](https://github.com/nex3/haml/pull/383), but the change doesn’t appear to work since Redcarpet doesn't get instantiated the same way as the other processors.

I think this is what we're looking for instead.
