### PR TITLE
Add data-id to HTML element when creating object reference.

### DIFF
--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -308,7 +308,7 @@ RUBY
         id = "#{ prefix }_#{ id }"
       end
 
-      {'id' => id, 'class' => class_name}
+      {'id' => id, 'class' => class_name, 'data-id' => ref_id}
     end
 
     # Changes a word from camel case to underscores.


### PR DESCRIPTION
Why parse the html element's id when we can put it into the data hash for free?
Hope this is an agreeable change.  :)
