### PR TITLE
Require 'erubis' if needed in erb filter

### DIFF
--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -379,6 +379,8 @@ RUBY
     module Erb
       class << self
         def precompiled(text)
+          #workaround for https://github.com/rtomayko/tilt/pull/183
+          require 'erubis' if (defined?(::Erubis) && !defined?(::Erubis::Eruby))
           super.sub(/^#coding:.*?\n/, '')
         end
       end


### PR DESCRIPTION
Requiring erubis/tiny can cause the erb fiter to fail if erubis hasn't
been explicitly required elsewhere.

See https://github.com/rtomayko/tilt/pull/183

As a workaround require 'erubis' if needed when compiling the erb
filter.

Strictly speaking I think this more of a Tilt issue, but this is a workaround until we can depend on a version of Tilt with the fix in.
