### PR TITLE
Add after_preamble hook for precompiled_with_ambles and separate Rails-related code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Add temple gem as dependency and create `Haml::TempleEngine` class.
   Some methods in `Haml::Compiler` are migrated to `Haml::TempleEngine`. (Takashi Kokubun)
 * Drop parser accessor from `Haml::Engine`. (Takashi Kokubun)
+* Don't ignore unexpected exceptions on initializing `ActionView::OutputBuffer`. (Takashi Kokubun)
 
 ## 4.0.7
 

--- a/lib/haml/template/plugin.rb
+++ b/lib/haml/template/plugin.rb
@@ -14,7 +14,7 @@ module Haml
       options[:filename] = template.identifier
       Haml::Engine.new(template.source, options).compiler.precompiled_with_ambles(
         [],
-        after_preamble: '@output_buffer = output_buffer ||= ActionView::OutputBuffer.new rescue nil',
+        after_preamble: '@output_buffer = output_buffer ||= ActionView::OutputBuffer.new if defined?(ActionView::OutputBuffer)',
       )
     end
 

--- a/lib/haml/template/plugin.rb
+++ b/lib/haml/template/plugin.rb
@@ -12,7 +12,10 @@ module Haml
         options[:mime_type] = template.mime_type
       end
       options[:filename] = template.identifier
-      Haml::Engine.new(template.source, options).compiler.precompiled_with_ambles([])
+      Haml::Engine.new(template.source, options).compiler.precompiled_with_ambles(
+        [],
+        after_preamble: '@output_buffer = output_buffer ||= ActionView::OutputBuffer.new rescue nil',
+      )
     end
 
     def self.call(template)

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -58,13 +58,12 @@ module Haml
     # (see {file:REFERENCE.md#encodings the `:encoding` option}).
     #
     # @return [String]
-    def precompiled_with_ambles(local_names)
-      preamble = <<END.tr!("\n", ';')
+    def precompiled_with_ambles(local_names, after_preamble: '')
+      preamble = "#{<<END};#{after_preamble};".tr!("\n", ';')
 begin
 extend Haml::Helpers
 _hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, #{Options.new(options).for_buffer.inspect})
 _erbout = _hamlout.buffer
-@output_buffer = output_buffer ||= ActionView::OutputBuffer.new rescue nil
 END
       postamble = <<END.tr!("\n", ';')
 #{precompiled_method_return_value}

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -59,11 +59,12 @@ module Haml
     #
     # @return [String]
     def precompiled_with_ambles(local_names, after_preamble: '')
-      preamble = "#{<<END};#{after_preamble};".tr!("\n", ';')
+      preamble = <<END.tr!("\n", ';')
 begin
 extend Haml::Helpers
 _hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, #{Options.new(options).for_buffer.inspect})
 _erbout = _hamlout.buffer
+#{after_preamble}
 END
       postamble = <<END.tr!("\n", ';')
 #{precompiled_method_return_value}


### PR DESCRIPTION
## Changes
- I added `after_preamble` option to have `ActionView::OutputBuffer.new rescue nil` and changed `Haml::Plugin` to use the option.
  - `ActionView::OutputBuffer.new rescue nil` has unnecessary overhead for the case `ActionView::OutputBuffer` is not defined. 
  - It may improve Tilt's maintainability by using `after_preamble` to insert [this part](https://github.com/rtomayko/tilt/blob/v2.0.6/lib/tilt/haml.rb#L40-L41).
- I also changed `rescue nil` to `if defined?(ActionView::OutputBuffer)` to avoid ignoring unexpected exceptions.

## Benchmark
For non-Rails environment, with Ruby 2.4.0 and [hamlit/benchmark/slim/view.haml](https://github.com/k0kubun/hamlit/blob/9a0378ed8a09734655a5813a65378a9c157449b3/benchmark/slim/view.haml),

### before
```
$ ONLY_HAML=1 be ruby benchmark/slim/run-benchmarks.rb
Calculating -------------------------------------
  haml v5.0.0.beta.2     4.198k i/100ms
         faml v0.8.1    19.575k i/100ms
       hamlit v2.7.5    23.553k i/100ms
-------------------------------------------------
  haml v5.0.0.beta.2     43.044k (± 2.2%) i/s -    218.296k
         faml v0.8.1    219.086k (± 1.9%) i/s -      1.096M
       hamlit v2.7.5    262.325k (± 2.2%) i/s -      1.319M

Comparison:
       hamlit v2.7.5:   262325.1 i/s
         faml v0.8.1:   219085.8 i/s - 1.20x slower
  haml v5.0.0.beta.2:    43044.4 i/s - 6.09x slower
```

### after
```h
$ ONLY_HAML=1 be ruby benchmark/slim/run-benchmarks.rb
Calculating -------------------------------------
  haml v5.0.0.beta.2     4.649k i/100ms
         faml v0.8.1    19.280k i/100ms
       hamlit v2.7.5    21.310k i/100ms
-------------------------------------------------
  haml v5.0.0.beta.2     47.519k (± 4.1%) i/s -    241.748k
         faml v0.8.1    203.113k (± 6.9%) i/s -      1.022M
       hamlit v2.7.5    250.933k (± 6.7%) i/s -      1.257M

Comparison:
       hamlit v2.7.5:   250932.7 i/s
         faml v0.8.1:   203112.8 i/s - 1.24x slower
  haml v5.0.0.beta.2:    47519.2 i/s - 5.28x slower
```