### PR TITLE
added option --html-attributes to html2haml

### DIFF
--- a/lib/haml/exec.rb
+++ b/lib/haml/exec.rb
@@ -334,6 +334,10 @@ END
           @module_opts[:xhtml] = true
         end
 
+        opts.on("--html-attributes", "Use HTML style attributes instead of Ruby hash style.") do
+          @module_opts[:html_style_attributes] = true
+        end
+
         super
       end
 

--- a/lib/haml/html.rb
+++ b/lib/haml/html.rb
@@ -401,11 +401,24 @@ module Haml
       # that's prettier than that produced by Hash#inspect
       def haml_attributes(options)
         attrs = attr_hash.sort.map do |name, value|
-          value = dynamic_attribute?(name, options) ? dynamic_attributes[name] : value.inspect
+          haml_attribute_pair(name, value, options)
+        end
+        if options[:html_style_attributes]
+          "(#{attrs.join(' ')})"
+        else
+          "{#{attrs.join(', ')}}"
+        end
+      end
+
+      # Returns the string representation of a single attribute key value pair
+      def haml_attribute_pair(name, value, options)
+        value = dynamic_attribute?(name, options) ? dynamic_attributes[name] : value.inspect
+        if options[:html_style_attributes]
+          "#{name}=#{value}"
+        else
           name = name.index(/\W/) ? name.inspect : ":#{name}"
           "#{name} => #{value}"
         end
-        "{#{attrs.join(', ')}}"
       end
     end
   end

--- a/test/haml/html2haml_test.rb
+++ b/test/haml/html2haml_test.rb
@@ -41,6 +41,13 @@ class Html2HamlTest < Test::Unit::TestCase
       render('<meta http-equiv="Content-Type" content="text/html" />'))
   end
 
+  def test_should_have_html_style_attributes
+    assert_equal('%input(name="login" type="text")/',
+      render('<input type="text" name="login" />', :html_style_attributes => true))
+    assert_equal('%meta(content="text/html" http-equiv="Content-Type")/',
+      render('<meta http-equiv="Content-Type" content="text/html" />', :html_style_attributes => true))
+  end
+
   def test_class_with_dot_and_hash
     assert_equal('%div{:class => "foo.bar"}', render("<div class='foo.bar'></div>"))
     assert_equal('%div{:class => "foo#bar"}', render("<div class='foo#bar'></div>"))


### PR DESCRIPTION
uses HTML style attributes: %div(attr="123") instead of a Ruby hash with this new option.

let me know what you guys think.
