### PR TITLE
Making tests green by modifying the partial_layout_erb template test

### DIFF
--- a/test/results/partial_layout_erb.xhtml
+++ b/test/results/partial_layout_erb.xhtml
@@ -1,5 +1,5 @@
 <h1>Partial layout used with for block:</h1>
 <div class='partial-layout'>
   <h2>This is inside a partial layout</h2>
-  <p>Some content within a layout</p>
+  Some content within a layout
 </div>

--- a/test/templates/partial_layout_erb.erb
+++ b/test/templates/partial_layout_erb.erb
@@ -1,4 +1,4 @@
 <h1>Partial layout used with for block:</h1>
 <%= render :layout => 'layout_for_partial' do -%>
-<p>Some content within a layout</p>
+Some content within a layout
 <% end %>


### PR DESCRIPTION
When using <%= , ActionView is escaping the result for safety purposes
so it will be better to remove the tags from the test. 
