### PR TITLE
Add `--remove-whitespace` option to the CLI

### DIFF
--- a/lib/haml/exec.rb
+++ b/lib/haml/exec.rb
@@ -236,6 +236,11 @@ END
           @options[:for_engine][:attr_wrapper] = '"'
         end
 
+        opts.on('--remove-whitespace',
+                'Remove whitespaces surrounding and within tags') do
+          @options[:for_engine][:remove_whitespace] = true
+        end
+
         opts.on('--cdata',
                 'Always add CDATA sections to javascript and css blocks.') do
           @options[:for_engine][:cdata] = true


### PR DESCRIPTION
Sets the `remove_whitespace` option to `true` for the engine, effectively stripping all whitespaces (including linebreaks).

I need it for my pipeline because I am working with AngularJS, and it adds an additional `<span ng-scope>` when there is whitespaces between tags.
