### PR TITLE
Fix to support 'sass-rails' 4.0.0.beta

### DIFF
--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -10,7 +10,7 @@ end
 module Haml
   class Railtie < ::Rails::Railtie
     initializer :haml do |app|
-      if defined?(::Sass::Rails) && app.config.assets.enabled
+      if defined?(::Sass::Rails::SassTemplate) && app.config.assets.enabled
         require "haml/sass_rails_filter"
       end
     end


### PR DESCRIPTION
It has no constant `Sass::Rails::SassTemplate`.
