### PR TITLE
Use Ruby 2.3.0 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.3
+  - 2.3.0
   - 2.2
   - 2.1
   - 2.0.0


### PR DESCRIPTION
Related to https://github.com/haml/haml/commit/1983bdc551e51703eb9671b5e25c6dadaa9f4665

While we can't use it via 2.3 somehow, we already have ruby-2.3.0 on Travis http://rubies.travis-ci.org/.