### PR TITLE
Newline after scripts

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -397,7 +397,7 @@ END
       push_silent('end', :can_suppress) unless @node.value[:dont_push_end]
       format_script_method = "_hamlout.format_script(haml_temp,#{args.join(',')});"
       @precompiled << "_hamlout.buffer << #{no_format ? "haml_temp.to_s;" : format_script_method}"
-      concat_merged_text("\n") unless opts[:in_tag] || opts[:nuke_inner_whitespace] || @options.ugly
+      concat_merged_text("\n") unless opts[:in_tag] || opts[:nuke_inner_whitespace]
     end
 
     def push_generated_script(text)

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -503,7 +503,7 @@ HAML
   end
 
   def test_equals_block_with_ugly
-    assert_equal("foo\n", render(<<HAML, :ugly => true))
+    assert_equal("foo\n\n", render(<<HAML, :ugly => true))
 = capture_haml do
   foo
 HAML

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1004,6 +1004,16 @@ HTML
 HAML
   end
 
+  def test_script_adds_newline_in_ugly_with_block
+    scope = Object.new
+    def scope.foo
+      "Hello"
+    end
+    haml = "= foo do\n  .ignored\nEnd\n"
+    html = "Hello\nEnd\n"
+    assert_equal(html, render(haml, :scope => scope, :ugly => true))
+  end
+
   # Options tests
 
   def test_filename_and_line

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -123,7 +123,7 @@ class TemplateTest < MiniTest::Unit::TestCase
 
     content_to_render = "%h1 This is part of the broken view.\n= render_something do |thing|\n  = thing.empty do\n    = 'test'"
     result = render(content_to_render, :ugly => true)
-    expected_result = "<h1>This is part of the broken view.</h1>\n"
+    expected_result = "<h1>This is part of the broken view.</h1>\n\n\n"
     assert_equal(expected_result, result)
   end
 


### PR DESCRIPTION
A (possible) fix for #748. There may be some corner cases I haven’t considered in relation to this, but I think this gives better and more consistent behaviour than before.
