### PR TITLE
Backport ActionView lazy-loading to the stable branch

### DIFF
--- a/lib/haml/template.rb
+++ b/lib/haml/template.rb
@@ -1,7 +1,14 @@
 require 'haml/template/options'
 require 'haml/engine'
-require 'haml/helpers/action_view_mods'
-require 'haml/helpers/action_view_extensions'
+if defined?(ActiveSupport)
+  ActiveSupport.on_load(:action_view) do
+    require 'haml/helpers/action_view_mods'
+    require 'haml/helpers/action_view_extensions'
+  end
+else
+  require 'haml/helpers/action_view_mods'
+  require 'haml/helpers/action_view_extensions'
+end
 require 'haml/helpers/xss_mods'
 require 'haml/helpers/action_view_xss_mods'
 


### PR DESCRIPTION
Released version of Haml doesn't include 520d92cc4f52ffe0983b2760ea798c1680476019 that I put in master 2 years ago, and lack of that causes possible test failures on Rails 5 + rails-controller-testing + haml  (see: https://github.com/rails/rails-controller-testing/issues/24 ).

So let me propose to backport this commit to the stable branch, and release new haml stable gem.
