### PR TITLE
Fixed small typo in Haml::Engine documentation

### DIFF
--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -177,7 +177,7 @@ module Haml
     # that renders the template and returns the result as a string.
     #
     # If `object` is a class or module,
-    # the method will instead by defined as an instance method.
+    # the method will instead be defined as an instance method.
     # For example:
     #
     #     t = Time.now


### PR DESCRIPTION
Hi, I just fixed a small typo.
