### PR TITLE
Deprecate Ruby 1.8.6 compatibility methods.

### DIFF
--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -438,35 +438,37 @@ MSG
     end
 
     # Flattens the first `n` nested arrays in a cross-version manner.
-    #
+    # 
+    # @deprecated Use `arr.flatten(n)`
     # @param arr [Array] The array to flatten
     # @param n [Fixnum] The number of levels to flatten
     # @return [Array] The flattened array
     def flatten(arr, n)
+      warn '`Util::flatten` is deprecated, use `arr.flatten(n)` instead'
       return arr.flatten(n)
-      return arr if n == 0
-      arr.inject([]) {|res, e| e.is_a?(Array) ? res.concat(flatten(e, n - 1)) : res << e}
     end
 
     # Returns the hash code for a set in a cross-version manner.
     # Aggravatingly, this is order-dependent in Ruby 1.8.6.
     #
+    # @deprecated Use `set.hash`
     # @param set [Set]
     # @return [Fixnum] The order-independent hashcode of `set`
     def set_hash(set)
+      warn '`Util::set_hash` is deprecated, use `set.hash` instead'
       return set.hash
-      set.map {|e| e.hash}.uniq.sort.hash
     end
 
     # Tests the hash-equality of two sets in a cross-version manner.
     # Aggravatingly, this is order-dependent in Ruby 1.8.6.
     #
+    # @deprecated Use `set1.eql?(set2)`
     # @param set1 [Set]
     # @param set2 [Set]
     # @return [Boolean] Whether or not the sets are hashcode equal
     def set_eql?(set1, set2)
+      warn '`Util::eql?` is deprecated, use `set1.eql?(set2)` instead'
       return set1.eql?(set2)
-      set1.to_a.uniq.sort_by {|e| e.hash}.eql?(set2.to_a.uniq.sort_by {|e| e.hash})
     end
 
     # Like `Object#inspect`, but preserves non-ASCII characters rather than escaping them under Ruby 1.9.2.

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -87,50 +87,6 @@ class UtilTest < MiniTest::Unit::TestCase
     assert_equal(98, ord("bar"))
   end
 
-  def test_flatten
-    assert_equal([1, 2, 3], flatten([1, 2, 3], 0))
-    assert_equal([1, 2, 3], flatten([1, 2, 3], 1))
-    assert_equal([1, 2, 3], flatten([1, 2, 3], 2))
-
-    assert_equal([[1, 2], 3], flatten([[1, 2], 3], 0))
-    assert_equal([1, 2, 3], flatten([[1, 2], 3], 1))
-    assert_equal([1, 2, 3], flatten([[1, 2], 3], 2))
-
-    assert_equal([[[1], 2], [3], 4], flatten([[[1], 2], [3], 4], 0))
-    assert_equal([[1], 2, 3, 4], flatten([[[1], 2], [3], 4], 1))
-    assert_equal([1, 2, 3, 4], flatten([[[1], 2], [3], 4], 2))
-  end
-
-  def test_set_hash
-    assert(set_hash(Set[1, 2, 3]) == set_hash(Set[3, 2, 1]))
-    assert(set_hash(Set[1, 2, 3]) == set_hash(Set[1, 2, 3]))
-
-    s1 = Set[]
-    s1 << 1
-    s1 << 2
-    s1 << 3
-    s2 = Set[]
-    s2 << 3
-    s2 << 2
-    s2 << 1
-    assert(set_hash(s1) == set_hash(s2))
-  end
-
-  def test_set_eql
-    assert(set_eql?(Set[1, 2, 3], Set[3, 2, 1]))
-    assert(set_eql?(Set[1, 2, 3], Set[1, 2, 3]))
-
-    s1 = Set[]
-    s1 << 1
-    s1 << 2
-    s1 << 3
-    s2 = Set[]
-    s2 << 3
-    s2 << 2
-    s2 << 1
-    assert(set_eql?(s1, s2))
-  end
-
   def test_caller_info
     assert_equal(["/tmp/foo.rb", 12, "fizzle"], caller_info("/tmp/foo.rb:12: in `fizzle'"))
     assert_equal(["/tmp/foo.rb", 12, nil], caller_info("/tmp/foo.rb:12"))


### PR DESCRIPTION
I noticed a recent commit (341f8bf180785e91acae526f11e966326a88e1f7) introduced some “statement not reached’ warnings.

It looks like these methods were only there to cater for 1.8.6, which is no longer used, so as well as remove the unreachable code I’ve marked them as deprecated.

(the real commit message is below)

`flatten`, `set_hash` and `set_eql?` in `Util` are only used to fix
the corresponding methods in Ruby 1.8.6, which is no longer supported.

Mark these methods as deprecated, and issue a warning if they are used.

Also remove test for these methods - the tests only check that the
core/std-lib Ruby methods are working.

As far as I can tell, these methods are no longer used anywhere in the
Haml codebase - the tests were the only uses.
