### PR TITLE
Do not require forwardable

### DIFF
--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -1,5 +1,3 @@
-require 'forwardable'
-
 require 'haml/parser'
 require 'haml/compiler'
 require 'haml/options'


### PR DESCRIPTION
It is part of the stdlib and does not need to be required.
