### PR TITLE
Don't preserve newlines in attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@
 * Support Rails 5.1 Erubi template handler.
 * Drop dynamic quotes support and always escape `'` for `escape_html`/`escape_attrs` instead.
   Also, escaped results are slightly changed and always unified to the same characters. (Takashi Kokubun)
+* Don't preserve newlines in attributes. (Takashi Kokubun)
 * Add temple gem as dependency and create `Haml::TempleEngine` class.
   Some methods in `Haml::Compiler` are migrated to `Haml::TempleEngine`. (Takashi Kokubun)
 * Drop parser/compiler accessor from `Haml::Engine`. Modify `Haml::Engine#initialize` options

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -29,7 +29,7 @@ module Haml
             next
           end
 
-          escaped =
+          value =
             if escape_attrs == :once
               Haml::Helpers.escape_once(value)
             elsif escape_attrs
@@ -37,7 +37,6 @@ module Haml
             else
               value.to_s
             end
-          value = Haml::Helpers.preserve(escaped)
           " #{attr}=#{attr_wrapper}#{value}#{attr_wrapper}"
         end
         result.compact!

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -970,8 +970,6 @@ HAML
                  render(".atlantis{:style => 'ugly&stupid'} foo"))
     assert_equal("<p class='atlantis' style='ugly&amp;stupid'>foo</p>\n",
                 render("%p.atlantis{:style => 'ugly&stupid'}= 'foo'"))
-    assert_equal("<p class='atlantis' style='ugly&#x000A;stupid'></p>\n",
-                render("%p.atlantis{:style => \"ugly\\nstupid\"}"))
   end
 
   def test_dynamic_attributes_should_be_escaped
@@ -981,8 +979,6 @@ HAML
                  render("%p{:width => nil, :src => '&foo.png', :alt => String.new} foo"))
     assert_equal("<div alt='' src='&amp;foo.png'>foo</div>\n",
                  render("%div{:width => nil, :src => '&foo.png', :alt => String.new}= 'foo'"))
-    assert_equal("<img alt='' src='foo&#x000A;.png'>\n",
-                 render("%img{:width => nil, :src => \"foo\\n.png\", :alt => String.new}"))
   end
 
   def test_string_double_equals_should_be_esaped
@@ -1148,7 +1144,6 @@ HAML
   def test_attrs_parsed_correctly
     assert_equal("<p boom=>biddly='bar =&gt; baz'></p>\n", render("%p{'boom=>biddly' => 'bar => baz'}"))
     assert_equal("<p foo,bar='baz, qux'></p>\n", render("%p{'foo,bar' => 'baz, qux'}"))
-    assert_equal("<p escaped='quo&#x000A;te'></p>\n", render("%p{ :escaped => \"quo\\nte\"}"))
     assert_equal("<p escaped='quo4te'></p>\n", render("%p{ :escaped => \"quo\#{2 + 2}te\"}"))
   end
 

--- a/test/pretty_engine_test.rb
+++ b/test/pretty_engine_test.rb
@@ -972,8 +972,6 @@ HAML
                  render(".atlantis{:style => 'ugly&stupid'} foo"))
     assert_equal("<p class='atlantis' style='ugly&amp;stupid'>foo</p>\n",
                 render("%p.atlantis{:style => 'ugly&stupid'}= 'foo'"))
-    assert_equal("<p class='atlantis' style='ugly&#x000A;stupid'></p>\n",
-                render("%p.atlantis{:style => \"ugly\\nstupid\"}"))
   end
 
   def test_dynamic_attributes_should_be_escaped
@@ -983,8 +981,6 @@ HAML
                  render("%p{:width => nil, :src => '&foo.png', :alt => String.new} foo"))
     assert_equal("<div alt='' src='&amp;foo.png'>foo</div>\n",
                  render("%div{:width => nil, :src => '&foo.png', :alt => String.new}= 'foo'"))
-    assert_equal("<img alt='' src='foo&#x000A;.png'>\n",
-                 render("%img{:width => nil, :src => \"foo\\n.png\", :alt => String.new}"))
   end
 
   def test_string_double_equals_should_be_esaped
@@ -1150,7 +1146,6 @@ HAML
   def test_attrs_parsed_correctly
     assert_equal("<p boom=>biddly='bar =&gt; baz'></p>\n", render("%p{'boom=>biddly' => 'bar => baz'}"))
     assert_equal("<p foo,bar='baz, qux'></p>\n", render("%p{'foo,bar' => 'baz, qux'}"))
-    assert_equal("<p escaped='quo&#x000A;te'></p>\n", render("%p{ :escaped => \"quo\\nte\"}"))
     assert_equal("<p escaped='quo4te'></p>\n", render("%p{ :escaped => \"quo\#{2 + 2}te\"}"))
   end
 


### PR DESCRIPTION
`Haml::Helpers.preserve` is very slow. I don't think it's necessary for attributes because Slim, Faml and Hamlit don't preserve them and work fine. 

The original change was done in 2008 https://github.com/haml/haml/commit/e8075e7feac72291a203b137b4f8c2a13457e843 and no reason is found to keep that change. Let's remove a legacy feature.

## Benchmark
With Ruby 2.4.0 and  [k0kubun/haml_bench/templates/slim_bench.haml](https://github.com/k0kubun/haml_bench/blob/97a7b9970684b975c48e1403ee4fe329bf1151fb/templates/slim_bench.haml),

### before
```
$ bundle exec ruby bench.rb
Rendering: /home/k0kubun/src/github.com/k0kubun/haml_bench/templates/slim_bench.haml
Calculating -------------------------------------
          haml 4.0.7     3.576k i/100ms
   haml 5.0.0.beta.2     5.450k i/100ms
-------------------------------------------------
          haml 4.0.7     37.559k (± 3.6%) i/s -    189.528k
   haml 5.0.0.beta.2     55.625k (± 4.5%) i/s -    277.950k

Comparison:
   haml 5.0.0.beta.2:    55625.3 i/s
          haml 4.0.7:    37558.8 i/s - 1.48x slower
```

### after
```
$ bundle exec ruby bench.rb
Rendering: /home/k0kubun/src/github.com/k0kubun/haml_bench/templates/slim_bench.haml
Calculating -------------------------------------
          haml 4.0.7     3.608k i/100ms
   haml 5.0.0.beta.2     6.140k i/100ms
-------------------------------------------------
          haml 4.0.7     37.460k (± 3.5%) i/s -    187.616k
   haml 5.0.0.beta.2     64.248k (± 4.5%) i/s -    325.420k

Comparison:
   haml 5.0.0.beta.2:    64247.5 i/s
          haml 4.0.7:    37459.9 i/s - 1.72x slower
```

@haml/committers WDYT?