### PR TITLE
Explicitly initialize ivar to nil to avoid warning

### DIFF
--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -88,6 +88,7 @@ module Haml
         :hyphenate_data_attrs => true,
       }
 
+      @index = nil # explicitily initialize to avoid warnings
 
       template = check_haml_encoding(template) do |msg, line|
         raise Haml::Error.new(msg, line)


### PR DESCRIPTION
This is the same warning as d82ce857d53a60e9f4cfb5509832df7ba1ff932b, but silencing it in a different way.

Set `@index` to nil in Engine#initialize before encoding check.

Currently, if `check_haml_encoding` raises an exception, a warning is
issued in the rescue block as `@index` isn't yet initialized.
