### PR TITLE
extract erb object creation out of powerset loop

### DIFF
--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -238,9 +238,10 @@ MSG
     def def_static_method(klass, name, args, *vars)
       erb = vars.pop
       info = caller_info
+      erb_object = (defined?(Erubis::TinyEruby) && Erubis::TinyEruby || ERB).new(erb)
       powerset(vars).each do |set|
         context = StaticConditionalContext.new(set).instance_eval {binding}
-        method_content = (defined?(Erubis::TinyEruby) && Erubis::TinyEruby || ERB).new(erb).result(context)
+        method_content = erb_object.result(context)
 
         klass.class_eval(<<METHOD, info[0], info[1])
           def #{static_method_name(name, *vars.map {|v| set.include?(v)})}(#{args.join(', ')})


### PR DESCRIPTION
Hey guys!  While profiling my small Sinatra app I found the slowest part was:

```
%self      total      self      wait     child     calls  name
5.52      0.312     0.160     0.000     0.152      128   ERB::Compiler::SimpleScanner2#scan
```

It is being called so many times because ERB.new(erb) is being called from within the powerset enumeration.

This small change eliminated my performance issue, and the haml tests continue to pass on Ruby 2.2.2
