### PR TITLE
Fix for the 694 issue: Modified the logic determining the output of capturing haml content

### DIFF
--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -388,7 +388,6 @@ MESSAGE
       haml_buffer.capture_position = nil
     end
 
-
     # Outputs text directly to the Haml buffer, with the proper indentation.
     #
     # @param text [#to_s] The text to output
@@ -474,10 +473,10 @@ MESSAGE
       name, attrs = merge_name_and_attributes(name.to_s, attrs)
 
       attributes = Haml::Compiler.build_attributes(haml_buffer.html?,
-      haml_buffer.options[:attr_wrapper],
-      haml_buffer.options[:escape_attrs],
-      haml_buffer.options[:hyphenate_data_attrs],
-      attrs)
+        haml_buffer.options[:attr_wrapper],
+        haml_buffer.options[:escape_attrs],
+        haml_buffer.options[:hyphenate_data_attrs],
+        attrs)
 
       if text.nil? && block.nil? && (haml_buffer.options[:autoclose].include?(name) || flags.include?(:/))
         haml_concat "<#{name}#{attributes}#{' /' if haml_buffer.options[:format] == :xhtml}>"
@@ -681,7 +680,6 @@ MESSAGE
       end.join
     end
   end
-
 end
 
 # @private

--- a/lib/haml/helpers/action_view_mods.rb
+++ b/lib/haml/helpers/action_view_mods.rb
@@ -42,7 +42,7 @@ module ActionView
           #double assignment is to avoid warnings
           _hamlout = _hamlout = eval('_hamlout', block.binding) # Necessary since capture_haml checks _hamlout
 
-          str = capture_haml(*args) { yield(*args) }
+          str = capture_haml(*args, &block)
 
           # NonCattingString is present in Rails less than 3.1.0. When support
           # for 3.0 is dropped, this can be removed.

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -111,7 +111,6 @@ class TemplateTest < MiniTest::Unit::TestCase
     end
   end
 
-
   def test_render_method_returning_null_with_ugly
     @base.instance_eval do
       def empty
@@ -134,8 +133,6 @@ class TemplateTest < MiniTest::Unit::TestCase
     expected_result = "<p>test</p>\nfoo\n"
     assert_equal(expected_result, result)
   end
-
-
 
   def test_templates_should_render_correctly_with_render_proc
     assert_renders_correctly("standard") do |name|


### PR DESCRIPTION
The 694 issue highlights an edge case when capturing haml: the buffer doesn't modify and the ugly flag is turned on. This pull request contains:
- Moved logic to determine the output of capturing haml to the capture_haml method of helpers
- Modify logic to address the edge case described above
- Test that replicates the issue
- Simple test of rendering with ugly flag turned on (for coverage purposes)
- Extracted logic about prettifying the text (adding correct tabs when ugly flag is off) to a private method
