### PR TITLE
Template/partial/line_number traces on generated DOM elements 

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -502,8 +502,13 @@ END
 
     def prerender_tag(name, self_close, attributes)
       # TODO: consider just passing in the damn options here
+      attributes.merge!({"data-trace"=>@options.filename.split('/views').last + ":" + @node.line.to_s}) if Haml::Template.options[:show_partial_trace]
       attributes_string = Compiler.build_attributes(
-        @options.html?, @options.attr_wrapper, @options.escape_attrs, @options.hyphenate_data_attrs, attributes)
+        @options.html?,
+        @options.attr_wrapper,
+        @options.escape_attrs,
+        @options.hyphenate_data_attrs,
+        attributes)
       "<#{name}#{attributes_string}#{self_close && @options.xhtml? ? ' /' : ''}>"
     end
 


### PR DESCRIPTION
Adding a trace to a DOM element data tag containing the path of the partial and line number of the location where the element is coming (rendered) from in a haml template. This feature proved useful for a new developer starting out on a complex project that uses haml templates.
To enable it, add this configuration:

  Haml::Template.options[:show_partial_trace] = true

note: I tried to see how i would go about testing it, but could not easily figure it out. Would appreciate if the maintainer can help covering this with appropriate tests.

Thanks!
