### PR TITLE
Don't depend on Rails in haml/template/plugin

### DIFF
--- a/lib/haml/template/plugin.rb
+++ b/lib/haml/template/plugin.rb
@@ -8,7 +8,7 @@ module Haml
     # the ERB handler does.
 
     # In Rails 3.1+, we don't need to include Compilable.
-    if ::Rails.version < "3.1"
+    if ActionPack::VERSION::MAJOR < 3 || (ActionPack::VERSION::MAJOR == 3 && ActionPack::VERSION::MINOR < 1)
       include ActionView::Template::Handlers::Compilable
     end
 


### PR DESCRIPTION
Only ActionPack is needed to use this file.
