### PR TITLE
Fix the :erb filter in rails.

### DIFF
--- a/lib/haml/helpers/safe_erubis_template.rb
+++ b/lib/haml/helpers/safe_erubis_template.rb
@@ -10,7 +10,7 @@ module Haml
     end
 
     def precompiled_preamble(locals)
-      [super, "@output_buffer = output_buffer ||= nil || ActionView::OutputBuffer.new;"]
+      [super, "@output_buffer = ActionView::OutputBuffer.new"]
     end
 
     def precompiled_postamble(locals)


### PR DESCRIPTION
See issue #654.

Fixes an issue where using the :erb filter multiple times in a rails view results in subsequent calls including output from previous calls.
