### PR TITLE
Preserve order of class names in Haml tags

### DIFF
--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -125,7 +125,7 @@ module Haml
         elsif key == 'class'
           merged_class = filter_and_join(from, ' ')
           if to && merged_class
-            merged_class = (merged_class.split(' ') | to.split(' ')).sort.join(' ')
+            merged_class = (to.split(' ') | merged_class.split(' ')).join(' ')
           elsif to || merged_class
             merged_class ||= to
           end

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -153,14 +153,14 @@ class EngineTest < Haml::TestCase
 
   def test_class_attr_with_array
     assert_equal("<p class='a b'>foo</p>\n", render("%p{:class => %w[a b]} foo")) # basic
-    assert_equal("<p class='a b css'>foo</p>\n", render("%p.css{:class => %w[a b]} foo")) # merge with css
-    assert_equal("<p class='b css'>foo</p>\n", render("%p.css{:class => %w[css b]} foo")) # merge uniquely
+    assert_equal("<p class='css a b'>foo</p>\n", render("%p.css{:class => %w[a b]} foo")) # merge with css
+    assert_equal("<p class='css b'>foo</p>\n", render("%p.css{:class => %w[b css]} foo")) # merge uniquely
     assert_equal("<p class='a b c d'>foo</p>\n", render("%p{:class => [%w[a b], %w[c d]]} foo")) # flatten
     assert_equal("<p class='a b'>foo</p>\n", render("%p{:class => [:a, :b] } foo")) # stringify
     assert_equal("<p>foo</p>\n", render("%p{:class => [nil, false] } foo")) # strip falsey
     assert_equal("<p class='a'>foo</p>\n", render("%p{:class => :a} foo")) # single stringify
     assert_equal("<p>foo</p>\n", render("%p{:class => false} foo")) # single falsey
-    assert_equal("<p class='a b html'>foo</p>\n", render("%p(class='html'){:class => %w[a b]} foo")) # html attrs
+    assert_equal("<p class='html a b'>foo</p>\n", render("%p(class='html'){:class => %w[a b]} foo")) # html attrs
   end
 
   def test_id_attr_with_array
@@ -196,7 +196,7 @@ HAML
   def test_attributes_with_to_s
     assert_equal(<<HTML, render(<<HAML))
 <p id='foo_2'></p>
-<p class='2 foo'></p>
+<p class='foo 2'></p>
 <p blaz='2'></p>
 <p 2='2'></p>
 HTML
@@ -1149,7 +1149,7 @@ HAML
   def test_correct_parsing_with_brackets
     assert_equal("<p class='foo'>{tada} foo</p>\n", render("%p{:class => 'foo'} {tada} foo"))
     assert_equal("<p class='foo'>deep {nested { things }}</p>\n", render("%p{:class => 'foo'} deep {nested { things }}"))
-    assert_equal("<p class='bar foo'>{a { d</p>\n", render("%p{{:class => 'foo'}, :class => 'bar'} {a { d"))
+    assert_equal("<p class='foo bar'>{a { d</p>\n", render("%p{{:class => 'foo'}, :class => 'bar'} {a { d"))
     assert_equal("<p foo='bar'>a}</p>\n", render("%p{:foo => 'bar'} a}"))
 
     foo = []
@@ -1185,8 +1185,8 @@ HAML
   def test_nil_class_with_syntactic_class
     assert_equal("<p class='foo'>nil</p>\n", render("%p.foo{:class => nil} nil"))
     assert_equal("<p class='bar foo'>nil</p>\n", render("%p.bar.foo{:class => nil} nil"))
-    assert_equal("<p class='bar foo'>nil</p>\n", render("%p.foo{{:class => 'bar'}, :class => nil} nil"))
-    assert_equal("<p class='bar foo'>nil</p>\n", render("%p.foo{{:class => nil}, :class => 'bar'} nil"))
+    assert_equal("<p class='foo bar'>nil</p>\n", render("%p.foo{{:class => 'bar'}, :class => nil} nil"))
+    assert_equal("<p class='foo bar'>nil</p>\n", render("%p.foo{{:class => nil}, :class => 'bar'} nil"))
   end
 
   def test_locals
@@ -1665,15 +1665,15 @@ HAML
   end
 
   def test_new_attribute_classes
-    assert_equal("<div class='bar foo'></div>\n", render(".foo(class='bar')"))
-    assert_equal("<div class='bar baz foo'></div>\n", render(".foo{:class => 'bar'}(class='baz')"))
-    assert_equal("<div class='bar baz foo'></div>\n", render(".foo(class='baz'){:class => 'bar'}"))
+    assert_equal("<div class='foo bar'></div>\n", render(".foo(class='bar')"))
+    assert_equal("<div class='foo baz bar'></div>\n", render(".foo{:class => 'bar'}(class='baz')"))
+    assert_equal("<div class='foo bar baz'></div>\n", render(".foo(class='bar'){:class => 'baz'}"))
     foo = User.new(42)
