### PR TITLE
Make escape_once respect hexadecimal references

### DIFF
--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -555,7 +555,7 @@ MESSAGE
       end
     end
 
-    HTML_ESCAPE_ONCE_REGEX = /[\"><]|&(?!(?:[a-zA-Z]+|(#\d+));)/
+    HTML_ESCAPE_ONCE_REGEX = /[\"><]|&(?!(?:[a-zA-Z]+|#(?:\d+|[xX][0-9a-fA-F]+));)/
 
     # Escapes HTML entities in `text`, but without escaping an ampersand
     # that is already part of an escaped entity.

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -493,7 +493,7 @@ HAML
 
   def test_escape_once_leaves_numeric_references
     assert_equal "&quot;&gt;&lt;&amp; &#160;", Haml::Helpers.escape_once('"><& &#160;') #decimal
-    #assert_equal "&quot;&gt;&lt;&amp; &#x00a0;", Haml::Helpers.escape_once('"><& &#x00a0;') #hexadecimal
+    assert_equal "&quot;&gt;&lt;&amp; &#x00a0;", Haml::Helpers.escape_once('"><& &#x00a0;') #hexadecimal
   end
 
   def test_escape_once_encoding


### PR DESCRIPTION
Any reason hexadecimal references would be omitted? I’m assuming it was just an oversight when originally written.

---

The regex for escape once recognises decimal numeric character
references and character entity references, but not hexadecimal
numeric character references.

Add hexadecimal references to the regex.
