### PR TITLE
Added new filter `jqready`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   for detailed info. (Matt Wildig)
 * Make escape_once respect hexadecimal references. (Matt Wildig)
 * General performance and memory usage improvements. (Akira Matsuda)
+* Added new filter `jqready` which behaves like the `javascript` filter but
+  additionaly wraps the code in a `jQuery(document).ready(function() { ... }`-
+  block for the code to be executed when the document is ready.
+  (thanks [Remo Fritzsche](https://github.com/remofritzsche)).
 
 ## 4.0.2
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1114,6 +1114,14 @@ Surrounds the filtered text with `<script>` and (optionally) CDATA tags.
 Useful for including inline Javascript. Use the {Haml::Options#cdata `:cdata`
 option} to control when CDATA tags are added.
 
+{#jqready-filter}
+### `:jqready`
+Surrounds the filtered text with `<script>`, (optionally) CDATA tags as well as
+with `jQuery(document).ready(function() { ... });` for your code to be executed
+when the document is ready. Useful for including inline Javascript in
+conjunction with the jQuery library. Use the {Haml::Options#cdata `:cdata`
+option} to control when CDATA tags are added.
+
 {#less-filter}
 ### `:less`
 Parses the filtered text with [Less](http://lesscss.org/) to produce CSS output.

--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -220,6 +220,31 @@ RUBY
       end
     end
 
+    # Surrounds the filtered text with '<script>' and CDATA tags as well as
+    # a jQuery(document).ready(function() { ... }); which is useful for inline
+    # Javascript that gets executed when the document is ready in conjunction
+    # with the jQuery library.
+    module JqReady
+      include Base
+
+      # @see Base#render_with_options
+      def render_with_options(text, options)
+        text_indent = options[:cdata] ? '      ' : '    ' # 6 or 4 spaces
+        jq_indent = options[:cdata] ? '    ' : '  ' # 4 or 2 spaces
+
+        if options[:format] == :html5
+          type = ''
+        else
+          type = " type=#{options[:attr_wrapper]}text/javascript#{options[:attr_wrapper]}"
+        end
+
+        text = text.rstrip
+        text.gsub!("\n", "\n#{text_indent}")
+
+        %!<script#{type}>\n#{"  //<![CDATA[\n" if options[:cdata]}#{jq_indent}jQuery(document).ready(function() {\n#{text_indent}#{text}\n#{jq_indent}});\n#{"  //]]>\n" if options[:cdata]}</script>!
+      end
+    end
+
     # Surrounds the filtered text with `<style>` and CDATA tags. Useful for
     # including inline CSS.
     module Css


### PR DESCRIPTION
Added a new filter which wraps JavaScript-code in a jQuery-document-ready callback.

My thought behind this feature is that my guess is that most people using haml use it in conjunction with Rails, and most people using rails use it with jQuery nowadays. And speaking for me, almost all my inline javascript blocks look like this:

``` javascript
:javascript
  jQuery(document).ready(function() {
    // js code goes here...
  });
```

With jqready it's as simple as this:

``` javascript
:jqready
  // js code goes here...
```

I'm aware that this is not a feature that can be used by all haml-users (who are not using jQuery) and also brings some duplicate code with it (it's very similar to the javascript-filter). However, I think it might be of use for a lot of us and might reduce the amount of boilerplate code.
