### PR TITLE
Single (inline) pipe is mistakenly (?) interpreted as multiline indicator

### DIFF
--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -314,6 +314,10 @@ HTML
   foo
 HAML
   end
+  
+  def test_faux_multiline
+    assert_equal("<span>|</span>\n", render("%span |"))
+  end
 
   def test_end_of_file_multiline
     assert_equal("<p>0</p>\n<p>1</p>\n<p>2</p>\n", render("- for i in (0...3)\n  %p= |\n   i |"))


### PR DESCRIPTION
When rendering a single pipe on the same line as the tag, Haml swallows the pipe — presumably because it’s interpreted as multiline indicator (http://haml.info/docs/yardoc/file.REFERENCE.html#multiline):

``` haml
%span |
```

is evaluated to:

``` html
<span></span>
```

In my eyes (and I understand that this might very well be just a matter of opinion) that’s incorrect or at least unexpected behavior, as this case contains only a single pipe, not _multiple_. IMO the pipe should be treated as a regular string in this case.

The attached test illustrates the issue.
