### PR TITLE
Tiny optimization to capture_haml

### DIFF
--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -385,7 +385,7 @@ MESSAGE
         end
 
         captured.map do |line|
-          line[min_tabs..-1]
+          line.slice(min_tabs, line.length)
         end.join
       end
     ensure


### PR DESCRIPTION
### WHAT

Reduce the amount of `Range` objects being created on this line to zero.
### WHY

When profiling my code, I noticed that this line created a few thousand `Range` objects per request. It's because for every line in the captured haml buffer, it created a range with `min_tabs..-1`. We can achieve the same result by using `slice(min_tabs, line.length)`. 
