### PR TITLE
Replace maruku with redcarpet [ci skip]

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,7 +1,7 @@
 --charset          utf-8
 --readme           README.md
 --markup           markdown
---markup-provider  maruku
+--markup-provider  redcarpet
 --template-path    yard
 --default-return   ""
 --title            "Haml Documentation"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 group :docs do
   gem "yard", "~> 0.8.0"
-  gem "maruku"
+  gem "redcarpet"
 end
 
 platform :mri do


### PR DESCRIPTION
See https://github.com/haml/haml/commit/ad98db7#commitcomment-5384115

Maruku is obsolete: http://benhollis.net/blog/2013/10/20/maruku-is-obsolete/
