### PR TITLE
Fix CLEAN list in Rakefile.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,7 +4,7 @@ require "rubygems/package_task"
 
 task :default => :test
 
-CLEAN << %w(pkg doc coverage .yardoc)
+CLEAN += %w(pkg doc coverage .yardoc)
 
 def silence_warnings
   the_real_stderr, $stderr = $stderr, StringIO.new


### PR DESCRIPTION
`<<` creates a nested array, so `rake clean` doesn't work. Use `+=`
instead.

Took a bit of head scratching to figure out why this wasn't working!
