### PR TITLE
Add haml_tag_if helper method

### DIFF
--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -527,6 +527,49 @@ MESSAGE
       ret
     end
 
+    # Conditionally wrap a block in an element. If `condition` is `true` then
+    # this method renders the tag described by the argumants in `tag` (using
+    # \{#haml_tag}) with the given block inside, otherwise it just renders the block.
+    #
+    # For example,
+    #
+    #     - haml_tag_if important, '.important' do
+    #       %p
+    #         A (possibly) important paragraph.
+    #
+    # will produce
+    #
+    #     <div class='important'>
+    #       <p>
+    #         A (possibly) important paragraph.
+    #       </p>
+    #     </div>
+    #
+    # if `important` is truthy, and just
+    #
+    #     <p>
+    #       A (possibly) important paragraph.
+    #     </p>
+    #
+    # otherwise.
+    #
+    # Like \{#haml_tag}, `haml_tag_if` outputs directly to the buffer and its
+    # return value should not be used. Use \{#capture_haml} if you need to use
+    # its results as a string.
+    #
+    # @param condition The condition to test to determine whether to render
+    #   the enclosing tag
+    # @param tag Definition of the enclosing tag. See \{#haml_tag} for details
+    #   (specifically the form that takes a block)
+    def haml_tag_if(condition, *tag)
+      if condition
+        haml_tag(*tag){ yield }
+      else
+        yield
+      end
+      ErrorReturn.new("haml_tag_if")
+    end
+
     # Characters that need to be escaped to HTML entities from user input
     HTML_ESCAPE = { '&' => '&amp;', '<' => '&lt;', '>' => '&gt;', '"' => '&quot;', "'" => '&#039;' }
 

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -332,6 +332,41 @@ HTML
 HAML
   end
 
+  def test_haml_tag_if_positive
+    assert_equal(<<HTML, render(<<HAML))
+<div class='conditional'>
+  <p>A para</p>
+</div>
+HTML
+- haml_tag_if true, '.conditional' do
+  %p A para
+HAML
+  end
+
+  def test_haml_tag_if_positive_with_attributes
+    assert_equal(<<HTML, render(<<HAML))
+<div class='conditional' foo='bar'>
+  <p>A para</p>
+</div>
+HTML
+- haml_tag_if true, '.conditional',  {:foo => 'bar'} do
+  %p A para
+HAML
+  end
+
+  def test_haml_tag_if_negative
+    assert_equal(<<HTML, render(<<HAML))
+<p>A para</p>
+HTML
+- haml_tag_if false, '.conditional' do
+  %p A para
+HAML
+  end
+
+  def test_haml_tag_if_error_return
+    assert_raises(Haml::Error) { render("= haml_tag_if false, '.conditional' do\n  %p Hello") }
+  end
+
   def test_is_haml
     assert(!ActionView::Base.new.is_haml?)
     assert_equal("true\n", render("= is_haml?"))


### PR DESCRIPTION
Add a helper method that renders a block, conditionally wrapped in
another element.

I recently came across [a question on StackOverflow](http://stackoverflow.com/questions/15257069/conditional-top-level-tags-haml-w-o-using-partials) asking about this, where someone had referenced [another question](http://stackoverflow.com/questions/7237308/how-can-i-conditionally-wrap-some-haml-content-in-a-tag) where an answer in turn referred to a [mailing list post](https://groups.google.com/d/msg/haml/VgapK2sEsuY/jSb-P0N7jYMJ) where @nex3 proposed adding something like this as a helper and asked for feedback. Nothing came of it, so I’ve packaged it up with some tests and docs, since it seems there is at least some demand for this.
