### PR TITLE
Fix Attribute Methods example in REFERENCE.md

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -343,7 +343,7 @@ left to right. For example, if you defined
 
 then
 
-    %sandwich{hash1, hash2, :delicious => true}/
+    %sandwich{hash1, hash2, :delicious => 'true'}/
 
 would compile to:
 


### PR DESCRIPTION
The example incorrectly showed `{:delicious => true}` being rendered as `delicious="true"`.
