### PR TITLE
Adding `while` and `until` to the list of start block keywords in the parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 * Don't treat the 'data' attribute specially when merging attribute hashes. (Matt Wildig and Norman Clarke)
 * Add a tracing option. When enabled, Haml will output a data-trace attribute on each tag showing the path
   to the source Haml file from which it was generated. Thanks [Alex Babkin](https://github.com/ababkin).
+* Adding while and until to the list of start block keywords in the parser. Thanks [Cameron Dutro](https://github.com/camertron)
 
 ## 4.0.5
 

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -74,7 +74,7 @@ module Haml
     BLOCK_WITH_SPACES = /do\s*\|\s*[^\|]*\s+\|\z/
 
     MID_BLOCK_KEYWORDS = %w[else elsif rescue ensure end when]
-    START_BLOCK_KEYWORDS = %w[if begin case unless]
+    START_BLOCK_KEYWORDS = %w[if begin case unless while until]
     # Try to parse assignments to block starters as best as possible
     START_BLOCK_KEYWORD_REGEX = /(?:\w+(?:,\s*\w+)*\s*=\s*)?(#{START_BLOCK_KEYWORDS.join('|')})/
     BLOCK_KEYWORD_REGEX = /^-?\s*(?:(#{MID_BLOCK_KEYWORDS.join('|')})|#{START_BLOCK_KEYWORD_REGEX.source})\b/


### PR DESCRIPTION
Currently `while` and `until` aren't identified as keywords by the haml parser.
