### PR TITLE
escape_once does not work on frozen strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Haml Changelog
 
+* Helpers#escape_once works on frozen strings (as does
+  ERB::Util.html_escape_once for which it acts as a replacement in
+  Rails.
+
 ## 4.0.3
 
 Released May 21, 2013 ([diff](https://github.com/haml/haml/compare/4.0.2...4.0.3)).

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -564,14 +564,12 @@ MESSAGE
       # @return [String] The sanitized string
       def escape_once(text)
         text = text.to_s
-        text.gsub!(HTML_ESCAPE_ONCE_REGEX, HTML_ESCAPE)
-        text
+        text.gsub(HTML_ESCAPE_ONCE_REGEX, HTML_ESCAPE)
       end
     else
       def escape_once(text)
         text = text.to_s
-        text.gsub!(HTML_ESCAPE_ONCE_REGEX){|s| HTML_ESCAPE[s]}
-        text
+        text.gsub(HTML_ESCAPE_ONCE_REGEX){|s| HTML_ESCAPE[s]}
       end
     end
 

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -553,5 +553,13 @@ HAML
     $stderr = old_stderr
   end
 
+  def test_escape_once_should_work_on_frozen_strings
+    begin
+      Haml::Helpers.escape_once('foo'.freeze)
+    rescue => e
+      flunk e.message
+    end
+  end
+
 end
 


### PR DESCRIPTION
The current implementation of escape_once does not work on frozen strings. Apart from the fact that it is not obvious from the name that the method modifies the string passed as an argument, the behavior differs from ERB::Util.html_escape_once for which it acts as a replacement in Rails.

That way, code that works with ActionView::Helpers::TagHelper#escape_once when using ERB does no longer work when a project uses Haml.

Thanks for creating and maintaining Haml. We use it all the time and love it!
