### PR TITLE
Add encoding settings for html2haml

### DIFF
--- a/lib/haml/exec.rb
+++ b/lib/haml/exec.rb
@@ -338,6 +338,14 @@ END
           @module_opts[:html_style_attributes] = true
         end
 
+        unless ::Haml::Util.ruby1_8?
+          opts.on('-E ex[:in]', 'Specify the default external and internal character encodings.') do |encoding|
+            external, internal = encoding.split(':')
+            Encoding.default_external = external if external && !external.empty?
+            Encoding.default_internal = internal if internal && !internal.empty?
+          end
+        end
+
         super
       end
 


### PR DESCRIPTION
On windows, ruby 1.9, the internal encoding is not utf-8, eg. GB2312.

Run html2haml command, the html with utf-8 encoding can not convert to haml which is automatic encoded in GB2312.

So add encoding specification for html2haml command.
