### PR TITLE
Ruby filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,9 @@
 * The Haml exectutable now accepts an `--autoclose` option. You can now
   specify a list of tags that should be autoclosed
 
-* The `:ruby` filter now runs the generated code with a exclusive lock, to
-  prevent issues with sharing `$stdout` across threads.
+* The `:ruby` filter no longer redirects $stdout to the Haml document, as this
+  is not thread safe. Instead it provides a `haml_io` local variable, which is
+  an IO object that writes to the document.
 
 * HTML5 is now the default output format rather than XHTML. This was already
   the default on Rails 3+, so many users will notice no difference.

--- a/test/filters_test.rb
+++ b/test/filters_test.rb
@@ -236,3 +236,23 @@ class EscapedFilterTest < MiniTest::Unit::TestCase
     assert_equal(html, render(haml))
   end
 end
+
+class RubyFilterTest < MiniTest::Unit::TestCase
+  test "can write to haml_io" do
+    haml = ":ruby\n  haml_io.puts 'hello'\n"
+    html = "hello\n"
+    assert_equal(html, render(haml))
+  end
+
+  test "haml_io appends to output" do
+    haml = "hello\n:ruby\n  haml_io.puts 'hello'\n"
+    html = "hello\nhello\n"
+    assert_equal(html, render(haml))
+  end
+
+  test "can create local variables" do
+    haml = ":ruby\n  a = 7\n=a"
+    html = "7\n"
+    assert_equal(html, render(haml))
+  end
+end


### PR DESCRIPTION
Changes `:ruby` filter to not redirect `$stdout`.

See #613, #614, #616.

I think this is the only way to fix this, I can’t see any way to safely redirect `$stdout` for a single thread (without replacing it with a custom IO of some sort).

If we do go with this, do we need to provide an option to leave the old behaviour for people running single-threaded, and totally remove it in the next version, or make a clean switch in this version? If so, what should the default be?
