### PR TITLE
Fix handling of 'unless' or 'case' nested in if/else

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -444,7 +444,7 @@ module Haml
     end
 
     def close_silent_script(node)
-      @script_level_stack.pop if node.value[:keyword] == "if"
+      @script_level_stack.pop if ["if", "case", "unless"].include? node.value[:keyword]
 
       # Post-process case statements to normalize the nesting of "when" clauses
       return unless node.value[:keyword] == "case"

--- a/test/templates/silent_script.haml
+++ b/test/templates/silent_script.haml
@@ -23,6 +23,11 @@
         Odd!
       - else
         Even!
+    - unless true
+      Testing else indent
+    - case 1
+    - when 2
+      Also testing else indent
   - else
     = "This can't happen!"
 - 13 |


### PR DESCRIPTION
The parser checks for incorrect 'else' nesting by tracking
if/case/unless blocks in an internal stack. It was pushing to but
never popping from this stack for 'unless' and 'case' blocks, leading
to spurious syntax errors.

Regression examples included.
