### PR TITLE
Data attribute flattening breaks with fixnum values

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -491,10 +491,11 @@ END
     end
 
     def self.flatten_data_attributes(data, key, join_char, seen = [])
+      return {key => data} unless data.is_a?(Hash)
+
       return {key => nil} if seen.include? data.object_id
       seen << data.object_id
 
-      return {key => data} unless data.is_a?(Hash)
       data.sort {|x, y| x[0].to_s <=> y[0].to_s}.inject({}) do |hash, (k, v)|
         joined = key == '' ? k : [key, k].join(join_char)
         hash.merge! flatten_data_attributes(v, joined, join_char, seen)

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1498,6 +1498,11 @@ HAML
       render("%div{data_val, :data => {:foo => 'blip', :brat => 'wurst'}}"))
   end
 
+  def test_html5_data_attributes_with_identical_attribute_values
+    assert_equal("<div data-x='50' data-y='50'></div>\n",
+      render("%div{:data => {:x => 50, :y => 50}}"))
+  end
+
   def test_xml_doc_using_html5_format_and_mime_type
     assert_equal(<<XML, render(<<HAML, { :format => :html5, :mime_type => 'text/xml' }))
 <?xml version='1.0' encoding='utf-8' ?>


### PR DESCRIPTION
The new data attribute flattening fails when the attribute values of the data hash are identical fixnums (or other immutable objects, like symbols). This HAML:

``` haml
%div{:data => {:x => 50, :y => 50}}
```

Should generate this:

``` html
<div data-x='50' data-y='50'></div>
```

But it records the `50` value as seen, and then returns `nil` for the second result, giving:

``` html
<div data-x='50'></div>
```

I think the circular reference check is only necessary for hash attribute values. Reversing the order of the type check with the seen check fixes this problem.
