### PR TITLE
Resolve test name conflict.

### DIFF
--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -245,8 +245,8 @@ HAML
     assert_equal("<p class='foo bar' id='some_id'></p>\n", render("- haml_tag 'p.foo.bar#some_id'"))
   end
 
-  def test_haml_tag_name_and_attribute_classes_merging
-    assert_equal("<p class='foo bar' id='some_id'></p>\n", render("- haml_tag 'p#some_id.foo', :class => 'bar'"))
+  def test_haml_tag_name_and_attribute_classes_merging_with_id
+    assert_equal("<p class='bar foo' id='some_id'></p>\n", render("- haml_tag 'p#some_id.foo', :class => 'bar'"))
   end
 
   def test_haml_tag_name_and_attribute_classes_merging


### PR DESCRIPTION
I think this one was hiding on the stable branch, which is why I’ve only just found the redefined method warning.

It’s been there a while too: 60e498d0444466cab7fa5c1667a175986ce72211.

(actual commit message below)

Rename the second of the two
`test_haml_tag_name_and_attribute_classes_merging` tests so it doesn't
override the first.

Swap order of expected classes so that it passes.
