### PR TITLE
Update data attribute docs

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -389,7 +389,7 @@ or using `true` and `false`:
 
     %input(selected=true)
 
-#### Hash Valued Attributes
+#### Prefixed Attributes
 
 HTML5 allows for adding
 [custom non-visible data attributes](http://www.whatwg.org/specs/web-apps/current-work/multipage/elements.html#embedding-custom-non-visible-data-with-the-data-*-attributes)


### PR DESCRIPTION
I’ve updated the docs to correctly describe the current behaviour, but the wording feels a little clumsy to me (the ambiguity between “parent” and “child” hashes). Any suggestions on improvements before merging?
## 

Any hash valued attribute is now expanded, not just those with the key
'data'. Update docs accordingly.

Also change example to better show how multiple attributes are created
with the same prefix.
