### PR TITLE
Every Ruby 1.8 Object responds_to :type

### DIFF
--- a/lib/haml/template/plugin.rb
+++ b/lib/haml/template/plugin.rb
@@ -16,7 +16,7 @@ module Haml
 
     def compile(template)
       options = Haml::Template.options.dup
-      if template.respond_to? :type
+      if (ActionPack::VERSION::MAJOR >= 4) && template.respond_to?(:type)
         options[:mime_type] = template.type
       elsif template.respond_to? :mime_type
         options[:mime_type] = template.mime_type


### PR DESCRIPTION
Since ec3157f4db4e945911196978aee56227d865d8a6, Haml scatters tons of warnings like this under Ruby 1.8:

```
 .../haml-3.2.0.rc.1/lib/haml/template/plugin.rb:20: warning: Object#type is deprecated; use Object#class
```

Here's a patch that checks the ActionPack version before asking the template object respond_to? :type or not. I think this would be enough in this case because Rails 4 does not support Ruby < 1.9.

<table><tr>
<th>versions</th>
<th>ActionPack::VERSION::MAJOR >= 4</th>
<th>template.respond_to?(:type)</th>
</tr><tr>
<td>Ruby 1.9 + Rails 4</td><td>true</td><td>true</td>
</tr><tr>
<td>Ruby 1.8 + Rails 4<td colspan=2>N/A</td>
</tr><tr>
<td>Ruby 1.9 + Rails 3<td>false</td><td>(will not be executed)</td>
</tr><tr>
<td>Ruby 1.8 + Rails 3<td>false</td><td>(will not be executed)</td>
</tr></table>


I didn't add new test code for this, but you can actually see these warnings as you run `rake` with 1.8.
