### PR TITLE
Allow escape_attrs on a per-tag basis

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -349,6 +349,9 @@ END
       quote_escape = attr_wrapper == '"' ? "&quot;" : "&apos;"
       other_quote_char = attr_wrapper == '"' ? "'" : '"'
 
+      # Allow escape_attrs on a per-tag basis
+      escape_attrs = attributes['escape_attrs'] if attributes.has_key?('escape_attrs')
+
       if attributes['data'].is_a?(Hash)
         attributes = attributes.dup
         attributes =

--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -636,6 +636,17 @@ HTML
   bar
 HAML
   end
+  
+  def test_escape_attrs_can_be_overridden_in_tag
+    assert_equal(<<HTML, render(<<HAML, :escape_attrs => true))
+<div class='<?php echo "&quot;" ?>' id='foo'>
+  bar
+</div>
+HTML
+#foo{:class => '<?php echo "&quot;" ?>', :escape_attrs => false}
+  bar
+HAML
+  end
 
   def test_escape_attrs_always
     assert_equal(<<HTML, render(<<HAML, :escape_attrs => :always))


### PR DESCRIPTION
There are situations where you might want escape_attrs to only be allowed for some pages or tags. This simple change allows this so that you can pass :escape_attrs into the haml tag.

A new test is provided along with the implementation.
