### PR TITLE
Make inline sass work with sprockets 3.x

### DIFF
--- a/lib/haml/sass_rails_filter.rb
+++ b/lib/haml/sass_rails_filter.rb
@@ -4,7 +4,11 @@ module Haml
     # Rails's asset helpers to be used inside Haml Sass filter.
     class SassRailsTemplate < ::Sass::Rails::SassTemplate
       def render(scope=Object.new, locals={}, &block)
-        scope = ::Rails.application.assets.context_class.new(::Rails.application.assets, "/", "/")
+        scope = ::Rails.application.assets.context_class.new(
+          environment: ::Rails.application.assets,
+          filename: "/",
+          metadata: {}
+        )
         super
       end
 


### PR DESCRIPTION
- Fixes #844
- Sprockets 3 changed Sprockets::Context#initialize to take a hash
  argument
- This makes haml incompatible with inline sass for sprockets 2.x but
  since the last sprockets 2.x release was in 2014 this is probably acceptable
