### PR TITLE
In parse_object_ref, when building the class name, if #haml_object_ref is not available, try #model_name before using the class name

### DIFF
--- a/doc-src/HAML_CHANGELOG.md
+++ b/doc-src/HAML_CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add RedCarpet support to Markdown filter.
 * Performance improvements (thanks to [Chris Heald](https://github.com/cheald)).
 * Generate object references based on `#to_key` if it exists in preference to `#id`.
+* Generate object references based on `#model_name` if it exists before using the class name (thanks to [Hugo Frappier](https://github.com/frahugo)).
 
 ## 3.1.5 (Unreleased)
 

--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -271,6 +271,8 @@ RUBY
       class_name =
         if ref.respond_to?(:haml_object_ref)
           ref.haml_object_ref
+        elsif ref.respond_to?(:model_name)
+          ref.model_name
         else
           underscore(ref.class)
         end

--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -95,6 +95,11 @@ MESSAGE
       "my_thing"
     end
   end
+  class CustomModelClass < Struct.new(:id)
+    def model_name
+      "my_model_name"
+    end
+  end
   CpkRecord = Struct.new('CpkRecord', :id) do
     def to_key
       [*self.id] unless id.nil?
@@ -1325,7 +1330,13 @@ HAML
     assert_equal("<p class='my_thing' id='my_thing_42' style='width: 100px;'>My Thing</p>\n",
                  render("%p[custom]{:style => 'width: 100px;'} My Thing", :locals => {:custom => custom}))
   end
-  
+
+  def test_object_ref_with_class_with_model_name
+    custom = CustomModelClass.new 42
+    assert_equal("<p class='my_model_name' id='my_model_name_42' style='width: 100px;'>My Thing</p>\n",
+                 render("%p[custom]{:style => 'width: 100px;'} My Thing", :locals => {:custom => custom}))
+  end
+
   def test_object_ref_with_multiple_ids
     cpk_record = CpkRecord.new([42,6,9])
     assert_equal("<p class='struct_cpk_record' id='struct_cpk_record_42_6_9' style='width: 100px;'>CPK Record</p>\n",


### PR DESCRIPTION
This is what #dom_class ends up calling in Rails.  It allows a developper to customize the model name so that we can get rid of the full namespace in some cases.
