### PR TITLE
Handling of "--", "-->", "<!--" in haml comments

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -439,6 +439,12 @@ module Haml
       conditional, text = balance(text, ?[, ?]) if text[0] == ?[
       text.strip!
 
+      text = text.split(/<!-+/).map do |x|
+        x.split(/--+>/).map do |y|
+          y.gsub(/-(-+)/, "-")
+        end
+      end.join("--><!--")
+
       if block_opened? && !text.empty?
         raise SyntaxError.new(Haml::Error.message(:illegal_nesting_content), @next_line.index)
       end

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -439,11 +439,11 @@ module Haml
       conditional, text = balance(text, ?[, ?]) if text[0] == ?[
       text.strip!
 
-      text = text.split(/<!-+/).map do |x|
-        x.split(/--+>/).map do |y|
-          y.gsub(/-(-+)/, "-")
-        end
-      end.join("--><!--")
+      text = text.split(/<!-+|--+>/).map do |x|
+          x.gsub!(/-(-+)/, "-")
+          x.strip!
+          x
+        end.join(" --><!-- ")
 
       if block_opened? && !text.empty?
         raise SyntaxError.new(Haml::Error.message(:illegal_nesting_content), @next_line.index)

--- a/test/results/comments.xhtml
+++ b/test/results/comments.xhtml
@@ -1,6 +1,6 @@
-<!-- This comment has a double hyphen like - - this! -->
+<!-- This comment has a double hyphen like - this! -->
 <!-- This comment has an extraneous --><!-- arrow -->
 <!-- This comment has an embedded comment --><!-- woot! -->
 <!-- This comment has an extraneous --><!-- exclamation mark -->
-<!-- This comment has --><!-- three hypens. Not good  -->
+<!-- This comment has-three hypens. Not good -->
 

--- a/test/results/comments.xhtml
+++ b/test/results/comments.xhtml
@@ -1,0 +1,6 @@
+<!-- This comment has a double hyphen like - - this! -->
+<!-- This comment has an extraneous --><!-- arrow -->
+<!-- This comment has an embedded comment --><!-- woot! -->
+<!-- This comment has an extraneous --><!-- exclamation mark -->
+<!-- This comment has --><!-- three hypens. Not good  -->
+

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -43,7 +43,7 @@ class TemplateTest < MiniTest::Unit::TestCase
   TEMPLATES = %w{          very_basic        standard    helpers
     whitespace_handling    original_engine   list        helpful
     silent_script          tag_parsing       just_stuff  partials
-    nuke_outer_whitespace  nuke_inner_whitespace
+    nuke_outer_whitespace  nuke_inner_whitespace comments
     render_layout partial_layout partial_layout_erb}
 
   def setup

--- a/test/templates/comments.haml
+++ b/test/templates/comments.haml
@@ -1,0 +1,6 @@
+/ This comment has a double hyphen like -- this!
+/ This comment has an extraneous --> arrow
+/ This comment has an embedded comment <!-- woot! -->
+/ This comment has an extraneous <!-- exclamation mark
+/ This comment has---three hypens. Not good 
+


### PR DESCRIPTION
- This adds functionality handle the parsing of a HAML document that has
  hypens and other hyphen-related special characters in comments.
