### PR TITLE
Autoclose docs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -517,7 +517,7 @@ when the format is `:xhtml`.
 Some tags are automatically treated as being empty, as long as they have no
 content in the Haml source. `meta`, `img`, `link`, `script`, `br`, and `hr` tags
 are treated as empty by default. This list can be customized by setting the
-[`:autoclose`](#autoclose-option) option.
+{Haml::Options#autoclose `:autoclose`} option.
 
 ### Whitespace Removal: `>` and `<`
 


### PR DESCRIPTION
See #658 and #622.

The terminology used in this is a little subtle (and I’m not entirely sure I’ve got it right) so this could do with a review before it gets merged.

I’ve put the new doc into [a gist](https://gist.github.com/mattwildig/5305812), where it might be easier to read than the diff.
