### PR TITLE
Symbol does not respond_to downcase in Ruby 1.8.7

### DIFF
--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -65,7 +65,7 @@ module Haml
     # @return Module The filter module that has been removed
     # @since 3.2.0
     def remove_filter(name)
-      defined.delete name.downcase
+      defined.delete name.to_s.downcase
       if constants.map(&:to_s).include?(name.to_s)
         remove_const name.to_sym
       end


### PR DESCRIPTION
This patch fixes

```
/haml-3.2.0.rc.3/lib/haml/filters.rb:68:in `remove_filter': undefined method `downcase' for :Sass:Symbol (NoMethodError)
```

in Ruby 1.8.7.
