### PR TITLE
[Haml] Fix nuke innerwhite space in loop.

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -53,10 +53,22 @@ END
       push_text @node.value[:text]
     end
 
+    def nuke_inner_whitespace?(node)
+      if node.value && node.value[:nuke_inner_whitespace]
+        true
+      elsif node.parent
+        nuke_inner_whitespace?(node.parent)
+      else
+        false
+      end
+    end
+
     def compile_script(&block)
       push_script(@node.value[:text],
-        :preserve_script => @node.value[:preserve],
-        :escape_html => @node.value[:escape_html], &block)
+                  :preserve_script       => @node.value[:preserve],
+                  :escape_html           => @node.value[:escape_html],
+                  :nuke_inner_whitespace => nuke_inner_whitespace?(@node),
+                  &block)
     end
 
     def compile_silent_script


### PR DESCRIPTION
At a recent Ruby hack night, I was inspired to investigate #465.

I've taken a stab at fixing it, I would appreciate any comments.  This approach walks back up the node tree, searching for the first node, if any, which had enabled :nuke_inner_whitespace.

All tests pass (`rake test`), but from docs I've understood there are no tests for script or silent-script node types.. ?

After the fix, the Haml below produces the desired HTML.

``` haml
%ul<
  - for str in %w[foo bar baz]
    = str
```

``` html
<ul>foobarbaz</ul>
```
