### PR TITLE
Unexpected removal of newline at the end of attribute value

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -450,7 +450,7 @@ END
           else
             value.to_s
           end
-        value = Haml::Helpers.preserve(escaped)
+        value = escaped.gsub(/\n/, '&#x000A;').delete("\r")
         if escape_attrs
           # We want to decide whether or not to escape quotes
           value.gsub!(/&quot;|&#x0022;/, '"')

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -366,6 +366,18 @@ HAML
     assert_equal("<p>foo</p>\n<p>bar</p>\n<p>baz</p>\n<p>boom</p>\n", render("%p foo\r%p bar\r\n%p baz\n\r%p boom"))
   end
 
+  def test_newline_in_attr_value_should_be_escaped
+    test_string = "test\nhoge\r\npoyo"
+    assert_equal("<input value='test&#x000A;hoge&#x000A;poyo'>\n",
+                 render("%input{:value => test_string}", :locals => {:test_string => test_string}))
+  end
+
+  def test_newline_at_the_end_of_attr_value_should_not_be_removed
+    test_string = "test\r\n\r\n"
+    assert_equal("<input value='test&#x000A;&#x000A;'>\n",
+                 render("%input{:value => test_string}", :locals => {:test_string => test_string}))
+  end
+
   def test_textareas
     assert_equal("<textarea>Foo&#x000A;  bar&#x000A;   baz</textarea>\n",
                  render('%textarea= "Foo\n  bar\n   baz"'))


### PR DESCRIPTION
This haml:

``` unexpected-removal-newline.haml
%input{:value => "some string\r\n"}
```

produces the following html:

``` unexpected-removal-newline.html
<input value='some string'>
```

It seems that the method `build_attributes` uses `Haml::Helpers.preserve` in order to replace `\n` by `&#x000A`. Thus, a newline at the end of an attribute value is removed because `Haml::Helpers.preserve` calls `chomp`.

So, I made a patch.
- Does not use `preserve` in `build_attributes`,
- Adds 2 related test cases.

In my environment, with both `ruby 1.9.3p194` and `ruby 2.0.0p451`, I passed to all tests. I also confirmed I could apply my patch to the `stable` branch without a conflict.

Could you please consider merging my patch?

Thanks for a nice template engine!
