### PR TITLE
Fix title of REFERENCE Attributes section

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -1,7 +1,7 @@
 --charset          utf-8
 --readme           README.md
 --markup           markdown
---markup-provider  maruku
+--markup-provider  kramdown
 --template-path    yard
 --default-return   ""
 --title            "Haml Documentation"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ gemspec
 
 group :docs do
   gem "yard", "~> 0.8.0"
-  gem "maruku"
+  gem "kramdown"
 end
 
 platform :mri do


### PR DESCRIPTION
# I'm cherry-picking https://github.com/haml/haml/pull/744 to fix header title of haml.info
## Before

> Attributes: `
> http://haml.info/docs/yardoc/file.REFERENCE.html#attributes_
## After this pull request merged

> Attributes: {} or ()
