### PR TITLE
Simplify HTML escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@
 * The `haml` command's debug option (`-d`) no longer executes the Haml code, but
   rather checks the generated Ruby syntax for errors.
 * Support Rails 5.1 Erubi template handler.
+* Drop dynamic quotes support and always escape `'` for `escape_html`/`escape_attrs` instead.
+  Also, escaped results are slightly changed and always unified to the same characters. (Takashi Kokubun)
 * Add temple gem as dependency and create `Haml::TempleEngine` class.
   Some methods in `Haml::Compiler` are migrated to `Haml::TempleEngine`. (Takashi Kokubun)
 * Drop parser/compiler accessor from `Haml::Engine`. Modify `Haml::Engine#initialize` options

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -5,8 +5,6 @@ module Haml
       def build_attributes(is_html, attr_wrapper, escape_attrs, hyphenate_data_attrs, attributes = {})
           # @TODO this is an absolutely ridiculous amount of arguments. At least
         # some of this needs to be moved into an instance method.
-        quote_escape     = attr_wrapper == '"' ? "&#x0022;" : "&#x0027;"
-        other_quote_char = attr_wrapper == '"' ? "'" : '"'
         join_char        = hyphenate_data_attrs ? '-' : '_'
 
         attributes.each do |key, value|
@@ -40,21 +38,7 @@ module Haml
               value.to_s
             end
           value = Haml::Helpers.preserve(escaped)
