### PR TITLE
Fix typo in Coffeescript documentation.

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1086,7 +1086,7 @@ Surrounds the filtered text with CDATA tags.
 
 {#coffee-filter}
 ### `:coffee`
-Compiles the filtered text to Javascript using Cofeescript. You can also
+Compiles the filtered text to Javascript using Coffeescript. You can also
 reference this filter as `:coffeescript`. This filter is implemented using
 Tilt.
 


### PR DESCRIPTION
I was reading the docs online and noticed a missing "f"!
