### PR TITLE
Escape "</" tags in Javascript filter.

### DIFF
--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -215,6 +215,7 @@ RUBY
 
         text = text.rstrip
         text.gsub!("\n", "\n#{indent}")
+        text.gsub!("</", "<\\/")
 
         %!<script#{type}>\n#{"  //<![CDATA[\n" if options[:cdata]}#{indent}#{text}\n#{"  //]]>\n" if options[:cdata]}</script>!
       end

--- a/test/filters_test.rb
+++ b/test/filters_test.rb
@@ -176,6 +176,12 @@ class JavascriptFilterTest < MiniTest::Unit::TestCase
     refute_match('//<![CDATA[', out)
     refute_match('//]]>', out)
   end
+
+  test "should escape </script> close tags" do
+    html = "<script>\n  \"<\\/script>\"\n</script>\n"
+    haml = ":javascript\n \"</script>\""
+    assert_equal(html, render(haml, :format => :html5))
+  end
 end
 
 class CSSFilterTest < MiniTest::Unit::TestCase


### PR DESCRIPTION
According to http://javascript.crockford.com/script.html, this is all we need to do to allow arbitrary javascript to be embedded within script tags.
