### PR TITLE
#560

### DIFF
--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -92,19 +92,23 @@ class EngineTest < MiniTest::Unit::TestCase
     end
   end
 
-  def render(text, options = {}, &block)
-    scope  = options.delete(:scope)  || Object.new
-    locals = options.delete(:locals) || {}
-    engine(text, options).to_html(scope, locals, &block)
-  end
-
-  def engine(text, options = {})
+  def use_test_tracing(options)
     unless options[:filename]
       # use caller method name as fake filename. useful for debugging
       i = -1
       caller[i+=1] =~ /`(.+?)'/ until $1 and $1.index('test_') == 0
       options[:filename] = "(#{$1})"
     end
+    options
+  end
+
+  def render(text, options = {}, &block)
+    options = use_test_tracing(options)
+    super
+  end
+
+  def engine(text, options = {})
+    options = use_test_tracing(options)
     Haml::Engine.new(text, options)
   end
 

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -43,12 +43,8 @@ class HelperTest < MiniTest::Unit::TestCase
   end
 
   def render(text, options = {})
-    if options == :action_view
-      @base.render :inline => text, :type => :haml
-    else
-      scope = options.delete :scope_object
-      Haml::Engine.new(text, options).to_html(scope ? scope : Object.new)
-    end
+    return @base.render :inline => text, :type => :haml if options == :action_view
+    super
   end
 
   def test_flatten
@@ -350,7 +346,7 @@ HAML
   def test_page_class
     controller = Struct.new(:controller_name, :action_name).new('troller', 'tion')
     scope = Struct.new(:controller).new(controller)
-    result = render("%div{:class => page_class} MyDiv", :scope_object => scope)
+    result = render("%div{:class => page_class} MyDiv", :scope => scope)
     expected = "<div class='troller tion'>MyDiv</div>\n"
     assert_equal expected, result
   end

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -68,10 +68,10 @@ class TemplateTest < MiniTest::Unit::TestCase
     base
   end
 
-  def render(text, opts = {})
-    return @base.render(:inline => text, :type => :haml) if opts == :action_view
-    opts = opts.merge(:format => :xhtml)
-    Haml::Engine.new(text, opts).to_html(@base)
+  def render(text, options = {})
+    return @base.render(:inline => text, :type => :haml) if options == :action_view
+    options = options.merge(:format => :xhtml)
+    super(text, options, @base)
   end
 
   def load_result(name)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,10 +39,12 @@ class MiniTest::Unit::TestCase
 
   extend Declarative
 
-  def render(text, options = {}, &block)
+  def render(text, options = {}, base = nil, &block)
     scope  = options.delete(:scope)  || Object.new
     locals = options.delete(:locals) || {}
-    Haml::Engine.new(text, options).to_html(scope, locals, &block)
+    engine = Haml::Engine.new(text, options)
+    return engine.to_html(base) if base
+    engine.to_html(scope, locals, &block)
   end
 
   def assert_warning(message)


### PR DESCRIPTION
This is (hopefully) a fix for issue #560. I couldn't find a way to feasibly move all the render methods' logic into one, but the methods in engine_test, helper_test, and template_test do all call the method in test_helper now, which has reduced duplication.

This is my first pull request, so if I've done something rude or strange, please attribute to ignorance and not malice!
