### PR TITLE
Fixed some instance variable not initialized warnings

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -454,7 +454,8 @@ END
     end
 
     def compile(node)
-      parent, @node = @node, node
+      parent = instance_variable_defined?('@node') ? @node : nil
+      @node = node
       if node.children.empty?
         send(:"compile_#{node.type}")
       else

--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -174,7 +174,8 @@ module Haml
     # @param block [#to_proc] A block that can be yielded to within the template
     # @return [String] The rendered template
     def render(scope = Object.new, locals = {}, &block)
-      buffer = Haml::Buffer.new(scope.instance_variable_get('@haml_buffer'), options_for_buffer)
+      parent = scope.instance_variable_defined?('@haml_buffer') ? scope.instance_variable_get('@haml_buffer') : nil
+      buffer = Haml::Buffer.new(parent, options_for_buffer)
 
       if scope.is_a?(Binding) || scope.is_a?(Proc)
         scope_object = eval("self", scope)

--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -152,7 +152,7 @@ RUBY
       private
 
       def resolve_lazy_requires
-        return unless @lazy_requires
+        return unless instance_variable_defined?('@lazy_requires')
 
         @lazy_requires[0...-1].each do |req|
           begin

--- a/lib/haml/helpers/action_view_extensions.rb
+++ b/lib/haml/helpers/action_view_extensions.rb
@@ -45,7 +45,8 @@ module Haml
       # @yield A block in which all input to `#haml_concat` is treated as raw.
       # @see Haml::Util#rails_xss_safe?
       def with_raw_haml_concat
-        @_haml_concat_raw, old = true, @_haml_concat_raw
+        @_haml_concat_raw = true
+        old = @_haml_concat_raw
         yield
       ensure
         @_haml_concat_raw = old

--- a/lib/haml/helpers/xss_mods.rb
+++ b/lib/haml/helpers/xss_mods.rb
@@ -63,7 +63,8 @@ module Haml
 
       # Input is escaped
       def haml_concat_with_haml_xss(text = "")
-        haml_concat_without_haml_xss(@_haml_concat_raw ? text : haml_xss_html_escape(text))
+        raw = instance_variable_defined?('@_haml_concat_raw') ? @_haml_concat_raw : false
+        haml_concat_without_haml_xss(raw ? text : haml_xss_html_escape(text))
       end
 
       # Output is always HTML safe

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -613,9 +613,10 @@ END
       # `flat?' here is a little outdated,
       # so we have to manually check if either the previous or current line
       # closes the flat block, as well as whether a new block is opened.
-      @line.tabs if @line
+      line_defined = instance_variable_defined?('@line')
+      @line.tabs if line_defined
       unless (flat? && !closes_flat?(line) && !closes_flat?(@line)) ||
-          (@line && @line.text[0] == ?: && line.full =~ %r[^#{@line.full[/^\s+/]}\s])
+          (line_defined && @line.text[0] == ?: && line.full =~ %r[^#{@line.full[/^\s+/]}\s])
         return next_line if line.text.empty?
 
         handle_multiline(line)


### PR DESCRIPTION
Put some instance_variable_defined? checks in place in order to avoid the annoying warnings.