-          if escape_attrs
-            # We want to decide whether or not to escape quotes
-            value.gsub!(/&quot;|&#x0022;/, '"')
-            this_attr_wrapper = attr_wrapper
-            if value.include? attr_wrapper
-              if value.include? other_quote_char
-                value.gsub!(attr_wrapper, quote_escape)
-              else
-                this_attr_wrapper = other_quote_char
-              end
-            end
-          else
-            this_attr_wrapper = attr_wrapper
-          end
-          " #{attr}=#{this_attr_wrapper}#{value}#{this_attr_wrapper}"
+          " #{attr}=#{attr_wrapper}#{value}#{attr_wrapper}"
         end
         result.compact!
         result.sort!

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -596,7 +596,7 @@ MESSAGE
     # Characters that need to be escaped to HTML entities from user input
     HTML_ESCAPE = { '&' => '&amp;', '<' => '&lt;', '>' => '&gt;', '"' => '&quot;', "'" => '&#039;' }
 
-    HTML_ESCAPE_REGEX = /[\"><&]/
+    HTML_ESCAPE_REGEX = /['"><&]/
 
     # Returns a copy of `text` with ampersands, angle brackets and quotes
     # escaped into HTML entities.

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -612,7 +612,7 @@ MESSAGE
       text.gsub(HTML_ESCAPE_REGEX, HTML_ESCAPE)
     end
 
-    HTML_ESCAPE_ONCE_REGEX = /[\"><]|&(?!(?:[a-zA-Z]+|#(?:\d+|[xX][0-9a-fA-F]+));)/
+    HTML_ESCAPE_ONCE_REGEX = /['"><]|&(?!(?:[a-zA-Z]+|#(?:\d+|[xX][0-9a-fA-F]+));)/
 
     # Escapes HTML entities in `text`, but without escaping an ampersand
     # that is already part of an escaped entity.

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -594,7 +594,7 @@ MESSAGE
     end
 
     # Characters that need to be escaped to HTML entities from user input
-    HTML_ESCAPE = { '&' => '&amp;', '<' => '&lt;', '>' => '&gt;', '"' => '&quot;', "'" => '&#039;' }
+    HTML_ESCAPE = { '&' => '&amp;', '<' => '&lt;', '>' => '&gt;', '"' => '&quot;', "'" => '&#39;' }
 
     HTML_ESCAPE_REGEX = /['"><&]/
 

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -1,3 +1,5 @@
+require 'erb'
+
 module Haml
   # This module contains various helpful methods to make it easier to do various tasks.
   # {Haml::Helpers} is automatically included in the context
@@ -608,8 +610,7 @@ MESSAGE
     # @param text [String] The string to sanitize
     # @return [String] The sanitized string
     def html_escape(text)
-      text = text.to_s
-      text.gsub(HTML_ESCAPE_REGEX, HTML_ESCAPE)
+      ERB::Util.html_escape(text)
     end
 
     HTML_ESCAPE_ONCE_REGEX = /['"><]|&(?!(?:[a-zA-Z]+|#(?:\d+|[xX][0-9a-fA-F]+));)/

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1127,8 +1127,8 @@ HAML
   def test_attr_wrapper
     assert_equal("<p strange=*attrs*></p>\n", render("%p{ :strange => 'attrs'}", :attr_wrapper => '*'))
     assert_equal("<p escaped='quo\"te'></p>\n", render("%p{ :escaped => 'quo\"te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped=\"quo'te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped=\"q'uo&#x0022;te\"></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"quo&#039;te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped='q&#039;uo\"te'></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
     assert_equal("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n", render("!!! XML", :attr_wrapper => '"', :format => :xhtml))
   end
 
@@ -1534,7 +1534,7 @@ HAML
       render("%div{:data => {:one_plus_one => 1+1}}",
         :hyphenate_data_attrs => false))
 
-    assert_equal("<div data-foo='Here&#x0027;s a \"quoteful\" string.'></div>\n",
+    assert_equal("<div data-foo='Here&#039;s a \"quoteful\" string.'></div>\n",
       render(%{%div{:data => {:foo => %{Here's a "quoteful" string.}}}},
         :hyphenate_data_attrs => false)) #'
   end
@@ -1698,9 +1698,9 @@ HAML
   def test_new_attribute_parsing
     assert_equal("<a a2='b2'>bar</a>\n", render("%a(a2=b2) bar", :locals => {:b2 => 'b2'}))
     assert_equal(%Q{<a a='foo"bar'>bar</a>\n}, render(%q{%a(a="#{'foo"bar'}") bar})) #'
-    assert_equal(%Q{<a a="foo'bar">bar</a>\n}, render(%q{%a(a="#{"foo'bar"}") bar})) #'
+    assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="#{"foo'bar"}") bar})) #'
     assert_equal(%Q{<a a='foo"bar'>bar</a>\n}, render(%q{%a(a='foo"bar') bar}))
-    assert_equal(%Q{<a a="foo'bar">bar</a>\n}, render(%q{%a(a="foo'bar") bar}))
+    assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="foo'bar") bar}))
     assert_equal("<a a:b='foo'>bar</a>\n", render("%a(a:b='foo') bar"))
     assert_equal("<a a='foo' b='bar'>bar</a>\n", render("%a(a = 'foo' b = 'bar') bar"))
     assert_equal("<a a='foo' b='bar'>bar</a>\n", render("%a(a = foo b = bar) bar", :locals => {:foo => 'foo', :bar => 'bar'}))
@@ -1713,8 +1713,8 @@ HAML
     assert_equal(%Q{<a a='foo " bar'>bar</a>\n}, render(%q{%a(a="foo \" bar") bar}))
     assert_equal(%Q{<a a='foo \\" bar'>bar</a>\n}, render(%q{%a(a="foo \\\\\" bar") bar}))
 
-    assert_equal(%Q{<a a="foo ' bar">bar</a>\n}, render(%q{%a(a='foo \' bar') bar}))
-    assert_equal(%Q{<a a="foo \\' bar">bar</a>\n}, render(%q{%a(a='foo \\\\\' bar') bar}))
+    assert_equal(%Q{<a a='foo &#039; bar'>bar</a>\n}, render(%q{%a(a='foo \' bar') bar}))
+    assert_equal(%Q{<a a='foo \\&#039; bar'>bar</a>\n}, render(%q{%a(a='foo \\\\\' bar') bar}))
 
     assert_equal(%Q{<a a='foo \\ bar'>bar</a>\n}, render(%q{%a(a="foo \\\\ bar") bar}))
     assert_equal(%Q{<a a='foo \#{1 + 1} bar'>bar</a>\n}, render(%q{%a(a="foo \#{1 + 1} bar") bar}))

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -694,7 +694,7 @@ HAML
 
   def test_escape_attrs_always
     assert_equal(<<HTML, render(<<HAML, :escape_attrs => :always))
-<div class='"&amp;lt;&amp;gt;&amp;amp;"' id='foo'>
+<div class='&quot;&amp;lt;&amp;gt;&amp;amp;&quot;' id='foo'>
 bar
 </div>
 HTML
@@ -815,7 +815,7 @@ HAML
     assert_equal("<a href='#'>Foo</a>\n",
       render('%a(href="#") #{"Foo"}'))
 
-    assert_equal("<a href='#\"'></a>\n", render('%a(href="#\\"")'))
+    assert_equal("<a href='#&quot;'></a>\n", render('%a(href="#\\"")'))
   end
 
   def test_case_assigned_to_var
@@ -1126,9 +1126,9 @@ HAML
 
   def test_attr_wrapper
     assert_equal("<p strange=*attrs*></p>\n", render("%p{ :strange => 'attrs'}", :attr_wrapper => '*'))
-    assert_equal("<p escaped='quo\"te'></p>\n", render("%p{ :escaped => 'quo\"te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"quo&quot;te\"></p>\n", render("%p{ :escaped => 'quo\"te'}", :attr_wrapper => '"'))
     assert_equal("<p escaped=\"quo&#039;te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped='q&#039;uo\"te'></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"q&#039;uo&quot;te\"></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
     assert_equal("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n", render("!!! XML", :attr_wrapper => '"', :format => :xhtml))
   end
 
@@ -1534,7 +1534,7 @@ HAML
       render("%div{:data => {:one_plus_one => 1+1}}",
         :hyphenate_data_attrs => false))
 
-    assert_equal("<div data-foo='Here&#039;s a \"quoteful\" string.'></div>\n",
+    assert_equal("<div data-foo='Here&#039;s a &quot;quoteful&quot; string.'></div>\n",
       render(%{%div{:data => {:foo => %{Here's a "quoteful" string.}}}},
         :hyphenate_data_attrs => false)) #'
   end
@@ -1697,9 +1697,9 @@ HAML
 
   def test_new_attribute_parsing
     assert_equal("<a a2='b2'>bar</a>\n", render("%a(a2=b2) bar", :locals => {:b2 => 'b2'}))
-    assert_equal(%Q{<a a='foo"bar'>bar</a>\n}, render(%q{%a(a="#{'foo"bar'}") bar})) #'
+    assert_equal(%Q{<a a='foo&quot;bar'>bar</a>\n}, render(%q{%a(a="#{'foo"bar'}") bar})) #'
     assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="#{"foo'bar"}") bar})) #'
-    assert_equal(%Q{<a a='foo"bar'>bar</a>\n}, render(%q{%a(a='foo"bar') bar}))
+    assert_equal(%Q{<a a='foo&quot;bar'>bar</a>\n}, render(%q{%a(a='foo"bar') bar}))
     assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="foo'bar") bar}))
     assert_equal("<a a:b='foo'>bar</a>\n", render("%a(a:b='foo') bar"))
     assert_equal("<a a='foo' b='bar'>bar</a>\n", render("%a(a = 'foo' b = 'bar') bar"))
@@ -1710,8 +1710,8 @@ HAML
   end
 
   def test_new_attribute_escaping
-    assert_equal(%Q{<a a='foo " bar'>bar</a>\n}, render(%q{%a(a="foo \" bar") bar}))
-    assert_equal(%Q{<a a='foo \\" bar'>bar</a>\n}, render(%q{%a(a="foo \\\\\" bar") bar}))
+    assert_equal(%Q{<a a='foo &quot; bar'>bar</a>\n}, render(%q{%a(a="foo \" bar") bar}))
+    assert_equal(%Q{<a a='foo \\&quot; bar'>bar</a>\n}, render(%q{%a(a="foo \\\\\" bar") bar}))
 
     assert_equal(%Q{<a a='foo &#039; bar'>bar</a>\n}, render(%q{%a(a='foo \' bar') bar}))
     assert_equal(%Q{<a a='foo \\&#039; bar'>bar</a>\n}, render(%q{%a(a='foo \\\\\' bar') bar}))

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -693,7 +693,7 @@ HAML
   end
 
   def test_escape_attrs_always
-    assert_equal(<<HTML, render(<<HAML, :escape_attrs => :always))
+    assert_equal(<<HTML, render(<<HAML, :escape_attrs => true))
 <div class='&quot;&amp;lt;&amp;gt;&amp;amp;&quot;' id='foo'>
 bar
 </div>

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1127,8 +1127,8 @@ HAML
   def test_attr_wrapper
     assert_equal("<p strange=*attrs*></p>\n", render("%p{ :strange => 'attrs'}", :attr_wrapper => '*'))
     assert_equal("<p escaped=\"quo&quot;te\"></p>\n", render("%p{ :escaped => 'quo\"te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped=\"quo&#039;te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped=\"q&#039;uo&quot;te\"></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"quo&#39;te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"q&#39;uo&quot;te\"></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
     assert_equal("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n", render("!!! XML", :attr_wrapper => '"', :format => :xhtml))
   end
 
@@ -1534,7 +1534,7 @@ HAML
       render("%div{:data => {:one_plus_one => 1+1}}",
         :hyphenate_data_attrs => false))
 
-    assert_equal("<div data-foo='Here&#039;s a &quot;quoteful&quot; string.'></div>\n",
+    assert_equal("<div data-foo='Here&#39;s a &quot;quoteful&quot; string.'></div>\n",
       render(%{%div{:data => {:foo => %{Here's a "quoteful" string.}}}},
         :hyphenate_data_attrs => false)) #'
   end
@@ -1698,9 +1698,9 @@ HAML
   def test_new_attribute_parsing
     assert_equal("<a a2='b2'>bar</a>\n", render("%a(a2=b2) bar", :locals => {:b2 => 'b2'}))
     assert_equal(%Q{<a a='foo&quot;bar'>bar</a>\n}, render(%q{%a(a="#{'foo"bar'}") bar})) #'
-    assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="#{"foo'bar"}") bar})) #'
+    assert_equal(%Q{<a a='foo&#39;bar'>bar</a>\n}, render(%q{%a(a="#{"foo'bar"}") bar})) #'
     assert_equal(%Q{<a a='foo&quot;bar'>bar</a>\n}, render(%q{%a(a='foo"bar') bar}))
-    assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="foo'bar") bar}))
+    assert_equal(%Q{<a a='foo&#39;bar'>bar</a>\n}, render(%q{%a(a="foo'bar") bar}))
     assert_equal("<a a:b='foo'>bar</a>\n", render("%a(a:b='foo') bar"))
     assert_equal("<a a='foo' b='bar'>bar</a>\n", render("%a(a = 'foo' b = 'bar') bar"))
     assert_equal("<a a='foo' b='bar'>bar</a>\n", render("%a(a = foo b = bar) bar", :locals => {:foo => 'foo', :bar => 'bar'}))
@@ -1713,8 +1713,8 @@ HAML
     assert_equal(%Q{<a a='foo &quot; bar'>bar</a>\n}, render(%q{%a(a="foo \" bar") bar}))
     assert_equal(%Q{<a a='foo \\&quot; bar'>bar</a>\n}, render(%q{%a(a="foo \\\\\" bar") bar}))
 
-    assert_equal(%Q{<a a='foo &#039; bar'>bar</a>\n}, render(%q{%a(a='foo \' bar') bar}))
-    assert_equal(%Q{<a a='foo \\&#039; bar'>bar</a>\n}, render(%q{%a(a='foo \\\\\' bar') bar}))
+    assert_equal(%Q{<a a='foo &#39; bar'>bar</a>\n}, render(%q{%a(a='foo \' bar') bar}))
+    assert_equal(%Q{<a a='foo \\&#39; bar'>bar</a>\n}, render(%q{%a(a='foo \\\\\' bar') bar}))
 
     assert_equal(%Q{<a a='foo \\ bar'>bar</a>\n}, render(%q{%a(a="foo \\\\ bar") bar}))
     assert_equal(%Q{<a a='foo \#{1 + 1} bar'>bar</a>\n}, render(%q{%a(a="foo \#{1 + 1} bar") bar}))

--- a/test/pretty_engine_test.rb
+++ b/test/pretty_engine_test.rb
@@ -696,7 +696,7 @@ HAML
 
   def test_escape_attrs_always
     assert_equal(<<HTML, render(<<HAML, :escape_attrs => :always))
-<div class='"&amp;lt;&amp;gt;&amp;amp;"' id='foo'>
+<div class='&quot;&amp;lt;&amp;gt;&amp;amp;&quot;' id='foo'>
   bar
 </div>
 HTML
@@ -817,7 +817,7 @@ HAML
     assert_equal("<a href='#'>Foo</a>\n",
       render('%a(href="#") #{"Foo"}'))
 
-    assert_equal("<a href='#\"'></a>\n", render('%a(href="#\\"")'))
+    assert_equal("<a href='#&quot;'></a>\n", render('%a(href="#\\"")'))
   end
 
   def test_case_assigned_to_var
@@ -1128,9 +1128,9 @@ HAML
 
   def test_attr_wrapper
     assert_equal("<p strange=*attrs*></p>\n", render("%p{ :strange => 'attrs'}", :attr_wrapper => '*'))
-    assert_equal("<p escaped='quo\"te'></p>\n", render("%p{ :escaped => 'quo\"te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"quo&quot;te\"></p>\n", render("%p{ :escaped => 'quo\"te'}", :attr_wrapper => '"'))
     assert_equal("<p escaped=\"quo&#039;te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped='q&#039;uo\"te'></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"q&#039;uo&quot;te\"></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
     assert_equal("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n", render("!!! XML", :attr_wrapper => '"', :format => :xhtml))
   end
 
@@ -1527,7 +1527,7 @@ HAML
       render("%div{:data => {:one_plus_one => 1+1}}",
         :hyphenate_data_attrs => false))
 
-    assert_equal("<div data-foo='Here&#039;s a \"quoteful\" string.'></div>\n",
+    assert_equal("<div data-foo='Here&#039;s a &quot;quoteful&quot; string.'></div>\n",
       render(%{%div{:data => {:foo => %{Here's a "quoteful" string.}}}},
         :hyphenate_data_attrs => false)) #'
   end
@@ -1690,9 +1690,9 @@ HAML
 
   def test_new_attribute_parsing
     assert_equal("<a a2='b2'>bar</a>\n", render("%a(a2=b2) bar", :locals => {:b2 => 'b2'}))
-    assert_equal(%Q{<a a='foo"bar'>bar</a>\n}, render(%q{%a(a="#{'foo"bar'}") bar})) #'
+    assert_equal(%Q{<a a='foo&quot;bar'>bar</a>\n}, render(%q{%a(a="#{'foo"bar'}") bar})) #'
     assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="#{"foo'bar"}") bar})) #'
-    assert_equal(%Q{<a a='foo"bar'>bar</a>\n}, render(%q{%a(a='foo"bar') bar}))
+    assert_equal(%Q{<a a='foo&quot;bar'>bar</a>\n}, render(%q{%a(a='foo"bar') bar}))
     assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="foo'bar") bar}))
     assert_equal("<a a:b='foo'>bar</a>\n", render("%a(a:b='foo') bar"))
     assert_equal("<a a='foo' b='bar'>bar</a>\n", render("%a(a = 'foo' b = 'bar') bar"))
@@ -1703,8 +1703,8 @@ HAML
   end
 
   def test_new_attribute_escaping
-    assert_equal(%Q{<a a='foo " bar'>bar</a>\n}, render(%q{%a(a="foo \" bar") bar}))
-    assert_equal(%Q{<a a='foo \\" bar'>bar</a>\n}, render(%q{%a(a="foo \\\\\" bar") bar}))
+    assert_equal(%Q{<a a='foo &quot; bar'>bar</a>\n}, render(%q{%a(a="foo \" bar") bar}))
+    assert_equal(%Q{<a a='foo \\&quot; bar'>bar</a>\n}, render(%q{%a(a="foo \\\\\" bar") bar}))
 
     assert_equal(%Q{<a a='foo &#039; bar'>bar</a>\n}, render(%q{%a(a='foo \' bar') bar}))
     assert_equal(%Q{<a a='foo \\&#039; bar'>bar</a>\n}, render(%q{%a(a='foo \\\\\' bar') bar}))

--- a/test/pretty_engine_test.rb
+++ b/test/pretty_engine_test.rb
@@ -1129,8 +1129,8 @@ HAML
   def test_attr_wrapper
     assert_equal("<p strange=*attrs*></p>\n", render("%p{ :strange => 'attrs'}", :attr_wrapper => '*'))
     assert_equal("<p escaped=\"quo&quot;te\"></p>\n", render("%p{ :escaped => 'quo\"te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped=\"quo&#039;te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped=\"q&#039;uo&quot;te\"></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"quo&#39;te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"q&#39;uo&quot;te\"></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
     assert_equal("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n", render("!!! XML", :attr_wrapper => '"', :format => :xhtml))
   end
 
@@ -1527,7 +1527,7 @@ HAML
       render("%div{:data => {:one_plus_one => 1+1}}",
         :hyphenate_data_attrs => false))
 
-    assert_equal("<div data-foo='Here&#039;s a &quot;quoteful&quot; string.'></div>\n",
+    assert_equal("<div data-foo='Here&#39;s a &quot;quoteful&quot; string.'></div>\n",
       render(%{%div{:data => {:foo => %{Here's a "quoteful" string.}}}},
         :hyphenate_data_attrs => false)) #'
   end
@@ -1691,9 +1691,9 @@ HAML
   def test_new_attribute_parsing
     assert_equal("<a a2='b2'>bar</a>\n", render("%a(a2=b2) bar", :locals => {:b2 => 'b2'}))
     assert_equal(%Q{<a a='foo&quot;bar'>bar</a>\n}, render(%q{%a(a="#{'foo"bar'}") bar})) #'
-    assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="#{"foo'bar"}") bar})) #'
+    assert_equal(%Q{<a a='foo&#39;bar'>bar</a>\n}, render(%q{%a(a="#{"foo'bar"}") bar})) #'
     assert_equal(%Q{<a a='foo&quot;bar'>bar</a>\n}, render(%q{%a(a='foo"bar') bar}))
-    assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="foo'bar") bar}))
+    assert_equal(%Q{<a a='foo&#39;bar'>bar</a>\n}, render(%q{%a(a="foo'bar") bar}))
     assert_equal("<a a:b='foo'>bar</a>\n", render("%a(a:b='foo') bar"))
     assert_equal("<a a='foo' b='bar'>bar</a>\n", render("%a(a = 'foo' b = 'bar') bar"))
     assert_equal("<a a='foo' b='bar'>bar</a>\n", render("%a(a = foo b = bar) bar", :locals => {:foo => 'foo', :bar => 'bar'}))
@@ -1706,8 +1706,8 @@ HAML
     assert_equal(%Q{<a a='foo &quot; bar'>bar</a>\n}, render(%q{%a(a="foo \" bar") bar}))
     assert_equal(%Q{<a a='foo \\&quot; bar'>bar</a>\n}, render(%q{%a(a="foo \\\\\" bar") bar}))
 
-    assert_equal(%Q{<a a='foo &#039; bar'>bar</a>\n}, render(%q{%a(a='foo \' bar') bar}))
-    assert_equal(%Q{<a a='foo \\&#039; bar'>bar</a>\n}, render(%q{%a(a='foo \\\\\' bar') bar}))
+    assert_equal(%Q{<a a='foo &#39; bar'>bar</a>\n}, render(%q{%a(a='foo \' bar') bar}))
+    assert_equal(%Q{<a a='foo \\&#39; bar'>bar</a>\n}, render(%q{%a(a='foo \\\\\' bar') bar}))
 
     assert_equal(%Q{<a a='foo \\ bar'>bar</a>\n}, render(%q{%a(a="foo \\\\ bar") bar}))
     assert_equal(%Q{<a a='foo \#{1 + 1} bar'>bar</a>\n}, render(%q{%a(a="foo \#{1 + 1} bar") bar}))

--- a/test/pretty_engine_test.rb
+++ b/test/pretty_engine_test.rb
@@ -695,7 +695,7 @@ HAML
   end
 
   def test_escape_attrs_always
-    assert_equal(<<HTML, render(<<HAML, :escape_attrs => :always))
+    assert_equal(<<HTML, render(<<HAML, :escape_attrs => true))
 <div class='&quot;&amp;lt;&amp;gt;&amp;amp;&quot;' id='foo'>
   bar
 </div>

--- a/test/pretty_engine_test.rb
+++ b/test/pretty_engine_test.rb
@@ -1129,8 +1129,8 @@ HAML
   def test_attr_wrapper
     assert_equal("<p strange=*attrs*></p>\n", render("%p{ :strange => 'attrs'}", :attr_wrapper => '*'))
     assert_equal("<p escaped='quo\"te'></p>\n", render("%p{ :escaped => 'quo\"te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped=\"quo'te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
-    assert_equal("<p escaped=\"q'uo&#x0022;te\"></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped=\"quo&#039;te\"></p>\n", render("%p{ :escaped => 'quo\\'te'}", :attr_wrapper => '"'))
+    assert_equal("<p escaped='q&#039;uo\"te'></p>\n", render("%p{ :escaped => 'q\\'uo\"te'}", :attr_wrapper => '"'))
     assert_equal("<?xml version=\"1.0\" encoding=\"utf-8\" ?>\n", render("!!! XML", :attr_wrapper => '"', :format => :xhtml))
   end
 
@@ -1527,7 +1527,7 @@ HAML
       render("%div{:data => {:one_plus_one => 1+1}}",
         :hyphenate_data_attrs => false))
 
-    assert_equal("<div data-foo='Here&#x0027;s a \"quoteful\" string.'></div>\n",
+    assert_equal("<div data-foo='Here&#039;s a \"quoteful\" string.'></div>\n",
       render(%{%div{:data => {:foo => %{Here's a "quoteful" string.}}}},
         :hyphenate_data_attrs => false)) #'
   end
@@ -1691,9 +1691,9 @@ HAML
   def test_new_attribute_parsing
     assert_equal("<a a2='b2'>bar</a>\n", render("%a(a2=b2) bar", :locals => {:b2 => 'b2'}))
     assert_equal(%Q{<a a='foo"bar'>bar</a>\n}, render(%q{%a(a="#{'foo"bar'}") bar})) #'
-    assert_equal(%Q{<a a="foo'bar">bar</a>\n}, render(%q{%a(a="#{"foo'bar"}") bar})) #'
+    assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="#{"foo'bar"}") bar})) #'
     assert_equal(%Q{<a a='foo"bar'>bar</a>\n}, render(%q{%a(a='foo"bar') bar}))
-    assert_equal(%Q{<a a="foo'bar">bar</a>\n}, render(%q{%a(a="foo'bar") bar}))
+    assert_equal(%Q{<a a='foo&#039;bar'>bar</a>\n}, render(%q{%a(a="foo'bar") bar}))
     assert_equal("<a a:b='foo'>bar</a>\n", render("%a(a:b='foo') bar"))
     assert_equal("<a a='foo' b='bar'>bar</a>\n", render("%a(a = 'foo' b = 'bar') bar"))
     assert_equal("<a a='foo' b='bar'>bar</a>\n", render("%a(a = foo b = bar) bar", :locals => {:foo => 'foo', :bar => 'bar'}))
@@ -1706,8 +1706,8 @@ HAML
     assert_equal(%Q{<a a='foo " bar'>bar</a>\n}, render(%q{%a(a="foo \" bar") bar}))
     assert_equal(%Q{<a a='foo \\" bar'>bar</a>\n}, render(%q{%a(a="foo \\\\\" bar") bar}))
 
-    assert_equal(%Q{<a a="foo ' bar">bar</a>\n}, render(%q{%a(a='foo \' bar') bar}))
-    assert_equal(%Q{<a a="foo \\' bar">bar</a>\n}, render(%q{%a(a='foo \\\\\' bar') bar}))
+    assert_equal(%Q{<a a='foo &#039; bar'>bar</a>\n}, render(%q{%a(a='foo \' bar') bar}))
+    assert_equal(%Q{<a a='foo \\&#039; bar'>bar</a>\n}, render(%q{%a(a='foo \\\\\' bar') bar}))
 
     assert_equal(%Q{<a a='foo \\ bar'>bar</a>\n}, render(%q{%a(a="foo \\\\ bar") bar}))
     assert_equal(%Q{<a a='foo \#{1 + 1} bar'>bar</a>\n}, render(%q{%a(a="foo \#{1 + 1} bar") bar}))

--- a/test/pretty_results/just_stuff.xhtml
+++ b/test/pretty_results/just_stuff.xhtml
@@ -6,7 +6,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
-<strong apos="Foo's bar!">Boo!</strong>
+<strong apos='Foo&#039;s bar!'>Boo!</strong>
 Embedded? false!
 Embedded? true!
 Embedded? true!
@@ -61,7 +61,7 @@ testtest
 <p class='article quux qux' id='article_1'>Blump</p>
 <p class='article' id='foo_bar_baz_article_1'>Whee</p>
 Woah inner quotes
-<p class='dynamic_quote' dyn='3' quotes="single '"></p>
+<p class='dynamic_quote' dyn='3' quotes='single &#039;'></p>
 <p class='dynamic_self_closing' dyn='3' />
 <body>
   hello

--- a/test/pretty_results/just_stuff.xhtml
+++ b/test/pretty_results/just_stuff.xhtml
@@ -6,7 +6,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
-<strong apos='Foo&#039;s bar!'>Boo!</strong>
+<strong apos='Foo&#39;s bar!'>Boo!</strong>
 Embedded? false!
 Embedded? true!
 Embedded? true!
@@ -61,7 +61,7 @@ testtest
 <p class='article quux qux' id='article_1'>Blump</p>
 <p class='article' id='foo_bar_baz_article_1'>Whee</p>
 Woah inner quotes
-<p class='dynamic_quote' dyn='3' quotes='single &#039;'></p>
+<p class='dynamic_quote' dyn='3' quotes='single &#39;'></p>
 <p class='dynamic_self_closing' dyn='3' />
 <body>
   hello

--- a/test/results/just_stuff.xhtml
+++ b/test/results/just_stuff.xhtml
@@ -6,7 +6,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
-<strong apos="Foo's bar!">Boo!</strong>
+<strong apos='Foo&#039;s bar!'>Boo!</strong>
 Embedded? false!
 Embedded? true!
 Embedded? true!
@@ -61,7 +61,7 @@ Nested content
 <p class='article quux qux' id='article_1'>Blump</p>
 <p class='article' id='foo_bar_baz_article_1'>Whee</p>
 Woah inner quotes
-<p class='dynamic_quote' dyn='3' quotes="single '"></p>
+<p class='dynamic_quote' dyn='3' quotes='single &#039;'></p>
 <p class='dynamic_self_closing' dyn='3' />
 <body>
 hello

--- a/test/results/just_stuff.xhtml
+++ b/test/results/just_stuff.xhtml
@@ -6,7 +6,7 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">
-<strong apos='Foo&#039;s bar!'>Boo!</strong>
+<strong apos='Foo&#39;s bar!'>Boo!</strong>
 Embedded? false!
 Embedded? true!
 Embedded? true!
@@ -61,7 +61,7 @@ Nested content
 <p class='article quux qux' id='article_1'>Blump</p>
 <p class='article' id='foo_bar_baz_article_1'>Whee</p>
 Woah inner quotes
-<p class='dynamic_quote' dyn='3' quotes='single &#039;'></p>
+<p class='dynamic_quote' dyn='3' quotes='single &#39;'></p>
 <p class='dynamic_self_closing' dyn='3' />
 <body>
 hello


### PR DESCRIPTION
close https://github.com/haml/haml/issues/901

All details are described in https://github.com/haml/haml/issues/901.

## Benchmark
Without implementing Temple compiler for attributes, it improves performance.

With Ruby 2.4.0 and  [k0kubun/haml_bench/templates/slim_bench.haml](https://github.com/k0kubun/haml_bench/blob/97a7b9970684b975c48e1403ee4fe329bf1151fb/templates/slim_bench.haml),

### before
```
$ bundle exec ruby bench.rb
Rendering: /home/k0kubun/src/github.com/k0kubun/haml_bench/templates/slim_bench.haml
Calculating -------------------------------------
          haml 4.0.7     4.183k i/100ms
   haml 5.0.0.beta.2     5.385k i/100ms
-------------------------------------------------
          haml 4.0.7     43.307k (± 1.0%) i/s -    217.516k
   haml 5.0.0.beta.2     56.453k (± 1.5%) i/s -    285.405k

Comparison:
   haml 5.0.0.beta.2:    56453.0 i/s
          haml 4.0.7:    43307.1 i/s - 1.30x slower
```

### after
```
$ bundle exec ruby bench.rb
Rendering: /home/k0kubun/src/github.com/k0kubun/haml_bench/templates/slim_bench.haml
Calculating -------------------------------------
          haml 4.0.7     4.178k i/100ms
   haml 5.0.0.beta.2     5.827k i/100ms
-------------------------------------------------
          haml 4.0.7     43.184k (± 1.3%) i/s -    217.256k
   haml 5.0.0.beta.2     61.642k (± 1.5%) i/s -    308.831k

Comparison:
   haml 5.0.0.beta.2:    61642.4 i/s
          haml 4.0.7:    43184.0 i/s - 1.43x slower
```