### PR TITLE
Add support for CSS class names containing the `@` sign ("commercial at", U+0040)

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -533,7 +533,7 @@ module Haml
       attributes = {}
       return attributes if list.empty?
 
-      list.scan(/([#.])([-:_a-zA-Z0-9]+)/) do |type, property|
+      list.scan(/([#.])([-:_a-zA-Z0-9@]+)/) do |type, property|
         case type
         when '.'
           if attributes[CLASS_KEY]
@@ -566,7 +566,7 @@ module Haml
 
     # Parses a line into tag_name, attributes, attributes_hash, object_ref, action, value
     def parse_tag(text)
-      match = text.scan(/%([-:\w]+)([-:\w.#]*)(.+)?/)[0]
+      match = text.scan(/%([-:\w]+)([-:\w.#@]*)(.+)?/)[0]
       raise SyntaxError.new(Error.message(:invalid_tag, text)) unless match
 
       tag_name, attributes, rest = match

--- a/test/results/bemit.xhtml
+++ b/test/results/bemit.xhtml
@@ -1,0 +1,4 @@
+<div class='o-media@md c-user c-user--premium'>
+  <img alt='' class='o-media__img@md c-user__photo c-avatar' src='' />
+  <p class='o-media__body@md c-user__bio'>...</p>
+</div>

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -43,7 +43,7 @@ class TemplateTest < Haml::TestCase
   TEMPLATES = %w{          very_basic        standard    helpers
     whitespace_handling    original_engine   list        helpful
     silent_script          tag_parsing       just_stuff  partials
-    nuke_outer_whitespace  nuke_inner_whitespace
+    nuke_outer_whitespace  nuke_inner_whitespace         bemit
     render_layout partial_layout partial_layout_erb}
 
   def setup

--- a/test/templates/bemit.haml
+++ b/test/templates/bemit.haml
@@ -1,0 +1,3 @@
+.o-media@md.c-user.c-user--premium
+  %img.o-media__img@md.c-user__photo.c-avatar{src: '', alt: ''}
+  %p.o-media__body@md.c-user__bio ...


### PR DESCRIPTION
CSS conventions including [BEMIT](http://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further) encourage use of the `@` sign in CSS class names as part of [a suffix indicating the breakpoint at which a class takes effect.](http://csswizardry.com/2015/08/bemit-taking-the-bem-naming-convention-a-step-further#responsive-suffixes)

This PR adds Haml support for `@` within class names, so we can do:

``` haml
.o-media@md
```

Instead of having to do:

``` haml
%div{class: 'o-media@md'}
```

A passing test is included.
