### PR TITLE
Ensure trace info is added to all tags

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -162,6 +162,10 @@ END
         preserve_script = t[:preserve_script]
       end
 
+      if @options[:trace]
+        t[:attributes].merge!({"data-trace" => @options.filename.split('/views').last + ":" + @node.line.to_s})
+      end
+
       # Check if we can render the tag directly to text and not process it in the buffer
       if (object_ref == :nil) && attributes_hashes.empty? && !preserve_script
         tag_closed = !block_given? && !t[:self_closing] && !parse
@@ -500,9 +504,6 @@ END
     end
 
     def prerender_tag(name, self_close, attributes)
-      if @options[:trace]
-        attributes.merge!({"data-trace" => @options.filename.split('/views').last + ":" + @node.line.to_s})
-      end
       attributes_string = Compiler.build_attributes(
         @options.html?, @options.attr_wrapper, @options.escape_attrs, @options.hyphenate_data_attrs, attributes)
       "<#{name}#{attributes_string}#{self_close && @options.xhtml? ? ' /' : ''}>"

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1987,8 +1987,8 @@ HAML
   end
 
   def test_tracing
-    result = render('%p', :trace => true, :filename => 'foo').strip
-    assert_equal "<p data-trace='foo:1'></p>", result
+    result = render('%p{:class => "hello"}', :trace => true, :filename => 'foo').strip
+    assert_equal "<p class='hello' data-trace='foo:1'></p>", result
   end
 
   private


### PR DESCRIPTION
The original commit adds the trace info in the `prerender_tag` method, which is only called in certain cases when the parser can detect the tag is static and can be rendered directly to the output. I’ve moved the code into `compile_tag`, so that it gets added to all tags (and updated the test so the tag doesn’t get pre-rendered).

(cc @ababkin)

---

Add trace info (when enabled) to all tags generated, not only those that
can be prerendered.
