### PR TITLE
[3.1 stable] Adding while, until, and unless to the list of start block keywords in the parser

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -65,7 +65,7 @@ module Haml
     MULTILINE_CHAR_VALUE = ?|
 
     MID_BLOCK_KEYWORDS = %w[else elsif rescue ensure end when]
-    START_BLOCK_KEYWORDS = %w[if begin case]
+    START_BLOCK_KEYWORDS = %w[if begin case unless while until]
     # Try to parse assignments to block starters as best as possible
     START_BLOCK_KEYWORD_REGEX = /(?:\w+(?:,\s*\w+)*\s*=\s*)?(#{START_BLOCK_KEYWORDS.join('|')})/
     BLOCK_KEYWORD_REGEX = /^-\s*(?:(#{MID_BLOCK_KEYWORDS.join('|')})|#{START_BLOCK_KEYWORD_REGEX.source})\b/


### PR DESCRIPTION
Backporting this from #802.
