### PR TITLE
Fix compiler to work without deprecation on ruby 2.4

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -61,13 +61,13 @@ END
       "#{preamble}#{locals_code(local_names)}#{precompiled}#{postamble}"
     end
 
-    private
-
     # Returns the string used as the return value of the precompiled method.
     # This method exists so it can be monkeypatched to return modified values.
     def precompiled_method_return_value
       "_erbout"
     end
+
+    private
 
     def locals_code(names)
       names = names.keys if Hash === names


### PR DESCRIPTION
Forwardable in ruby 2.4 prints a deprecation warning if forwarding
to a private method (preview2 actually raises an exception).
Haml::Engine forwards precompiled_method_return_value to
Haml::Compiler, so the easiest way to fix this is to make
Haml::Compiler#precompiled_method_return_value public.