### PR TITLE
update nokogiri dependency to 1.6.0

### DIFF
--- a/haml.gemspec
+++ b/haml.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rails', '>= 3.0.0'
   spec.add_development_dependency 'rbench'
   spec.add_development_dependency 'minitest'
-  spec.add_development_dependency 'nokogiri', '~> 1.5.10'
+  spec.add_development_dependency 'nokogiri', '~> 1.6.0'
 
   spec.description = <<-END
 Haml (HTML Abstraction Markup Language) is a layer on top of HTML or XML that's


### PR DESCRIPTION
Since we no longer support ruby 1.8, we can use nokogri 1.6.x.
