### PR TITLE
Use Rails default options for Haml's default options

### DIFF
--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -94,7 +94,7 @@ module Haml
     def initialize(upper = nil, options = {})
       @active     = true
       @upper      = upper
-      @options    = options
+      @options    = Options.buffer_defaults.merge(options)
       @buffer     = new_encoded_string
       @tabulation = 0
 

--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -94,7 +94,8 @@ module Haml
     def initialize(upper = nil, options = {})
       @active     = true
       @upper      = upper
-      @options    = Options.buffer_defaults.merge(options)
+      @options    = Options.buffer_defaults
+      @options    = @options.merge(options) unless options.empty?
       @buffer     = new_encoded_string
       @tabulation = 0
 

--- a/lib/haml/options.rb
+++ b/lib/haml/options.rb
@@ -28,7 +28,8 @@ module Haml
       @buffer_option_keys
     end
 
-    # @return Hash
+    # Returns a subset of defaults: those that {Haml::Buffer} cares about.
+    # @return [{Symbol => Object}] The options hash
     def self.buffer_defaults
       @buffer_defaults ||= buffer_option_keys.inject({}) do |hash, key|
         hash.merge(key => defaults[key])
@@ -251,7 +252,7 @@ module Haml
       @encoding = "UTF-8" if @encoding.upcase == "US-ASCII"
     end
 
-    # Returns a subset of options: those that {Haml::Buffer} cares about.
+    # Returns a non-default subset of options: those that {Haml::Buffer} cares about.
     # All of the values here are such that when `#inspect` is called on the hash,
     # it can be `Kernel#eval`ed to get the same result back.
     #
@@ -260,7 +261,10 @@ module Haml
     # @return [{Symbol => Object}] The options hash
     def for_buffer
       self.class.buffer_option_keys.inject({}) do |hash, key|
-        hash[key] = send(key)
+        value = public_send(key)
+        if self.class.buffer_defaults[key] != value
+          hash[key] = value
+        end
         hash
       end
     end

--- a/lib/haml/options.rb
+++ b/lib/haml/options.rb
@@ -28,6 +28,13 @@ module Haml
       @buffer_option_keys
     end
 
+    # @return Hash
+    def self.buffer_defaults
+      @buffer_defaults ||= buffer_option_keys.inject({}) do |hash, key|
+        hash.merge(key => defaults[key])
+      end
+    end
+
     def self.wrap(options)
       if options.is_a?(Options)
         options

--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -27,6 +27,8 @@ module Haml
       if defined?(::Sass::Rails::SassTemplate) && app.config.assets.enabled
         require "haml/sass_rails_filter"
       end
+      Haml::Options.buffer_defaults[:escape_html] = true
+      Haml::Options.buffer_defaults[:ugly] = true
     end
   end
 end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+module Haml
+  class OptionsTest < Haml::TestCase
+    def test_buffer_defaults_have_only_buffer_option_keys
+      assert_equal(
+        Haml::Options.buffer_option_keys.sort,
+        Haml::Options.buffer_defaults.keys.sort,
+      )
+    end
+
+    def test_buffer_defaults_values_are_default_options
+      Haml::Options.buffer_option_keys.each do |key|
+        assert_equal(
+          Haml::Options.defaults[key],
+          Haml::Options.buffer_defaults[key],
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Changes
- To reduce object allocations on runtime, I added `Haml::Options.buffer_defaults` to use in `Haml::Buffer#initialize`.
- To avoid allocating new Hash, I changed `Haml::Buffer#initialize` not to call `Hash#merge` if no options are given.
- ~~Use `escape_html: true, ugly: true` as Haml's default options. This change gives significant performance gain for all Rails applications.~~
  - ~~related to: https://github.com/haml/haml/issues/894~~
  - ~~**This is breaking change.** I think we should ship this change in Haml 6.~~

## Details
Preamble code will be changed like:

```diff
-begin;extend Haml::Helpers;_hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, {:autoclose=>["area", "base", "basefont", "br", "col", "command", "embed", "frame", "hr", "img", "input", "isindex", "keygen", "link", "menuitem", "meta", "param", "source", "track", "wbr"], :preserve=>["textarea", "pre", "code"], :attr_wrapper=>"'", :ugly=>true, :format=>:html5, :encoding=>"UTF-8", :escape_html=>true, :escape_attrs=>true, :hyphenate_data_attrs=>true, :cdata=>false});_erbout = _hamlout.buffer;;_hamlout.buffer << ("<!DOCTYPE html>\n<html>\n<head>\n<title>Simple Benchmark</title>\n</head>\n<body>\n<h1>".freeze);; _hamlout.buffer << (
+begin;extend Haml::Helpers;_hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, {});_erbout = _hamlout.buffer;;_hamlout.buffer << ("<!DOCTYPE html>\n<html>\n<head>\n<title>Simple Benchmark</title>\n</head>\n<body>\n<h1>".freeze);; _hamlout.buffer << (

```


## Benchmark
With Ruby 2.4.0 and [k0kubun/haml_bench/templates/view.haml](https://github.com/k0kubun/haml_bench/blob/4a435313c94fe8f5131a870db2d145a290fdccb3/templates/view.haml),
### before
```
$ bundle exec ruby bench.rb
Calculating -------------------------------------
          haml 4.0.7     3.606k i/100ms
   haml 5.0.0.beta.2     3.969k i/100ms
-------------------------------------------------
          haml 4.0.7     36.977k (± 2.7%) i/s -    187.512k
   haml 5.0.0.beta.2     40.408k (± 2.2%) i/s -    202.419k

Comparison:
   haml 5.0.0.beta.2:    40408.4 i/s
          haml 4.0.7:    36977.4 i/s - 1.09x slower
```

### after
```
$ bundle exec ruby bench.rb
Calculating -------------------------------------
          haml 4.0.7     3.602k i/100ms
   haml 5.0.0.beta.2     4.764k i/100ms
-------------------------------------------------
          haml 4.0.7     36.435k (± 2.7%) i/s -    183.702k
   haml 5.0.0.beta.2     49.756k (± 2.5%) i/s -    252.492k

Comparison:
   haml 5.0.0.beta.2:    49756.4 i/s
          haml 4.0.7:    36435.3 i/s - 1.37x slower
```