### PR TITLE
Use type instead of mime_type in plugin.rb

### DIFF
--- a/lib/haml/template/plugin.rb
+++ b/lib/haml/template/plugin.rb
@@ -16,7 +16,11 @@ module Haml
 
     def compile(template)
       options = Haml::Template.options.dup
-      options[:mime_type] = template.mime_type if template.respond_to? :mime_type
+      if template.respond_to? :type
+        options[:mime_type] = template.type
+      elsif template.respond_to? :mime_type
+        options[:mime_type] = template.mime_type
+      end
       options[:filename] = template.identifier
       Haml::Engine.new(template.source, options).compiler.precompiled_with_ambles([])
     end


### PR DESCRIPTION
Fix for #589. Looks simple enough, but could do with a look over in case there’s something I’ve missed with the Rails intergration.

Template#mime_type method is deprecated in Rails 4.

Use Template#type in template/plugin.rb if it's available.
