### PR TITLE
Combine two gsub calls into one with a regex

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -445,8 +445,7 @@ END
         value = Haml::Helpers.preserve(escaped)
         if escape_attrs
           # We want to decide whether or not to escape quotes
-          value.gsub!('&quot;', '"')
-          value.gsub!('&#x0022;', '"')
+          value.gsub!(/&quot;|&#x0022;/, '"')
           this_attr_wrapper = attr_wrapper
           if value.include? attr_wrapper
             if value.include? other_quote_char


### PR DESCRIPTION
String#gsub! is just as fast with a regex as it is with a string - so we can combine the two gsubs! into one with a regex.

``` ruby
Benchmark.bm do |x|
  x.report{ 10000.times{ Haml::Compiler.build_attributes(true, '"', true, true, "type" => "text", "value" => "Foo\"B'ar")}}
  x.report{ 10000.times{ Haml::Compiler.build_attributes(true, '"', true, true, "type" => "text", "value" => "FooBar")}}
end
```

```
Before:
       user     system      total        real
   1.520000   0.010000   1.530000 (  1.535725)
   1.200000   0.010000   1.210000 (  1.199978)

After:
       user     system      total        real
   0.790000   0.000000   0.790000 (  0.787912)
   0.500000   0.010000   0.510000 (  0.498231)
```
