### PR TITLE
Word break element is self-closing

### DIFF
--- a/lib/haml/options.rb
+++ b/lib/haml/options.rb
@@ -6,7 +6,9 @@ module Haml
 
     @defaults = {
       :attr_wrapper         => "'",
-      :autoclose            => %w(meta img link br hr input area param col base),
+      :autoclose            => %w(area base basefont br col command embed frame
+                                  hr img input isindex keygen link menuitem meta
+                                  param source track wbr),
       :encoding             => "UTF-8",
       :escape_attrs         => true,
       :escape_html          => false,


### PR DESCRIPTION
- The <wbr /> tag for word breaks in HTML5 is [auto-closing.](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/wbr)

![screen shot 2013-11-29 at 9 49 42 pm](https://f.cloud.github.com/assets/2602872/1648271/7c626f4a-5983-11e3-8958-d0cfd3733074.png)
