### PR TITLE
Add Code Climate badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Haml
 
 [![Build Status](https://secure.travis-ci.org/haml/haml.png?branch=master)](http://travis-ci.org/haml/haml)
+[![Code Climate](https://codeclimate.com/github/haml/haml.png)](https://codeclimate.com/github/haml/haml)
 
 Haml is a templating engine for HTML. It's designed to make it both easier and
 more pleasant to write HTML documents, by eliminating redundancy, reflecting the


### PR DESCRIPTION
Hey Norman,

Good seeing you in UY! Hope to run into you if you make it back to the US for RailsConf.

I thought you'd be interested to know that Haml was added to Code Climate a while back (in fact, you may have been the one who added it, hah):

https://codeclimate.com/github/haml/haml

This PR just adds a fancy, dynamic Code Climate badge to the README (like Travis), in case you'd like the quality reports to be available to project contributors.

Let me know what you think!

Best,

-Bryan
