### PR TITLE
Fix 1.8.7 warning: "regexp has invalid interval"

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -83,7 +83,7 @@ module Haml
     DOCTYPE_REGEX = /(\d(?:\.\d)?)?[\s]*([a-z]*)\s*([^ ]+)?/i
 
     # The Regex that matches a literal string or symbol value
-    LITERAL_VALUE_REGEX = /:(\w*)|(["'])((?!\\|\#{|\#@|\#\$|\2).|\\.)*\2/
+    LITERAL_VALUE_REGEX = /:(\w*)|(["'])((?!\\|\#\{|\#@|\#\$|\2).|\\.)*\2/
 
     def initialize(template, options)
       # :eod is a special end-of-document marker


### PR DESCRIPTION
Apparently `{` needs to be escaped in Ruby 1.8
