### PR TITLE
Temple migration

### DIFF
--- a/haml.gemspec
+++ b/haml.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
+  spec.add_dependency 'temple'
   spec.add_dependency 'tilt'
 
   spec.add_development_dependency 'rails', '>= 4.0.0'

--- a/haml.gemspec
+++ b/haml.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency 'temple'
+  spec.add_dependency 'temple', '>= 0.7.6'
   spec.add_dependency 'tilt'
 
   spec.add_development_dependency 'rails', '>= 4.0.0'

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -5,8 +5,7 @@ module Haml
     attr_accessor :options
 
     def initialize(options)
-      @options     = options
-      @options     = Options.new(options) unless options.is_a?(Options)
+      @options     = Options.wrap(options)
       @output_tabs = 0
       @to_merge    = []
       @precompiled = ''

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -35,50 +35,7 @@ module Haml
       return @precompiled.encode(encoding)
     end
 
-    def precompiled_with_return_value
-      "#{precompiled};#{precompiled_method_return_value}"
-    end
-
-    # Returns the precompiled string with the preamble and postamble.
-    #
-    # Initializes to ActionView::OutputBuffer when available; this is necessary
-    # to avoid ordering issues with partial layouts in Rails. If not available,
-    # initializes to nil.
-    def precompiled_with_ambles(local_names)
-      preamble = <<END.tr!("\n", ';')
-begin
-extend Haml::Helpers
-_hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, #{options.for_buffer.inspect})
-_erbout = _hamlout.buffer
-@output_buffer = output_buffer ||= ActionView::OutputBuffer.new rescue nil
-END
-      postamble = <<END.tr!("\n", ';')
-#{precompiled_method_return_value}
-ensure
-@haml_buffer = @haml_buffer.upper if @haml_buffer
-end
-END
-      "#{preamble}#{locals_code(local_names)}#{precompiled}#{postamble}"
-    end
-
-    # Returns the string used as the return value of the precompiled method.
-    # This method exists so it can be monkeypatched to return modified values.
-    def precompiled_method_return_value
-      "_erbout"
-    end
-
     private
-
-    def locals_code(names)
-      names = names.keys if Hash === names
-
-      names.each_with_object('') do |name, code|
-        # Can't use || because someone might explicitly pass in false with a symbol
-        sym_local = "_haml_locals[#{inspect_obj(name.to_sym)}]"
-        str_local = "_haml_locals[#{inspect_obj(name.to_s)}]"
-        code << "#{name} = #{sym_local}.nil? ? #{str_local} : #{sym_local};"
-      end
-    end
 
     def compile_root
       @dont_indent_next_line = @dont_tab_up_next_text = false

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -6,10 +6,16 @@ module Haml
 
     def initialize(options)
       @options     = options
+      @options     = Options.new(options) unless options.is_a?(Options)
       @output_tabs = 0
       @to_merge    = []
       @precompiled = ''
       @node        = nil
+    end
+
+    def call(node)
+      compile(node)
+      @precompiled
     end
 
     def compile(node)
@@ -21,18 +27,6 @@ module Haml
       end
     ensure
       @node = parent
-    end
-
-    # The source code that is evaluated to produce the Haml document.
-    #
-    # This is automatically converted to the correct encoding
-    # (see {file:REFERENCE.md#encodings the `:encoding` option}).
-    #
-    # @return [String]
-    def precompiled
-      encoding = Encoding.find(@options.encoding)
-      return @precompiled.force_encoding(encoding) if encoding == Encoding::ASCII_8BIT
-      return @precompiled.encode(encoding)
     end
 
     private

--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -170,7 +170,7 @@ module Haml
 
       begin
         eval("Proc.new { |*_haml_locals| _haml_locals = _haml_locals[0] || {};" <<
-             compiler.precompiled_with_ambles(local_names) << "}\n", scope, @options.filename, @options.line)
+             @temple_engine.precompiled_with_ambles(local_names) << "}\n", scope, @options.filename, @options.line)
       rescue ::SyntaxError => e
         raise SyntaxError, e.message
       end
@@ -217,7 +217,7 @@ module Haml
     def def_method(object, name, *local_names)
       method = object.is_a?(Module) ? :module_eval : :instance_eval
 
