### PR TITLE
Add docs badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Build Status](https://secure.travis-ci.org/haml/haml.png?branch=master)](http://travis-ci.org/haml/haml)
 [![Code Climate](https://codeclimate.com/github/haml/haml.png)](https://codeclimate.com/github/haml/haml)
 [![Coverage Status](https://coveralls.io/repos/haml/haml/badge.png)](https://coveralls.io/r/haml/haml)
+[![Inline docs](http://inch-pages.github.io/github/haml/haml.png)](http://inch-pages.github.io/github/haml/haml)
 
 Haml is a templating engine for HTML. It's designed to make it both easier and
 more pleasant to write HTML documents, by eliminating redundancy, reflecting the


### PR DESCRIPTION
Hi there,

this patch adds a docs badge to the README to show off inline-documentation to the casual visitor: [![Inline docs](http://inch-pages.github.io/github/haml/haml.png)](http://inch-pages.github.io/github/haml/haml) (and Haml's inline documentation is really good!)

The badge links to [Inch Pages](http://inch-pages.github.io), a project that tries to raise the visibility of documentation in Ruby projects. The status page for Haml is http://inch-pages.github.io/github/haml/haml/

Inch Pages is still in it's infancy, but already used by projects like [Virtus](https://github.com/solnic/virtus) and [libnotify](https://github.com/splattael/libnotify).

What do you think?
