### PR TITLE
[stable] Check for Rails.env instead

### DIFF
--- a/lib/haml/template.rb
+++ b/lib/haml/template.rb
@@ -26,7 +26,7 @@ module Haml
 end
 
 
-Haml::Template.options[:ugly] = defined?(Rails) ? !Rails.env.development? : true
+Haml::Template.options[:ugly] = defined?(Rails.env) ? !Rails.env.development? : true
 Haml::Template.options[:escape_html] = true
 
 require 'haml/template/plugin'


### PR DESCRIPTION
I ran into this problem while trying to run haml 4.0.6 with actionmailer 4.2.0 with sinatra (or rather without Rails).

```ruby
require 'actionmailer'
require 'haml/template' #NoMethodError: undefined method `env' for Rails:Module
```
This is because actionmailer 4.2.0 now has a runtime dependency in `rails-dom-testing`, which loads Rails module, so, defined?(Rails)=true, but, Rails.env is not defined.

Hope I explained it well enough.