### PR TITLE
Introduce Temple generator and freeze string literals

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -14,7 +14,7 @@ module Haml
 
     def call(node)
       compile(node)
-      @precompiled
+      [:code, @precompiled]
     end
 
     def compile(node)

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -361,7 +361,7 @@ module Haml
       yield
       push_silent('end', :can_suppress) unless @node.value[:dont_push_end]
       format_script_method = "_hamlout.format_script(haml_temp,#{args.join(',')});"
-      @temple << [:code, "_hamlout.buffer << #{no_format ? "haml_temp.to_s;" : format_script_method}"]
+      @temple << [:dynamic, no_format ? "haml_temp.to_s;" : format_script_method]
       concat_merged_text("\n") unless opts[:in_tag] || opts[:nuke_inner_whitespace] || @options.ugly
     end
 

--- a/lib/haml/generator.rb
+++ b/lib/haml/generator.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Haml
   class Generator
     include Temple::Mixins::CompiledDispatcher
@@ -5,6 +6,10 @@ module Haml
 
     def call(exp)
       compile(exp)
+    end
+
+    def on_multi(*exp)
+      exp.map { |e| compile(e) }.join('; ')
     end
 
     def on_code(exp)

--- a/lib/haml/generator.rb
+++ b/lib/haml/generator.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 module Haml
+  # Ruby code generator, which is a limited version of Temple::Generator.
+  # Limit methods since Haml doesn't need most of them.
   class Generator
     include Temple::Mixins::CompiledDispatcher
     include Temple::Mixins::Options
+
+    define_options freeze_static: RUBY_VERSION >= '2.1'
 
     def call(exp)
       compile(exp)
@@ -12,8 +16,22 @@ module Haml
       exp.map { |e| compile(e) }.join('; ')
     end
 
+    def on_static(text)
+      concat(options[:freeze_static] ? "#{text.inspect}.freeze" : text.inspect)
+    end
+
+    def on_dynamic(code)
+      concat(code)
+    end
+
     def on_code(exp)
       exp
+    end
+
+    private
+
+    def concat(str)
+      "_hamlout.buffer << (#{str});"
     end
   end
 end

--- a/lib/haml/generator.rb
+++ b/lib/haml/generator.rb
@@ -1,0 +1,14 @@
+module Haml
+  class Generator
+    include Temple::Mixins::CompiledDispatcher
+    include Temple::Mixins::Options
+
+    def call(exp)
+      compile(exp)
+    end
+
+    def on_code(exp)
+      exp
+    end
+  end
+end

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -1,4 +1,5 @@
 require 'temple'
+require 'haml/generator'
 
 module Haml
   class TempleEngine < Temple::Engine
@@ -27,6 +28,7 @@ module Haml
 
     use :Parser,   -> { options[:parser_class] }
     use :Compiler, -> { options[:compiler_class] }
+    use Generator
 
     def compile(template)
       initialize_encoding(template, options[:encoding])

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -28,6 +28,7 @@ module Haml
 
     use :Parser,   -> { options[:parser_class] }
     use :Compiler, -> { options[:compiler_class] }
+    filter :StaticMerger
     use Generator
 
     def compile(template)


### PR DESCRIPTION
ref: https://github.com/haml/haml/issues/851

I inserted `Haml::Generator` like `Temple::Generator` into `Haml::TempleEngine`. It allows us to use Temple AST to generate compiled Ruby code.

Using that, I added `.freeze` for static string literals for Ruby 2.1+. Whille I'm going to add some changes, this is just a first step.

## Benchmark
With [hamlit/benchmark/etc/tags_loop.haml](https://github.com/k0kubun/hamlit/blob/9a0378ed8a09734655a5813a65378a9c157449b3/benchmark/etc/tags_loop.haml) and Ruby 2.4.0,

### before
```
$ bin/bench benchmark/etc/tags_loop.haml
=================================================
 Rendering: benchmark/etc/tags_loop.haml
=================================================
Calculating -------------------------------------
  haml v5.0.0.beta.2     3.538k i/100ms
         faml v0.8.1     4.801k i/100ms
       hamlit v2.7.5     4.834k i/100ms
-------------------------------------------------
  haml v5.0.0.beta.2     38.358k i/s (0.026ms) -    194.590k
         faml v0.8.1     52.347k i/s (0.019ms) -    259.254k
       hamlit v2.7.5     53.066k i/s (0.019ms) -    265.870k

Comparison:
       hamlit v2.7.5:    53066.3 i/s (0.019ms)
         faml v0.8.1:    52346.5 i/s (0.019ms) - 1.01x slower
  haml v5.0.0.beta.2:    38358.0 i/s (0.026ms) - 1.38x slower
```

### after
```
$ bin/bench benchmark/etc/tags_loop.haml
=================================================
 Rendering: benchmark/etc/tags_loop.haml
=================================================
Calculating -------------------------------------
  haml v5.0.0.beta.2     4.336k i/100ms
         faml v0.8.1     5.150k i/100ms
       hamlit v2.7.5     4.975k i/100ms
-------------------------------------------------
  haml v5.0.0.beta.2     43.109k i/s (0.023ms) -    216.800k
         faml v0.8.1     51.425k i/s (0.019ms) -    257.500k
       hamlit v2.7.5     52.881k i/s (0.019ms) -    263.675k

Comparison:
       hamlit v2.7.5:    52880.7 i/s (0.019ms)
         faml v0.8.1:    51425.4 i/s (0.019ms) - 1.03x slower
  haml v5.0.0.beta.2:    43109.0 i/s (0.023ms) - 1.23x slower
```

Haml's rendering became a little faster.