### PR TITLE
Remove unused variables warnings

### DIFF
--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -611,8 +611,8 @@ MESSAGE
     # @return [Proc] A new proc with the new variables bound
     def haml_bind_proc(&proc)
       _hamlout = haml_buffer
-      _erbout = _hamlout.buffer
-      _erbout.to_s #"use" the variable to silence warnings
+      #double assignment is to avoid warnings
+      _erbout = _erbout = _hamlout.buffer
       proc { |*args| proc.call(*args) }
     end
   end

--- a/lib/haml/helpers/action_view_mods.rb
+++ b/lib/haml/helpers/action_view_mods.rb
@@ -39,7 +39,8 @@ module ActionView
     module CaptureHelper
       def capture_with_haml(*args, &block)
         if Haml::Helpers.block_is_haml?(block)
-          _hamlout = eval('_hamlout', block.binding) # Necessary since capture_haml checks _hamlout
+          #double assignment is to avoid warnings
+          _hamlout = _hamlout = eval('_hamlout', block.binding) # Necessary since capture_haml checks _hamlout
           value = nil
           buffer = capture_haml(*args) { value = yield(*args) }
           str =


### PR DESCRIPTION
I previously used  what in hindsight looks like a rather dubious technique to avoid an unused variable warning (calling `to_s` on a string to “use” it). I also recently discovered a more reasonable looking technique to achieve the same (double assignment), which has been used in Rails among other places (I think https://github.com/rails/rails/blob/v3.2.8/activesupport/lib/active_support/callbacks.rb#L184-187 is the only current use of it).

This change swaps the former for the latter, and also uses the double assignment method to remove what I think is the last Haml warning (at least with the Rails 3.2 gemfile).

---

Use double assignment in preference to `to_s` call to avoid unused
variable warning in lib/haml/helper.rb.

Use same technique to remove same warning in
lib/haml/helpers/action_view_mods.rb.
