### PR TITLE
Fix for ruby bug in 1.9.2

### DIFF
--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -314,14 +314,14 @@ RUBY
 
       def self.extended(base)
         base.options = {}
-        base.instance_eval do
+        base.instance_eval %Q{
           include Base
 
           def render_with_options(text, compiler_options)
             text = template_class.new(nil, 1, options) {text}.render
             super(text, compiler_options)
           end
-        end
+        }
       end
     end
 


### PR DESCRIPTION
This fix closes issue #603.

There's a bug in 1.9.2 where the same parse tree cannot be shared across several singleton classes -- this bug is fixed in 1.9.3.

We work around this by using a string eval instead of a block eval so that a new parse tree is created for each singleton class.
