### PR TITLE
Hash#each_key instead of Hash#keys.each. Faster code.

### DIFF
--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -238,7 +238,7 @@ module Haml
         from[CLASS_KEY] ||= to[CLASS_KEY]
       end
 
-      from.keys.each do |key|
+      from.each_key do |key|
         next unless from[key].kind_of?(Hash) || to[key].kind_of?(Hash)
 
         from_data = from.delete(key)


### PR DESCRIPTION
More info at https://github.com/JuanitoFatas/fast-ruby#hasheach_key-instead-of-hashkeyseach-code.

Hash#keys creates new array and then you call #each on that array, while #each_key iterates over hash keys without creating new objects.
