### PR TITLE
Removing dependency on rails when plugging haml into ActionView.

### DIFF
--- a/lib/haml/template.rb
+++ b/lib/haml/template.rb
@@ -26,7 +26,7 @@ module Haml
 end
 
 
-Haml::Template.options[:ugly]        = !Rails.env.development?
+Haml::Template.options[:ugly] = defined?(Rails) ? !Rails.env.development? : true
 Haml::Template.options[:escape_html] = true
 
 require 'haml/template/plugin'


### PR DESCRIPTION
Ran into this while adding haml 4.0 to a stand alone ActionMailer app. The ugly option's default was being set based off of the Rails environment, changed it to default to true if Rails isn't present.
