### PR TITLE
Fix benchmark script

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@ end
 
 desc "Benchmark Haml against ERb. TIMES=n sets the number of runs, default is 1000."
 task :benchmark do
-  sh "ruby test/benchmark.rb #{ENV['TIMES']}"
+  sh "ruby benchmark.rb #{ENV['TIMES']}"
 end
 
 Rake::TestTask.new do |t|

--- a/benchmark.rb
+++ b/benchmark.rb
@@ -13,12 +13,12 @@ END
   exit 1
 end
 
-%w[rubygems erb erubis active_support action_controller
+%w[rubygems erb erubis rails active_support action_controller
    action_view action_pack haml/template rbench].each {|dep| require(dep)}
 
 def view
   base = ActionView::Base.new
-  base.finder.append_view_path(File.dirname(__FILE__))
+  base.view_paths << File.join(File.dirname(__FILE__), '/test')
   base
 end
 
@@ -33,8 +33,8 @@ RBench.run(times) do
   column :erubis, :title => "Erubis"
 
   template_name = 'standard'
-  haml_template    = File.read("#{File.dirname(__FILE__)}/templates/#{template_name}.haml")
-  erb_template     = File.read("#{File.dirname(__FILE__)}/erb/#{template_name}.erb")
+  haml_template    = File.read("#{File.dirname(__FILE__)}/test/templates/#{template_name}.haml")
+  erb_template     = File.read("#{File.dirname(__FILE__)}/test/erb/#{template_name}.erb")
 
   report "Cached" do
     obj = Object.new


### PR DESCRIPTION
The benchmark script was out of date. I think I’ve got it working, but it needs someone who knows Rails to check that I’ve got those bits right (particularly the `base.view_paths << ...` bit).

(commit message below)

Bring benchmark.rb up to date.
- Update paths in benchmark.rb and Rakefile (benchmark.rb is now in top
  level, not in test).
- Add "rails" to requre list (needed for version check).
- Use current api when adding view path to ActionView.base.
