### PR TITLE
SafeErubisTemplate fixes

### DIFF
--- a/lib/haml/helpers/safe_erubis_template.rb
+++ b/lib/haml/helpers/safe_erubis_template.rb
@@ -1,11 +1,20 @@
 module Haml
+
+  class ErubisTemplateHandler < ActionView::Template::Handlers::Erubis
+
+    def initialize(*args, &blk)
+      @newline_pending = 0
+      super
+    end
+  end
+
   class SafeErubisTemplate < Tilt::ErubisTemplate
 
     def initialize_engine
     end
 
     def prepare
-      @options.merge! :engine_class => ActionView::Template::Handlers::Erubis
+      @options.merge! :engine_class => Haml::ErubisTemplateHandler
       super
     end
 


### PR DESCRIPTION
A couple of fixes for recently reported bugs that could do with a second set of eyes cast over them before merging.

The first is fairly straightforward (return strings and not arrays). The second I’m less sure of (initializing the `@newline_pending` variable). Arguably the more correct fix for that might be in the Rails Erb handler itself.
