### PR TITLE
Work with ruby 2.3's --enable-frozen-string-literal

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -8,7 +8,7 @@ module Haml
       @options     = options
       @output_tabs = 0
       @to_merge    = []
-      @precompiled = ''
+      @precompiled = String.new
       @node        = nil
     end
 

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -700,7 +700,7 @@ MESSAGE
         min_tabs = min_tabs > tabs ? tabs : min_tabs
       end
 
-      text.each_with_object('') do |line, str|
+      text.each_with_object(String.new) do |line, str|
         str << line.slice(min_tabs, line.length)
       end
     end


### PR DESCRIPTION
These changes are the minimal ones necessary to allow Roda's specs
to pass.  There may well be other changes that are required.
