### PR TITLE
[Haml] Add SCSS filter.

### DIFF
--- a/doc-src/HAML_CHANGELOG.md
+++ b/doc-src/HAML_CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add RedCarpet support to Markdown filter.
 * Performance improvements (thanks to [Chris Heald](https://github.com/cheald)).
 * Generate object references based on `#to_key` if it exists in preference to `#id`.
+* Add SCSS filter.
 
 ## 3.1.5 (Unreleased)
 

--- a/doc-src/HAML_REFERENCE.md
+++ b/doc-src/HAML_REFERENCE.md
@@ -1259,6 +1259,11 @@ Embedded Ruby code is evaluated in the same context as the Haml template.
 ### `:sass`
 Parses the filtered text with Sass to produce CSS output.
 
+{#scss-filter}
+### `:scss`
+Parses the filtered text with Sass like the `:sass` filter, but uses the newer SCSS
+syntax to produce CSS output.
+
 {#textile-filter}
 ### `:textile`
 Parses the filtered text with [Textile](http://www.textism.com/tools/textile).

--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -313,6 +313,17 @@ END
       end
     end
 
+    # Parses the filtered text with {Sass} to produce CSS output using SCSS syntax.
+    module Scss
+      include Base
+      lazy_require 'sass/plugin'
+
+      # @see Base#render
+      def render(text)
+        ::Sass::Engine.new(text, ::Sass::Plugin.engine_options.merge(:syntax => :scss)).render
+      end
+    end
+
     # Parses the filtered text with ERB.
     # Not available if the {file:HAML_REFERENCE.md#suppress_eval-option `:suppress_eval`} option is set to true.
     # Embedded Ruby code is evaluated in the same context as the Haml template.

--- a/test/haml/results/filters.xhtml
+++ b/test/haml/results/filters.xhtml
@@ -5,6 +5,13 @@
   /* line 6 */
   h1 { font-weight: normal; }
 </style>
+<style>
+  /* line 1 */
+  p { border-style: dotted; border-width: 22px; border-color: fuchsia; }
+  
+  /* line 8 */
+  h1 { font-weight: normal; }
+</style>
 TESTING HAHAHAHA!
 <p>
   <script type='text/javascript'>

--- a/test/haml/templates/filters.haml
+++ b/test/haml/templates/filters.haml
@@ -9,6 +9,20 @@
     h1
       :font-weight normal
 
+%style
+  - width = 5 + 17
+  :scss
+    p {
+      border: {
+        style: dotted;
+        width: #{width}px;
+        color: #ff00ff
+      }
+    }
+    h1 {
+      font-weight: normal;
+    }
+
 :test
   This
   Should


### PR DESCRIPTION
Add filter to generate CSS from Sass using SCSS syntax.

Addresses issue #474.

I opted to keep the filter simple and standalone, rather than trying to do something like `include Sass`.

`git diff --check` does show extra whitespace, but this is in the expected results file, and the tests fail without it (the whitespace is in the `:sass` output too).
