### PR TITLE
Added extra argument to Helper#list_of so list items can have attributes

### DIFF
--- a/doc-src/HAML_CHANGELOG.md
+++ b/doc-src/HAML_CHANGELOG.md
@@ -9,6 +9,7 @@
 * Add RedCarpet support to Markdown filter.
 * Performance improvements (thanks to [Chris Heald](https://github.com/cheald)).
 * Generate object references based on `#to_key` if it exists in preference to `#id`.
+* Helper `list_of` takes an extra argument that is rendered into list item attributes (thanks [Iain Barnett](http://iainbarnett.me.uk/))
 
 ## 3.1.5 (Unreleased)
 

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -147,7 +147,7 @@ MESSAGE
     #     <li>hello</li>
     #     <li>yall</li>
     #
-    # And
+    # And:
     #
     #     = list_of({:title => 'All the stuff', :description => 'A book about all the stuff.'}) do |key, val|
     #       %h3= key.humanize
@@ -164,10 +164,33 @@ MESSAGE
     #       <p>A book about all the stuff.</p>
     #     </li>
     #
+    # While:
+    #
+    #     = list_of(["Home", "About", "Contact", "FAQ"], {class: "nav", role: "nav"}) do |item|
+    #       %a{ href="#" }= item
+    #
+    # Produces:
+    #
+    #     <li class='nav' role='nav'>
+    #       <a href='#'>Home</a>
+    #     </li>
+    #     <li class='nav' role='nav'>
+    #       <a href='#'>About</a>
+    #     </li>
+    #     <li class='nav' role='nav'>
+    #       <a href='#'>Contact</a>
+    #     </li>
+    #     <li class='nav' role='nav'>
+    #       <a href='#'>FAQ</a>
+    #     </li>
+    #
+    #  `[[class", "nav"], [role", "nav"]]` could have been used instead of `{class: "nav", role: "nav"}` (or any enumerable collection where each pair of items responds to #to_s)
+    #
     # @param enum [Enumerable] The list of objects to iterate over
+    # @param [Enumerable<#to_s,#to_s>] opts Each key/value pair will become an attribute pair for each list item element.
     # @yield [item] A block which contains Haml code that goes within list items
     # @yieldparam item An element of `enum`
-    def list_of(enum, &block)
+    def list_of(enum, opts={}, &block)
       to_return = enum.collect do |i|
         result = capture_haml(i, &block)
 
@@ -178,7 +201,7 @@ MESSAGE
           result = result.strip
         end
 
-        "<li>#{result}</li>"
+        %Q!<li#{opts.empty? ? "" : " ".<<(opts.map{|k,v| "#{k}='#{v}'" }.join(" "))}>#{result}</li>!
       end
       to_return.join("\n")
     end

--- a/test/haml/helper_test.rb
+++ b/test/haml/helper_test.rb
@@ -1,5 +1,5 @@
 #!/usr/bin/env ruby
-require File.dirname(__FILE__) + '/../test_helper'
+require File.expand_path File.join( File.dirname(__FILE__),  '/../test_helper')
 
 class ActionView::Base
   def nested_tag
@@ -68,6 +68,10 @@ class HelperTest < Test::Unit::TestCase
     assert_equal("<li>[1]</li>\n", render("= list_of([[1]]) do |i|\n  = i.inspect"))
     assert_equal("<li>\n  <h1>Fee</h1>\n  <p>A word!</p>\n</li>\n<li>\n  <h1>Fi</h1>\n  <p>A word!</p>\n</li>\n<li>\n  <h1>Fo</h1>\n  <p>A word!</p>\n</li>\n<li>\n  <h1>Fum</h1>\n  <p>A word!</p>\n</li>\n",
       render("= list_of(['Fee', 'Fi', 'Fo', 'Fum']) do |title|\n  %h1= title\n  %p A word!"))
+    assert_equal("<li c='3' d='4'>1</li>\n<li c='3' d='4'>2</li>\n", render("= list_of([1, 2], {c: 3, d: 4}) do |i|\n  = i"))
+    assert_equal("<li c='3' d='4'>[1]</li>\n", render("= list_of([[1]], {c: 3, d: 4}) do |i|\n  = i.inspect"))
+    assert_equal("<li c='3' d='4'>\n  <h1>Fee</h1>\n  <p>A word!</p>\n</li>\n<li c='3' d='4'>\n  <h1>Fi</h1>\n  <p>A word!</p>\n</li>\n<li c='3' d='4'>\n  <h1>Fo</h1>\n  <p>A word!</p>\n</li>\n<li c='3' d='4'>\n  <h1>Fum</h1>\n  <p>A word!</p>\n</li>\n",
+      render("= list_of(['Fee', 'Fi', 'Fo', 'Fum'], {c: 3, d: 4}) do |title|\n  %h1= title\n  %p A word!"))
   end
 
   def test_buffer_access


### PR DESCRIPTION
[Haml]
There were several places I wanted `list_of` to be able to produce something like this:

```
<li class='nav' role='nav'>
```

so I updated the code to allow it. I've extended the existing unit tests for it and updated the yard comments. Hope this is ok.

Regards,
Iain