-    assert_equal("<div class='bar baz foo struct_user' id='struct_user_42'></div>\n",
-      render(".foo(class='baz'){:class => 'bar'}[foo]", :locals => {:foo => foo}))
-    assert_equal("<div class='bar baz foo struct_user' id='struct_user_42'></div>\n",
+    assert_equal("<div class='foo bar baz struct_user' id='struct_user_42'></div>\n",
+      render(".foo(class='bar'){:class => 'baz'}[foo]", :locals => {:foo => foo}))
+    assert_equal("<div class='foo baz bar struct_user' id='struct_user_42'></div>\n",
       render(".foo[foo](class='baz'){:class => 'bar'}", :locals => {:foo => foo}))
-    assert_equal("<div class='bar baz foo struct_user' id='struct_user_42'></div>\n",
+    assert_equal("<div class='foo baz bar struct_user' id='struct_user_42'></div>\n",
       render(".foo[foo]{:class => 'bar'}(class='baz')", :locals => {:foo => foo}))
   end
 

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -283,11 +283,11 @@ HAML
   end
 
   def test_haml_tag_name_and_attribute_classes_merging_with_id
-    assert_equal("<p class='bar foo' id='some_id'></p>\n", render("- haml_tag 'p#some_id.foo', :class => 'bar'"))
+    assert_equal("<p class='foo bar' id='some_id'></p>\n", render("- haml_tag 'p#some_id.foo', :class => 'bar'"))
   end
 
   def test_haml_tag_name_and_attribute_classes_merging
-    assert_equal("<p class='bar foo'></p>\n", render("- haml_tag 'p.foo', :class => 'bar'"))
+    assert_equal("<p class='foo bar'></p>\n", render("- haml_tag 'p.foo', :class => 'bar'"))
   end
 
   def test_haml_tag_name_merges_id_and_attribute_id
@@ -308,7 +308,7 @@ HAML
 
   def test_haml_tag_with_class_array
     assert_equal("<p class='a b'>foo</p>\n", render("- haml_tag :p, 'foo', :class => %w[a b]"))
-    assert_equal("<p class='a b c d'>foo</p>\n", render("- haml_tag 'p.c.d', 'foo', :class => %w[a b]"))
+    assert_equal("<p class='c d a b'>foo</p>\n", render("- haml_tag 'p.c.d', 'foo', :class => %w[a b]"))
   end
 
   def test_haml_tag_with_id_array

--- a/test/results/helpful.xhtml
+++ b/test/results/helpful.xhtml
@@ -3,11 +3,11 @@
 <div>World</div>
 </div>
 <div class='article' id='id_article_1'>id</div>
-<div class='article class' id='article_1'>class</div>
-<div class='article class' id='id_article_1'>id class</div>
+<div class='class article' id='article_1'>class</div>
+<div class='class article' id='id_article_1'>id class</div>
 <div class='article full' id='article_1'>boo</div>
 <div class='article full' id='article_1'>moo</div>
-<div class='article articleFull' id='article_1'>foo</div>
+<div class='articleFull article' id='article_1'>foo</div>
 <span>
 Boo
 </span>

--- a/test/results/just_stuff.xhtml
+++ b/test/results/just_stuff.xhtml
@@ -55,10 +55,10 @@ testtest
 <br>
 Nested content
 </br>
-<p class='article bar foo' id='article_1'>Blah</p>
-<p class='article foo' id='article_1'>Blah</p>
-<p class='article bar baz foo' id='article_1'>Blah</p>
-<p class='article quux qux' id='article_1'>Blump</p>
+<p class='foo bar article' id='article_1'>Blah</p>
+<p class='foo article' id='article_1'>Blah</p>
+<p class='foo bar baz article' id='article_1'>Blah</p>
+<p class='qux quux article' id='article_1'>Blump</p>
 <p class='article' id='foo_bar_baz_article_1'>Whee</p>
 Woah inner quotes
 <p class='dynamic_quote' dyn='3' quotes='single &#39;'></p>


### PR DESCRIPTION
Since Ruby 1.8.7 is no longer supported, and therefore the Array `|`
method preserves the order of their elements, there should be no technical
need to sort class names of Haml tags.

In addition to likely boosting performance (one less array instantiated
per tag, though I did not run any benchmarks), this fixes weird
interactions that Haml has with libaries like Hamlbars.

Take, for instance:
  `%section.class-name{ class: "{{ maybe ? 'top' : 'bottom' }}" }`

When class names are sorted, the contents of the curly-braces
expression gets reordered so that it's no longer valid Handlebars.
By not sorting, the two sources of classes (`.class-name` and the
`class` attribute) get merged without disrupting the Handlebars.
