### PR TITLE
Use Erubis when available for faster startup

### DIFF
--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -1,5 +1,5 @@
 begin
-  require 'erubis'
+  require 'erubis/tiny'
 rescue LoadError
   require 'erb'
 end
@@ -240,7 +240,7 @@ MSG
       info = caller_info
       powerset(vars).each do |set|
         context = StaticConditionalContext.new(set).instance_eval {binding}
-        method_content = (defined?(Erubis::Eruby) && Erubis::Eruby || ERB).new(erb).result(context)
+        method_content = (defined?(Erubis::TinyEruby) && Erubis::TinyEruby || ERB).new(erb).result(context)
 
         klass.class_eval(<<METHOD, info[0], info[1])
           def #{static_method_name(name, *vars.map {|v| set.include?(v)})}(#{args.join(', ')})


### PR DESCRIPTION
Haml currently compiles 128 ERB templates during bootup as a result of `#def_static_method`. This takes roughly half a second on my machine.

By using Erubis' TinyRuby rather than ERB to do the parsing, this takes about 1/3rd as much time. If Erubis is not available, Haml will fall back to ERB.
