### PR TITLE
Fixed the link to Tilt repo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,7 +57,7 @@
   (thanks to [Péter Pál Koszta](https://github.com/koszta))
 
 * Filters that rely on third-party template engines are now implemented using
-  [Tilt](github.com/rtomayko/tilt). Several new filters have been added, namely
+  [Tilt](https://github.com/rtomayko/tilt). Several new filters have been added, namely
   SCSS (:scss), LessCSS, (:less), and Coffeescript (:coffee/:coffeescript).
 
   Though the list of "official" filters is kept intentionally small, Haml comes


### PR DESCRIPTION
Was going through the changelog for HAML 4.0 and found that the link to Tilt repo on Github was broken. Made a small fix.
