### PR TITLE
HTML escape interpolated code in filters

### DIFF
--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -163,7 +163,7 @@ module Haml
           if contains_interpolation?(text)
             return if options[:suppress_eval]
 
-            text = unescape_interpolation(text).gsub(/(\\+)n/) do |s|
+            text = unescape_interpolation(text, options[:escape_html]).gsub(/(\\+)n/) do |s|
               escapes = $1.size
               next s if escapes % 2 == 0
               "#{'\\' * (escapes - 1)}\n"

--- a/test/filters_test.rb
+++ b/test/filters_test.rb
@@ -109,6 +109,11 @@ class FiltersTest < MiniTest::Unit::TestCase
     end
   end
 
+  test "interpolated code should use be escaped in escape_html is set" do
+    assert_equal "&lt;script&gt;evil&lt;/script&gt;\n",
+                 render(":plain\n  \#{'<script>evil</script>'}", :escape_html => true)
+  end
+
 end
 
 class ErbFilterTest < MiniTest::Unit::TestCase
@@ -140,8 +145,8 @@ class JavascriptFilterTest < MiniTest::Unit::TestCase
     assert_match(/bar/, html)
   end
 
-  test "should never HTML-escape ampersands" do
-    html = "<script>\n  & < > &\n</script>\n"
+  test "should never HTML-escape non-interpolated ampersands" do
+    html = "<script>\n  & < > &amp;\n</script>\n"
     haml = %Q{:javascript\n  & < > \#{"&"}}
     assert_equal(html, render(haml, :escape_html => true))
   end


### PR DESCRIPTION
HTML escape any interpolated code if the escape_html option is set.

I’ve used the existing `:escape_html` option rather than creating a new option. Does anyone think there should be separate options?
