### PR TITLE
Fix preserve_pattern regex in buffer.rb

### DIFF
--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -98,7 +98,7 @@ module Haml
       # @real_tabs + @tabulation is the number of tabs actually output
       @real_tabs = 0
 
-      @preserve_pattern = /<[\s]*#{@options[:preserve].join("|")}/i
+      @preserve_pattern = /<[\s]*(?:#{@options[:preserve].join("|")})/i
     end
 
     # Appends text to the buffer, properly tabulated.


### PR DESCRIPTION
Group preserved tag names to reduce false positives.

This is a fairly simple change, but I know this code has changed a lot in master/4.0. The regex matching whitespace sensitive elements didn’t group the names, so only `textarea` needed the leading `<` to match. `pre` and `code` woud match “raw”.

Are there plans to make the same whitespace handling changes to 3-1? If so this commit is probably redundant.
