### PR TITLE
Fix parsing of Ruby multi-line blocks ending in question-marked methods

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -664,8 +664,15 @@ END
       text
     end
 
+    # `text' is a Ruby multiline block if it:
+    # - ends with a comma
+    # - but not "?," which is a character literal
+    #   (however, "x?," is a method call and not a literal)
+    # - and not "?\," which is a character literal
+    #
     def is_ruby_multiline?(text)
-      text && text.length > 1 && text[-1] == ?, && text[-2] != ?? && text[-3..-2] != "?\\"
+      text && text.length > 1 && text[-1] == ?, &&
+        !((text[-3..-2] =~ /\W\?/) || text[-3..-2] == "?\\")
     end
 
     def contains_interpolation?(str)

--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -1662,6 +1662,35 @@ HTML
 HAML
   end
 
+  def test_ruby_multiline_with_punctuated_methods_is_continuation
+    assert_equal(<<HTML, render(<<HAML))
+bar, , true, bang
+<p>foo</p>
+<p>bar</p>
+HTML
+= ["bar",
+   "  ".strip!,
+   "".empty?,
+   "bang"].join(", ")
+%p foo
+%p bar
+HAML
+  end
+
+  def test_ruby_character_literals_are_not_continuation
+    assert_equal(<<HTML, render(<<HAML))
+,
+,
+<p>foo</p>
+<p>bar</p>
+HTML
+= ?,
+= ?\,
+%p foo
+%p bar
+HAML
+  end
+
   def test_escaped_loud_ruby_multiline
     assert_equal(<<HTML, render(<<HAML))
 bar&lt;, baz, bang


### PR DESCRIPTION
The parser currently believes that any line ending in `?,` or `?\,` is not a Ruby multiline block, as those sequences represent Ruby character literals (both equal to the comma character). However, this fails for code like this:

``` haml
= some_method @object.foo?,
  bar, baz
```

because the `?,` prevents the first line from being considered a continuation.

The workaround is to add whitespace before the comma:

``` haml
= some_method @object.foo? ,
  bar, baz
```

but I am attaching a tested patch that I believe to fix this issue.

Cheers,
-be
