### PR TITLE
attribute escaping respects html_safe

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -372,7 +372,7 @@ END
           if escape_attrs == :once
             Haml::Helpers.escape_once(value.to_s)
           elsif escape_attrs
-            CGI.escapeHTML(value.to_s)
+            Haml::Helpers.html_escape(value.to_s)
           else
             value.to_s
           end

--- a/test/haml/template_test.rb
+++ b/test/haml/template_test.rb
@@ -339,6 +339,14 @@ HAML
       assert_equal("Foo &amp; Bar\n", render('Foo #{"&"} Bar', :action_view))
     end
 
+    def test_xss_protection_in_attributes
+      assert_equal("<div data-html='&lt;foo&gt;bar&lt;/foo&gt;'></div>\n", render('%div{ "data-html" => "<foo>bar</foo>" }', :action_view))
+    end
+
+    def test_xss_protection_in_attributes_with_safe_strings
+      assert_equal("<div data-html='<foo>bar</foo>'></div>\n", render('%div{ "data-html" => "<foo>bar</foo>".html_safe }', :action_view))
+    end
+
     def test_xss_protection_with_bang_in_interpolation
       assert_equal("Foo & Bar\n", render('! Foo #{"&"} Bar', :action_view))
     end


### PR DESCRIPTION
it's sometimes the case where we don't want attributes to be
html_escaped... for instance `%input{ placeholder: 'Filter&hellip;' }`

this commit changes the attribute escaping to respect the rails
`html_safe` flag and not escape attributes when `.html_safe` is
explicitly called on them
