### PR TITLE
add haml_proc to return a proc that captures a given haml block

### DIFF
--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -704,6 +704,28 @@ MESSAGE
         str << line.slice(min_tabs, line.length)
       end
     end
+
+    # Returns a proc that captures a given haml block.
+    # For example:
+    #
+    #     - tagger = haml_proc do |tag, &block|
+    #       <#{tag}>#{block.call}</#{tag}>
+    #     = tagger.call('p') { 'hello' }
+    #
+    # Produces:
+    #
+    #     <p>hello</p>
+    #
+    #
+    # @param block [#call] A haml block
+    # @return [Proc] A new proc that returns a string.
+    def haml_proc(&block)
+      proc do |*args, &arg_block|
+        capture_haml do
+          block.call(*args, &arg_block)
+        end
+      end
+    end
   end
 end
 

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -707,4 +707,13 @@ HAML
     end
   end
 
+  def test_haml_proc
+    assert_equal(<<HTML, render(<<'HAML'))
+<p>hello</p>
+HTML
+- tagger = haml_proc do |tag, &my_block|
+  <#{tag}>#{my_block.call}</#{tag}>
+= tagger.call('p') { 'hello' }
+HAML
+  end
 end


### PR DESCRIPTION
Just wondering if you'd consider a helper that allows you to condense 

``` haml
- tagger = lambda do |tag, &my_block| capture_haml do
  <#{tag}>#{my_block.call}</#{tag}> 
- end end    
= tagger.call('p') { 'hello' }
```

as

``` haml
- tagger = haml_proc do |tag, &my_block|
  <#{tag}>#{my_block.call}</#{tag}>
= tagger.call('p') { 'hello' }
```

There are a couple of issues I'm concerned about though:

1) I'd really like to be able to call `yield` to execute the block, but that doesn't work.
2) In my test, if I rename `my_block` to just `block` I get a mri warning message that says `warning: shadowing outer local variable - block`.  Maybe that's ok in normal operation but I didn't want the test to generate noise.  I assume this is just because block is available in haml.  I assume block is meant to be exposed in the template.