-      object.send(method, "def #{name}(_haml_locals = {}); #{compiler.precompiled_with_ambles(local_names)}; end",
+      object.send(method, "def #{name}(_haml_locals = {}); #{@temple_engine.precompiled_with_ambles(local_names)}; end",
                   @options.filename, @options.line)
     end
 

--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -7,6 +7,7 @@ require 'haml/helpers'
 require 'haml/buffer'
 require 'haml/filters'
 require 'haml/error'
+require 'haml/temple_engine'
 
 module Haml
   # This is the frontend for using Haml programmatically.
@@ -63,6 +64,9 @@ module Haml
       @compiler = @options.compiler_class.new(@options)
 
       @compiler.compile(parser.parse)
+
+      @temple_engine = TempleEngine.new(options)
+      @temple_engine.compile(@template)
     end
 
     # Processes the template and returns the result as a string.
@@ -122,7 +126,7 @@ module Haml
       scope_object.extend(Haml::Helpers)
       scope_object.instance_variable_set(:@haml_buffer, buffer)
       begin
-        eval(@compiler.precompiled_with_return_value, scope, @options.filename, @options.line)
+        eval(@temple_engine.precompiled_with_return_value, scope, @options.filename, @options.line)
       rescue ::SyntaxError => e
         raise SyntaxError, e.message
       end

--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -36,7 +36,6 @@ module Haml
     attr_accessor :indentation
 
     attr_accessor :compiler
-    attr_accessor :parser
 
     # Tilt currently depends on these moved methods, provide a stable API
     def_delegators :compiler, :precompiled, :precompiled_method_return_value
@@ -60,10 +59,10 @@ module Haml
 
       initialize_encoding options[:encoding]
 
-      @parser   = @options.parser_class.new(@template, @options)
+      parser    = @options.parser_class.new(@template, @options)
       @compiler = @options.compiler_class.new(@options)
 
-      @compiler.compile(@parser.parse)
+      @compiler.compile(parser.parse)
     end
 
     # Processes the template and returns the result as a string.

--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -36,8 +36,6 @@ module Haml
     # @return [String]
     attr_accessor :indentation
 
-    attr_accessor :compiler
-
     # Tilt currently depends on these moved methods, provide a stable API
     def_delegators :compiler, :precompiled, :precompiled_method_return_value
 
@@ -58,15 +56,13 @@ module Haml
         raise Haml::Error.new(msg, line)
       end
 
-      initialize_encoding options[:encoding]
-
-      parser    = @options.parser_class.new(@template, @options)
-      @compiler = @options.compiler_class.new(@options)
-
-      @compiler.compile(parser.parse)
-
       @temple_engine = TempleEngine.new(options)
       @temple_engine.compile(@template)
+    end
+
+    # Deprecated API for backword compatibility
+    def compiler
+      @temple_engine
     end
 
     # Processes the template and returns the result as a string.
@@ -222,12 +218,6 @@ module Haml
     end
 
     private
-
-    def initialize_encoding(given_value)
-      unless given_value
-        @options.encoding = Encoding.default_internal || @template.encoding
-      end
-    end
 
     def set_locals(locals, scope, scope_object)
       scope_object.instance_variable_set :@_haml_locals, locals

--- a/lib/haml/options.rb
+++ b/lib/haml/options.rb
@@ -51,6 +51,14 @@ module Haml
       @buffer_option_keys
     end
 
+    def self.wrap(options)
+      if options.is_a?(Options)
+        options
+      else
+        Options.new(options)
+      end
+    end
+
     # The character that should wrap element attributes. This defaults to `'`
     # (an apostrophe). Characters of this type within the attributes will be
     # escaped (e.g. by replacing them with `&apos;`) if the character is an

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -89,9 +89,7 @@ module Haml
     CLASS_KEY = 'class'.freeze
 
     def initialize(options)
-      @options = options
-      @options = Options.new(options) unless options.is_a?(Options)
-
+      @options = Options.wrap(options)
       # Record the indent levels of "if" statements to validate the subsequent
       # elsif and else statements are indented at the appropriate level.
       @script_level_stack = []

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -88,14 +88,18 @@ module Haml
     ID_KEY    = 'id'.freeze
     CLASS_KEY = 'class'.freeze
 
-    def initialize(template, options)
-      @options            = options
+    def initialize(options)
+      @options = options
+      @options = Options.new(options) unless options.is_a?(Options)
+
       # Record the indent levels of "if" statements to validate the subsequent
       # elsif and else statements are indented at the appropriate level.
       @script_level_stack = []
       @template_index     = 0
       @template_tabs      = 0
+    end
 
+    def call(template)
       match = template.rstrip.scan(/(([ \t]+)?(.*?))(?:\Z|\r\n|\r|\n)/m)
       # discard the last match which is always blank
       match.pop
@@ -104,9 +108,7 @@ module Haml
       end
       # Append special end-of-document marker
       @template << Line.new(nil, '-#', '-#', @template.size, self, true)
-    end
 
-    def parse
       @root = @parent = ParseNode.new(:root)
       @flat = false
       @filter_buffer = nil

--- a/lib/haml/template.rb
+++ b/lib/haml/template.rb
@@ -21,6 +21,14 @@ module Haml
     alias_method :precompiled_method_return_value, :precompiled_method_return_value_with_haml_xss
   end
 
+  class TempleEngine
+    def precompiled_method_return_value_with_haml_xss
+      "::Haml::Util.html_safe(#{precompiled_method_return_value_without_haml_xss})"
+    end
+    alias_method :precompiled_method_return_value_without_haml_xss, :precompiled_method_return_value
+    alias_method :precompiled_method_return_value, :precompiled_method_return_value_with_haml_xss
+  end
+
   module Helpers
     include Haml::Helpers::XssMods
   end

--- a/lib/haml/template.rb
+++ b/lib/haml/template.rb
@@ -13,14 +13,6 @@ require 'haml/helpers/xss_mods'
 require 'haml/helpers/action_view_xss_mods'
 
 module Haml
-  class Compiler
-    def precompiled_method_return_value_with_haml_xss
-      "::Haml::Util.html_safe(#{precompiled_method_return_value_without_haml_xss})"
-    end
-    alias_method :precompiled_method_return_value_without_haml_xss, :precompiled_method_return_value
-    alias_method :precompiled_method_return_value, :precompiled_method_return_value_with_haml_xss
-  end
-
   class TempleEngine
     def precompiled_method_return_value_with_haml_xss
       "::Haml::Util.html_safe(#{precompiled_method_return_value_without_haml_xss})"

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -11,7 +11,7 @@ module Haml
       @compiler = @options.compiler_class.new(@options)
 
       @compiler.compile(parser.parse)
-      @compiler.precompiled_with_return_value
+      @compiler.precompiled
     end
   end
 
@@ -70,7 +70,7 @@ ensure
 @haml_buffer = @haml_buffer.upper if @haml_buffer
 end
 END
-      "#{preamble}#{locals_code(local_names)}#{precompiled};#{postamble}"
+      "#{preamble}#{locals_code(local_names)}#{precompiled}#{postamble}"
     end
 
     private

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -3,26 +3,26 @@ require 'temple'
 module Haml
   class TempleEngine < Temple::Engine
     define_options(
-      :attr_wrapper         => "'",
-      :autoclose            => %w(area base basefont br col command embed frame
-                                  hr img input isindex keygen link menuitem meta
-                                  param source track wbr),
-      :encoding             => nil,
-      :escape_attrs         => true,
-      :escape_html          => false,
-      :filename             => '(haml)',
-      :format               => :html5,
-      :hyphenate_data_attrs => true,
-      :line                 => 1,
-      :mime_type            => 'text/html',
-      :preserve             => %w(textarea pre code),
-      :remove_whitespace    => false,
-      :suppress_eval        => false,
-      :ugly                 => false,
-      :cdata                => false,
-      :parser_class         => ::Haml::Parser,
-      :compiler_class       => ::Haml::Compiler,
-      :trace                => false
+      attr_wrapper:         "'",
+      autoclose:            %w(area base basefont br col command embed frame
+                               hr img input isindex keygen link menuitem meta
+                               param source track wbr),
+      encoding:             nil,
+      escape_attrs:         true,
+      escape_html:          false,
+      filename:             '(haml)',
+      format:               :html5,
+      hyphenate_data_attrs: true,
+      line:                 1,
+      mime_type:            'text/html',
+      preserve:             %w(textarea pre code),
+      remove_whitespace:    false,
+      suppress_eval:        false,
+      ugly:                 false,
+      cdata:                false,
+      parser_class:         ::Haml::Parser,
+      compiler_class:       ::Haml::Compiler,
+      trace:                false,
     )
 
     use :Parser,   -> { options[:parser_class] }

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -1,16 +1,6 @@
 require 'temple'
 
 module Haml
-  class ParserFilter
-    def initialize(options = {})
-      @options = Options.new(options)
-    end
-
-    def call(template)
-      @options.parser_class.new(template, @options).parse
-    end
-  end
-
   class CompilerFilter
     def initialize(options = {})
       @options = Options.new(options)
@@ -47,7 +37,7 @@ module Haml
       :trace                => false
     )
 
