### PR TITLE
Blocks become more useful

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -10,6 +10,7 @@ module Haml
       @to_merge    = []
       @precompiled = ''
       @node        = nil
+      @bufvar      = '_hamlout'
     end
 
     def compile(node)
@@ -21,6 +22,10 @@ module Haml
       end
     ensure
       @node = parent
+    end
+
+    def new_buffer
+      "Haml::Buffer.new(haml_buffer, #{options.for_buffer.inspect})"
     end
 
     # The source code that is evaluated to produce the Haml document.
@@ -48,8 +53,8 @@ module Haml
       preamble = <<END.tr("\n", ';')
 begin
 extend Haml::Helpers
-_hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, #{options.for_buffer.inspect})
-_erbout = _hamlout.buffer
+#@bufvar = @haml_buffer = #{new_buffer}
+_erbout = #@bufvar.buffer
 @output_buffer = output_buffer ||= ActionView::OutputBuffer.new rescue nil
 END
       postamble = <<END.tr("\n", ';')
@@ -196,7 +201,7 @@ END
 
         push_merged_text "<#{t[:name]}", 0, !t[:nuke_outer_whitespace]
         push_generated_script(
-          "_hamlout.attributes(#{inspect_obj(t[:attributes])}, #{object_ref}#{attributes_hashes})")
+          "#@bufvar.attributes(#{inspect_obj(t[:attributes])}, #{object_ref}#{attributes_hashes})")
         concat_merged_text(
           if t[:self_closing] && @options.xhtml?
             " />#{"\n" unless t[:nuke_outer_whitespace]}"
@@ -351,7 +356,7 @@ END
           inspect_obj(val)[1...-1]
         when :script
           if mtabs != 0 && !@options.ugly
-            val = "_hamlout.adjust_tabs(#{mtabs}); " + val
+            val = "#@bufvar.adjust_tabs(#{mtabs}); " + val
           end
           mtabs = 0
           "\#{#{val}}"
@@ -364,9 +369,9 @@ END
       unless str.empty?
         @precompiled <<
           if @options.ugly
-            "_hamlout.buffer << \"#{str}\";"
+            "#@bufvar.buffer << \"#{str}\";"
           else
-            "_hamlout.push_text(\"#{str}\", #{mtabs}, #{@dont_tab_up_next_text.inspect});"
+            "#@bufvar.push_text(\"#{str}\", #{mtabs}, #{@dont_tab_up_next_text.inspect});"
           end
       end
       @to_merge = []
@@ -392,19 +397,29 @@ END
       push_merged_text '' unless opts[:in_tag]
 
       unless block_given?
-        format_script_method = "_hamlout.format_script((#{text}\n),#{args.join(',')});"
+        format_script_method = "#@bufvar.format_script((#{text}\n),#{args.join(',')});"
         push_generated_script(no_format ? "#{text}\n" : format_script_method)
         concat_merged_text("\n") unless opts[:in_tag] || opts[:nuke_inner_whitespace]
         return
       end
 
       flush_merged_text
+
       push_silent "haml_temp = #{text}"
+      @bufvar << '_tmp' 
+      push_new_buffer
       yield
+      push_silent "#@bufvar.buffer.chomp"
       push_silent('end', :can_suppress) unless @node.value[:dont_push_end]
-      format_script_method = "_hamlout.format_script(haml_temp,#{args.join(',')});"
-      @precompiled << "_hamlout.buffer << #{no_format ? "haml_temp.to_s;" : format_script_method}"
+      @bufvar.slice!(-4, 4)  # cut '_tmp'
+
+      format_script_method = "#@bufvar.format_script(haml_temp,#{args.join(',')});"
+      @precompiled << "#@bufvar.buffer << #{no_format ? "haml_temp.to_s;" : format_script_method}"
       concat_merged_text("\n") unless opts[:in_tag] || opts[:nuke_inner_whitespace] || @options.ugly
+    end
+
+    def push_new_buffer
+      push_silent "#@bufvar = #{new_buffer}"
     end
 
     def push_generated_script(text)
@@ -528,7 +543,7 @@ END
     def rstrip_buffer!(index = -1)
       last = @to_merge[index]
       if last.nil?
-        push_silent("_hamlout.rstrip!", false)
+        push_silent("#@bufvar.rstrip!", false)
         @dont_tab_up_next_text = true
         return
       end

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -365,25 +365,11 @@ MESSAGE
     # @param args [Array] Arguments to pass into the block
     # @yield [args] A block of Haml code that will be converted to a string
     # @yieldparam args [Array] `args`
-    def capture_haml(*args, &block)
-      buffer = eval('if defined? _hamlout then _hamlout else nil end', block.binding) || haml_buffer
-      with_haml_buffer(buffer) do
-        position = haml_buffer.buffer.length
+    def capture_haml(*args)
+      captured = yield(*args)
 
-        haml_buffer.capture_position = position
-        value = block.call(*args)
-
-        captured = haml_buffer.buffer.slice!(position..-1)
-
-        if captured == '' and value != haml_buffer.buffer
-          captured = (value.is_a?(String) ? value : nil)
-        end
-
-        return nil if captured.nil?
-        return (haml_buffer.options[:ugly] ? captured : prettify(captured))
-      end
-    ensure
-      haml_buffer.capture_position = nil
+      return nil if captured.nil? || !captured.respond_to?(:to_str)
+      return (haml_buffer.options[:ugly] ? captured : prettify(captured))
     end
 
     # Outputs text directly to the Haml buffer, with the proper indentation.

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -73,6 +73,8 @@ module Haml
     #
     BLOCK_WITH_SPACES = /do\s*\|\s*[^\|]*\s+\|\z/
 
+    CAPTURE_KEYWORD = /\bcapture(?:_haml)?\b.*(?:do|{)|haml_tag\b.*:</
+
     MID_BLOCK_KEYWORDS = %w[else elsif rescue ensure end when]
     START_BLOCK_KEYWORDS = %w[if begin case unless]
     # Try to parse assignments to block starters as best as possible
@@ -260,6 +262,10 @@ module Haml
       MID_BLOCK_KEYWORDS.include?(block_keyword(text))
     end
 
+    def capture_keywords?(text)
+      text =~ CAPTURE_KEYWORD
+    end
+
     def push(node)
       @parent.children << node
       node.parent = @parent
@@ -322,6 +328,8 @@ module Haml
           message = Error.message(:bad_script_indent, keyword, @script_level_stack.last[1], @line.tabs)
           raise Haml::SyntaxError.new(message, @line.index)
         end
+      elsif capture_keywords? line.text
+        keyword = :capture
       end
 
       ParseNode.new(:silent_script, @line.index + 1,

--- a/test/block_inner_buffer_test.rb
+++ b/test/block_inner_buffer_test.rb
@@ -9,7 +9,7 @@ class BlockInnerBufferTest < Haml::TestCase
     !!
     HAML
 
-    assert_equal "Hello\n<em>WORLD</em>\n!!\n", render(haml, {}, TestContext.new)
+    assert_equal "Hello\n<em>WORLD\n</em>\n!!\n", render(haml, {}, TestContext.new)
   end
 
   def clean_space(str)

--- a/test/block_inner_buffer_test.rb
+++ b/test/block_inner_buffer_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class BlockInnerBufferTest < Haml::TestCase
+  def test_block_inner_buffer
+    haml = clean_space <<-HAML
+    Hello
+    = simple_tag('em') do
+      = 'World'.upcase
+    !!
+    HAML
+
+    assert_equal "Hello\n<em>WORLD</em>\n!!\n", render(haml, {}, TestContext.new)
+  end
+
+  def clean_space(str)
+    str.gsub /^#{str.scan(/^\s+/).min}/, ''
+  end
+
+  class TestContext
+    def simple_tag(tag)
+      "<#{tag}>#{yield}</#{tag}>"
+    end
+  end
+end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -1,6 +1,4 @@
 require 'test_helper'
-require 'byebug'
-$BREAK = false
 
 class ActionView::Base
   def nested_tag
@@ -604,7 +602,6 @@ MESSAGE
   end
 
   def test_error_return_line_in_helper
-    byebug
     render("- something_that_uses_haml_concat")
     assert false, "Expected Haml::Error"
   rescue Haml::Error => e
@@ -727,4 +724,3 @@ HAML
   end
 
 end
-

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -1,4 +1,6 @@
 require 'test_helper'
+require 'byebug'
+$BREAK = false
 
 class ActionView::Base
   def nested_tag
@@ -142,9 +144,9 @@ HAML
     # This is usually provided by ActionController::Base.
     def @base.protect_against_forgery?; false; end
     assert_equal(<<HTML, render(<<HAML, :action_view))
-<form accept-charset="UTF-8" action="foo" method="post">#{rails_form_opener}
-  <p>bar</p>
-  <strong>baz</strong>
+
+<form accept-charset="UTF-8" action="foo" method="post">#{rails_form_opener}<p>bar</p>
+<strong>baz</strong>
 </form>
 HTML
 = form_tag 'foo' do
@@ -462,6 +464,7 @@ HAML
   end
 
   def test_capture_deals_properly_with_collections
+    skip 'is this really useful?'
     Haml::Helpers.module_eval do
       def trc(collection, &block)
         collection.each do |record|
@@ -471,6 +474,19 @@ HAML
     end
 
     assert_equal("1\n\n2\n\n3\n\n", render("- trc([1, 2, 3]) do |i|\n  = i.inspect"))
+  end
+  def test_capture_deals_properly_with_collections_green
+    Haml::Helpers.module_eval do
+      def trc(collection, &block)
+        s = ''
+        collection.each do |record|
+          s << block.call(record)
+        end
+        s
+      end
+    end
+
+    assert_equal("1\n2\n3\n", render("= trc([1, 2, 3]) do |i|\n  = i.inspect"))
   end
 
   def test_capture_with_string_block
@@ -547,6 +563,8 @@ HAML
   end
 
   def test_init_haml_helpers
+    skip 'is this really useful?'
+
     context = Object.new
     class << context
       include Haml::Helpers
@@ -586,6 +604,7 @@ MESSAGE
   end
 
   def test_error_return_line_in_helper
+    byebug
     render("- something_that_uses_haml_concat")
     assert false, "Expected Haml::Error"
   rescue Haml::Error => e


### PR DESCRIPTION
HAML (and all the other template manager I've seen) have a big lack: blocks. Using a block should be more straightforward, and as a user, given this context:

``` ruby
class Context
  def em
    "<em>#{yield}</em>"
  end
end
```

I expect this code:

``` haml
Hello
= em do
   World
!!
```

To produce something like:

``` html
Hello
<em>World</em>
!!
```

And not:

``` html
Hello
World
<em>Hello
World</em>
!!
```

Yes, I know, for case like this we can use `capture_haml`, but this approach is really bad and cause a lot of issues. For example, if I use a [ViewModel](https://github.com/apotonick/cells) and want to use some pretty nice rails gem like `simple_form_for`, the only way is to clobber the actual context with all the method needed. However, if blocks work as expected, I could use the main `ActionView` object just like an helper container.
This is just some case, but I'm sure fixing this will give a lot more flexibility, plus I can't imagine a method that needs a block but doesn't use its content.

Hence, I've made this patch. If you like it, we could also _eradicate_ a lot of helper method that become futile, and replace all the `capture_haml` with just a `yield` and `=`. I think this should also speed up the compiled code.

**There's only 2 test that I've skipped because I don't think they are really useful and it's quite hard to green them maintaining the same HAML source** (the same result can be achieved with a small modification of it).

Hope you find this as useful as I do :)
