### PR TITLE
Fixed link to Haml reference in FAQ

### DIFF
--- a/FAQ.md
+++ b/FAQ.md
@@ -151,7 +151,7 @@ For other plugins, a little searching will probably turn up a way to fix them as
 
 ## You still haven't answered my question!
 
-Sorry! Try looking at the [Haml](http://haml.info/docs/yardoc/HAML_REFERENCE.md.html) reference,
+Sorry! Try looking at the [Haml](http://haml.info/docs/yardoc/file.REFERENCE.html) reference,
 If you can't find an answer there,
 feel free to ask in `#haml` on irc.freenode.net
 or send an email to the [mailing list](http://groups.google.com/group/haml).


### PR DESCRIPTION
The current FAQ links to http://haml.info/docs/yardoc/HAML_REFERENCE.md.html which is a dead link.