-    use ParserFilter
+    use :Parser, -> { options[:parser_class] }
     use CompilerFilter
 
     def compile(template)

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -1,17 +1,25 @@
 require 'temple'
 
 module Haml
-  class EngineFilter
+  class ParserFilter
     def initialize(options = {})
       @options = Options.new(options)
     end
 
     def call(template)
-      parser    = @options.parser_class.new(template, @options)
-      @compiler = @options.compiler_class.new(@options)
+      @options.parser_class.new(template, @options).parse
+    end
+  end
 
-      @compiler.compile(parser.parse)
-      @compiler.precompiled
+  class CompilerFilter
+    def initialize(options = {})
+      @options = Options.new(options)
+    end
+
+    def call(node)
+      compiler = @options.compiler_class.new(@options)
+      compiler.compile(node)
+      compiler.precompiled
     end
   end
 
@@ -39,7 +47,8 @@ module Haml
       :trace                => false
     )
 
-    use EngineFilter
+    use ParserFilter
+    use CompilerFilter
 
     def compile(template)
       initialize_encoding(template, options[:encoding])

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -1,0 +1,75 @@
+require 'temple'
+
+module Haml
+  class EngineFilter
+    def initialize(options = {})
+      @options = Options.new(options)
+    end
+
+    def call(template)
+      parser    = @options.parser_class.new(template, @options)
+      @compiler = @options.compiler_class.new(@options)
+
+      @compiler.compile(parser.parse)
+      @compiler.precompiled_with_return_value
+    end
+  end
+
+  class TempleEngine < Temple::Engine
+    define_options(
+      :attr_wrapper         => "'",
+      :autoclose            => %w(area base basefont br col command embed frame
+                                  hr img input isindex keygen link menuitem meta
+                                  param source track wbr),
+      :encoding             => nil,
+      :escape_attrs         => true,
+      :escape_html          => false,
+      :filename             => '(haml)',
+      :format               => :html5,
+      :hyphenate_data_attrs => true,
+      :line                 => 1,
+      :mime_type            => 'text/html',
+      :preserve             => %w(textarea pre code),
+      :remove_whitespace    => false,
+      :suppress_eval        => false,
+      :ugly                 => false,
+      :cdata                => false,
+      :parser_class         => ::Haml::Parser,
+      :compiler_class       => ::Haml::Compiler,
+      :trace                => false
+    )
+
+    use EngineFilter
+
+    def compile(template)
+      initialize_encoding(template, options[:encoding])
+      @precompiled = call(template)
+    end
+
+    def precompiled
+      encoding = Encoding.find(@encoding || '')
+      return @precompiled.force_encoding(encoding) if encoding == Encoding::ASCII_8BIT
+      return @precompiled.encode(encoding)
+    end
+
+    def precompiled_with_return_value
+      "#{precompiled};#{precompiled_method_return_value}"
+    end
+
+    private
+
+    def initialize_encoding(template, given_value)
+      if given_value
+        @encoding = given_value
+      else
+        @encoding = Encoding.default_internal || template.encoding
+      end
+    end
+
+    # Returns the string used as the return value of the precompiled method.
+    # This method exists so it can be monkeypatched to return modified values.
+    def precompiled_method_return_value
+      "_erbout"
+    end
+  end
+end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -165,8 +165,8 @@ module Haml
 
     def parse(haml, options = nil)
       options ||= Options.new
-      parser = Parser.new(haml, options)
-      parser.parse
+      parser = Parser.new(options)
+      parser.call(haml)
     end
   end
 end


### PR DESCRIPTION
ref: https://github.com/haml/haml/issues/851

I migrated Haml's engine backend to Temple.
In this PR, I didn't change compiler process to temple-AST-based one and make breaking changes. But now `Haml::Parser` and `Haml::Compiler` are on Temple Engine's pipeline.
There is no feature addition or performance improvement but refactoring for future maintainability.

Since I implemented Hamlit v2 with original `Haml::Parser` in https://github.com/k0kubun/hamlit/pull/43, I know we can compile `Haml::Parser::ParseNode` into Temple AST (but not completely compatible about `Haml::Helpers`, though). This is just a first step for a whole migration.
