### PR TITLE
Add Haml::TestCase

### DIFF
--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 require 'test_helper'
 
-class EngineTest < MiniTest::Unit::TestCase
+class EngineTest < Haml::TestCase
   # A map of erroneous Haml documents to the error messages they should produce.
   # The error messages may be arrays;
   # if so, the second element should be the line number that should be reported for the error.

--- a/test/filters_test.rb
+++ b/test/filters_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class FiltersTest < MiniTest::Unit::TestCase
+class FiltersTest < Haml::TestCase
   test "should be registered as filters when including Haml::Filters::Base" do
     begin
       refute Haml::Filters.defined.has_key? "bar"
@@ -116,7 +116,7 @@ class FiltersTest < MiniTest::Unit::TestCase
 
 end
 
-class ErbFilterTest < MiniTest::Unit::TestCase
+class ErbFilterTest < Haml::TestCase
   test "multiline expressions should work" do
     html = "foobarbaz\n"
     haml = %Q{:erb\n  <%= "foo" +\n      "bar" +\n      "baz" %>}
@@ -137,7 +137,7 @@ class ErbFilterTest < MiniTest::Unit::TestCase
 
 end
 
-class JavascriptFilterTest < MiniTest::Unit::TestCase
+class JavascriptFilterTest < Haml::TestCase
   test "should interpolate" do
     scope = Object.new.instance_eval {foo = "bar"; nil if foo; binding}
     haml  = ":javascript\n  \#{foo}"
@@ -183,7 +183,7 @@ class JavascriptFilterTest < MiniTest::Unit::TestCase
   end
 end
 
-class CSSFilterTest < MiniTest::Unit::TestCase
+class CSSFilterTest < Haml::TestCase
   test "should wrap output in CDATA and a CSS tag when output is XHTML" do
     html = "<style type='text/css'>\n  /*<![CDATA[*/\n    foo\n  /*]]>*/\n</style>\n"
     haml = ":css\n  foo"
@@ -222,7 +222,7 @@ class CSSFilterTest < MiniTest::Unit::TestCase
   end
 end
 
-class CDATAFilterTest < MiniTest::Unit::TestCase
+class CDATAFilterTest < Haml::TestCase
   test "should wrap output in CDATA tag" do
     html = "<![CDATA[\n    foo\n]]>\n"
     haml = ":cdata\n  foo"
@@ -230,7 +230,7 @@ class CDATAFilterTest < MiniTest::Unit::TestCase
   end
 end
 
-class EscapedFilterTest < MiniTest::Unit::TestCase
+class EscapedFilterTest < Haml::TestCase
   test "should escape ampersands" do
     html = "&amp;\n"
     haml = ":escaped\n  &"
@@ -238,7 +238,7 @@ class EscapedFilterTest < MiniTest::Unit::TestCase
   end
 end
 
-class RubyFilterTest < MiniTest::Unit::TestCase
+class RubyFilterTest < Haml::TestCase
   test "can write to haml_io" do
     haml = ":ruby\n  haml_io.puts 'hello'\n"
     html = "hello\n"

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -33,7 +33,7 @@ class FormModel
 end
 
 
-class HelperTest < MiniTest::Unit::TestCase
+class HelperTest < Haml::TestCase
   Post = Struct.new('Post', :body, :error_field, :errors)
   class PostErrors
     def on(name)

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1,7 +1,7 @@
 require 'test_helper'
 
 module Haml
-  class ParserTest < MiniTest::Unit::TestCase
+  class ParserTest < Haml::TestCase
 
     test "should raise error for 'else' at wrong indent level" do
       begin

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -38,7 +38,7 @@ class DummyController
   end
 end
 
-class TemplateTest < MiniTest::Unit::TestCase
+class TemplateTest < Haml::TestCase
   TEMPLATE_PATH = File.join(File.dirname(__FILE__), "templates")
   TEMPLATES = %w{          very_basic        standard    helpers
     whitespace_handling    original_engine   list        helpful

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,14 +41,19 @@ require 'haml/template'
 Haml::Template.options[:ugly]   = false
 Haml::Template.options[:format] = :xhtml
 
+BASE_TEST_CLASS = if defined?(Minitest::Test)
+                    Minitest::Test
+                  else
+                    MiniTest::Unit::TestCase
+                  end
+
 module Declarative
   def test(name, &block)
     define_method("test #{name}", &block)
   end
 end
 
-class MiniTest::Unit::TestCase
-
+class Haml::TestCase < BASE_TEST_CLASS
   extend Declarative
 
   def render(text, options = {}, base = nil, &block)

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class UtilTest < MiniTest::Unit::TestCase
+class UtilTest < Haml::TestCase
   include Haml::Util
 
   def test_powerset


### PR DESCRIPTION
Fix Minitest base class warnings by creating a `Haml::TestCase` base
class that inherits from the latest Minitest base class available.

Background:

ActiveSupport 4.1 depends on minitest 5.x, which uses `Minitest::Test` as the base test class.

ActiveSupport 4.0 depends on minitest 4.x, which uses `MiniTest::Unit::TestCase` as the base class.

Rails 3.2 uses `Test::Unit::TestCase` defined by stdlib. There is no gem dependency on minitest in Rails 3.2, nor is there a gem dependency on test-unit.
