### PR TITLE
Introduce Temple attribute compiler

### DIFF
--- a/haml.gemspec
+++ b/haml.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency 'temple', '>= 0.7.6'
+  spec.add_dependency 'temple', '0.7.7'
   spec.add_dependency 'tilt'
 
   spec.add_development_dependency 'rails', '>= 4.0.0'

--- a/haml.gemspec
+++ b/haml.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.0.0'
 
-  spec.add_dependency 'temple', '0.7.7'
+  spec.add_dependency 'temple', '>= 0.8.0'
   spec.add_dependency 'tilt'
 
   spec.add_development_dependency 'rails', '>= 4.0.0'

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -79,9 +79,20 @@ module Haml
         to
       end
 
+      # Merge multiple values to one attribute value. No destructive operation.
+      #
+      # @param key [String]
+      # @param values [Array<Object>]
+      # @return [String,Hash]
+      def merge_values(key, *values)
+        values.inject(nil) do |to, from|
+          merge_value(key, to, from)
+        end
+      end
+
       private
 
-      # Merge values for Haml attributes. No destructive operation.
+      # Merge a couple of values to one attribute value. No destructive operation.
       #
       # @param to [String,Hash,nil]
       # @param from [Object]

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -131,27 +131,26 @@ module Haml
     # @return [Array] Temple expression
     def compile_attribute(key, values)
       case key
-      when 'id'
-        compile_id_attribute(values)
-      when 'class'
-        runtime_build(values)
+      when 'id', 'class'
+        compile_id_or_class_attribute(key, values)
       else
         compile_common_attribute(key, values)
       end
     end
 
+    # @param id_or_class [String] "id" or "class"
     # @param values [Array<AttributeValue>]
     # @return [Array] Temple expression
-    def compile_id_attribute(values)
+    def compile_id_or_class_attribute(id_or_class, values)
       var = unique_name
       [:multi,
-       [:code, "#{var} = (#{merged_value('id', values)})"],
+       [:code, "#{var} = (#{merged_value(id_or_class, values)})"],
        [:case, var,
-        ['Hash, Array', runtime_build([AttributeValue.new(:dynamic, 'id', var)])],
-        ['true', true_value('id')],
+        ['Hash, Array', runtime_build([AttributeValue.new(:dynamic, id_or_class, var)])],
+        ['true', true_value(id_or_class)],
         ['false, nil', [:multi]],
         [:else, [:multi,
-                 [:static, " id=#{@attr_wrapper}"],
+                 [:static, " #{id_or_class}=#{@attr_wrapper}"],
                  [:escape, @escape_attrs, [:dynamic, var]],
                  [:static, @attr_wrapper]],
         ]

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -167,7 +167,6 @@ module Haml
        [:code, "#{var} = (#{merged_value(id_or_class, values)})"],
        [:case, var,
         ['Hash, Array', runtime_build([AttributeValue.new(:dynamic, id_or_class, var)])],
-        ['true', true_value(id_or_class)],
         ['false, nil', [:multi]],
         [:else, [:multi,
                  [:static, " #{id_or_class}=#{@attr_wrapper}"],

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -81,15 +81,21 @@ module Haml
 
     # Compiles attribute values with the same base_key to Temple expression.
     #
-    # @param base_values [Array<AttributeValue>] `base_key`'s results are the same. `key`'s result may differ.
+    # @param values [Array<AttributeValue>] `base_key`'s results are the same. `key`'s result may differ.
     # @return [Array] Temple expression
-    def compile_attribute_values(base_values)
-      if base_values.map(&:key).uniq.size == 1
-        return compile_attribute(base_values.first.key, base_values)
+    def compile_attribute_values(values)
+      if values.map(&:key).uniq.size == 1
+        compile_attribute(values.first.key, values)
+      else
+        runtime_build(values)
       end
+    end
 
-      hash_content = base_values.group_by(&:key).map do |key, values|
-        "#{frozen_string(key)} => #{merged_value(key, values)}"
+    # @param values [Array<AttributeValue>]
+    # @return [Array] Temple expression
+    def runtime_build(values)
+      hash_content = values.group_by(&:key).map do |key, values_for_key|
+        "#{frozen_string(key)} => #{merged_value(key, values_for_key)}"
       end.join(', ')
       [:dynamic, "_hamlout.attributes({ #{hash_content} }, nil)"]
     end
@@ -117,7 +123,7 @@ module Haml
     # @param values [Array<AttributeValue>]
     # @return [Array] Temple expression
     def compile_attribute(key, values)
-      [:dynamic, "_hamlout.attributes({ #{frozen_string(key)} => #{merged_value(key, values)} }, nil)"]
+      runtime_build(values)
     end
   end
 end

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -146,7 +146,7 @@ module Haml
     # @param values [Array<AttributeValue>]
     # @return [Array] Temple expression
     def compile_attribute(key, values)
-      if values.all? { |v| Temple::Filters::StaticAnalyzer.static?(v.to_literal) }
+      if values.all? { |v| Temple::StaticAnalyzer.static?(v.to_literal) }
         return static_build(values)
       end
 

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -98,7 +98,11 @@ module Haml
     # @param values [Array<AttributeValue>]
     # @return [String]
     def merged_value(key, values)
-      "::Haml::AttributeBuilder.merge_values(#{frozen_string(key)}, #{values.map(&:to_literal).join(', ')})"
+      if values.size == 1
+        values.first.to_literal
+      else
+        "::Haml::AttributeBuilder.merge_values(#{frozen_string(key)}, #{values.map(&:to_literal).join(', ')})"
+      end
     end
 
     # @param str [String]

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -131,15 +131,34 @@ module Haml
     # @return [Array] Temple expression
     def compile_attribute(key, values)
       case key
-      when 'id', 'class'
+      when 'id'
+        compile_id_attribute(values)
+      when 'class'
         runtime_build(values)
       else
         compile_common_attribute(key, values)
       end
     end
 
-    # Compiles attribute for keys except "id" and "class".
-    #
+    # @param values [Array<AttributeValue>]
+    # @return [Array] Temple expression
+    def compile_id_attribute(values)
+      var = unique_name
+      [:multi,
+       [:code, "#{var} = (#{merged_value('id', values)})"],
+       [:case, var,
+        ['Hash, Array', runtime_build([AttributeValue.new(:dynamic, 'id', var)])],
+        ['true', true_value('id')],
+        ['false, nil', [:multi]],
+        [:else, [:multi,
+                 [:static, " id=#{@attr_wrapper}"],
+                 [:escape, @escape_attrs, [:dynamic, var]],
+                 [:static, @attr_wrapper]],
+        ]
+       ],
+      ]
+    end
+
     # @param key [String] Not "id" or "class"
     # @param values [Array<AttributeValue>]
     # @return [Array] Temple expression

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -1,0 +1,84 @@
+require 'haml/attribute_parser'
+
+module Haml
+  class AttributeCompiler
+    # @param type [Symbol] :static or :dynamic
+    # @param value [String] Actual string value for :static type, value's Ruby literal for :dynamic type.
+    class AttributeValue < Struct.new(:type, :value)
+      # @return [String] A Ruby literal of value.
+      def to_literal
+        case type
+        when :static
+          Haml::Util.inspect_obj(value)
+        when :dynamic
+          value
+        end
+      end
+    end
+
+    # Returns a script to render attributes on runtime.
+    #
+    # @param attributes [Hash]
+    # @param object_ref [String,:nil]
+    # @param attributes_hashes [Array<String>]
+    # @return [String] Attributes rendering code
+    def self.runtime_build(attributes, object_ref, attributes_hashes)
+      "_hamlout.attributes(#{Haml::Util.inspect_obj(attributes)}, #{object_ref},#{attributes_hashes.join(', ')})"
+    end
+
+    # Returns Temple expression to render attributes.
+    #
+    # @param attributes [Hash]
+    # @param object_ref [String,:nil]
+    # @param attributes_hashes [Array<String>]
+    # @return [Array] Temple expression
+    def compile(attributes, object_ref, attributes_hashes)
+      if object_ref != :nil || !AttributeParser.available?
+        return [:dynamic, AttributeCompiler.runtime_build(attributes, object_ref, attributes_hashes)]
+      end
+
+      parsed_hashes = attributes_hashes.map do |attribute_hash|
+        unless (hash = AttributeParser.parse(attribute_hash))
+          return [:dynamic, AttributeCompiler.runtime_build(attributes, object_ref, attributes_hashes)]
+        end
+        hash
+      end
+
+      values_by_key = build_attribute_values_by_key(attributes, parsed_hashes)
+      sorted_keys   = values_by_key.keys.sort
+      [:multi, *sorted_keys.map { |k| compile_attribute(k, values_by_key[k]) }]
+    end
+
+    private
+
+    # Builds { key => attribute values } hash from static attributes and dynamic attributes_hashes.
+    # The order of attribute values are the same as Haml::Buffer#attributes's merge order.
+    #
+    # @param attributes [{ String => String }]
+    # @param parsed_hashes [{ String => String }]
+    # @return [{ String => Array<AttributeValue> }]
+    def build_attribute_values_by_key(attributes, parsed_hashes)
+      Hash.new { |h, k| h[k] = [] }.tap do |values_by_key|
+        attributes.each do |attr, static_value|
+          values_by_key[attr] << AttributeValue.new(:static, static_value)
+        end
+        parsed_hashes.each do |parsed_hash|
+          parsed_hash.each do |attr, dynamic_value|
+            values_by_key[attr] << AttributeValue.new(:dynamic, dynamic_value)
+          end
+        end
+      end
+    end
+
+    # Compiles one attribute to Temple expression for rendering " key='value'".
+    #
+    # @param key [String]
+    # @param values [Array<AttributeValue>]
+    # @return [Array] Temple expression
+    def compile_attribute(key, values)
+      code = "_hamlout.attributes({ #{Haml::Util.inspect_obj(key)}.freeze => "\
+        "::Haml::AttributeBuilder.merge_values(#{Haml::Util.inspect_obj(key)}.freeze, #{values.map(&:to_literal).join(', ')}) }, nil)"
+      [:dynamic, code]
+    end
+  end
+end

--- a/lib/haml/attribute_parser.rb
+++ b/lib/haml/attribute_parser.rb
@@ -1,0 +1,112 @@
+begin
+  require 'ripper'
+rescue LoadError
+end
+
+module Haml
+  module AttributeParser
+    class UnexpectedTokenError < StandardError; end
+    class UnexpectedKeyError < StandardError; end
+
+    class << self
+      def available?
+        defined?(Ripper) && defined?(Temple::Filters::StaticAnalyzer::SyntaxChecker)
+      end
+
+      def parse(text)
+        exp = wrap_bracket(text)
+        return if Temple::Filters::StaticAnalyzer::SyntaxChecker.syntax_error?(exp)
+
+        hash = {}
+        tokens = Ripper.lex(exp)[1..-2] || []
+        each_attr(tokens) do |attr_tokens|
+          key = parse_key!(attr_tokens)
+          hash[key] = attr_tokens.map(&:last).join.strip
+        end
+        hash
+      rescue UnexpectedTokenError, UnexpectedKeyError
+        nil
+      end
+
+      private
+
+      def wrap_bracket(text)
+        text = text.strip
+        return text if text[0] == '{'
+        "{#{text}}"
+      end
+
+      def parse_key!(tokens)
+        _, type, str = tokens.shift
+        case type
+        when :on_sp
+          parse_key!(tokens)
+        when :on_label
+          str.tr(':', '')
+        when :on_symbeg
+          _, _, key = tokens.shift
+          assert_type!(tokens.shift, :on_tstring_end) if str != ':'
+          skip_until_hash_rocket!(tokens)
+          key
+        when :on_tstring_beg
+          _, _, key = tokens.shift
+          next_token = tokens.shift
+          unless next_token[1] == :on_label_end
+            assert_type!(next_token, :on_tstring_end)
+            skip_until_hash_rocket!(tokens)
+          end
+          key
+        else
+          raise UnexpectedKeyError
+        end
+      end
+
+      def assert_type!(token, type)
+        raise UnexpectedTokenError if token[1] != type
+      end
+
+      def skip_until_hash_rocket!(tokens)
+        until tokens.empty?
+          _, type, str = tokens.shift
+          break if type == :on_op && str == '=>'
+        end
+      end
+
+      def each_attr(tokens)
+        attr_tokens = []
+        array_open  = 0
+        brace_open  = 0
+        paren_open  = 0
+
+        tokens.each do |token|
+          _, type, _ = token
+          case type
+          when :on_comma
+            if array_open == 0 && brace_open == 0 && paren_open == 0
+              yield(attr_tokens)
+              attr_tokens = []
+              next
+            end
+          when :on_lbracket
+            array_open += 1
+          when :on_rbracket
+            array_open -= 1
+          when :on_lbrace
+            brace_open += 1
+          when :on_rbrace
+            brace_open -= 1
+          when :on_lparen
+            paren_open += 1
+          when :on_rparen
+            paren_open -= 1
+          when :on_sp
+            next if attr_tokens.empty?
+          end
+
+          attr_tokens << token
+        end
+        yield(attr_tokens) unless attr_tokens.empty?
+      end
+    end
+  end
+end

--- a/lib/haml/attribute_parser.rb
+++ b/lib/haml/attribute_parser.rb
@@ -10,12 +10,12 @@ module Haml
 
     class << self
       def available?
-        defined?(Ripper) && defined?(Temple::Filters::StaticAnalyzer::SyntaxChecker)
+        defined?(Ripper) && Temple::StaticAnalyzer.available?
       end
 
       def parse(text)
         exp = wrap_bracket(text)
-        return if Temple::Filters::StaticAnalyzer::SyntaxChecker.syntax_error?(exp)
+        return if Temple::StaticAnalyzer.syntax_error?(exp)
 
         hash = {}
         tokens = Ripper.lex(exp)[1..-2] || []

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -14,7 +14,7 @@ module Haml
       @to_merge    = []
       @temple      = [:multi]
       @node        = nil
-      @attribute_compiler = AttributeCompiler.new
+      @attribute_compiler = AttributeCompiler.new(options)
     end
 
     def call(node)

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -12,6 +12,7 @@ module Haml
       @to_merge    = []
       @temple      = [:multi]
       @node        = nil
+      @generator   = Generator.new # to count newlines in generated code
     end
 
     def call(node)
@@ -138,8 +139,14 @@ module Haml
         return if tag_closed
       else
         push_merged_text "<#{t[:name]}", 0, !t[:nuke_outer_whitespace]
-        push_generated_script(
-          "_hamlout.attributes(#{inspect_obj(t[:attributes])}, #{object_ref},#{attributes_hashes.join(',')})")
+
+        rendering_script = "_hamlout.attributes(#{inspect_obj(t[:attributes])}, #{object_ref},#{attributes_hashes.join(',')})"
+        if @options.ugly
+          push_temple([:dynamic, rendering_script])
+        else
+          push_generated_script(rendering_script)
+        end
+
         concat_merged_text(
           if t[:self_closing] && @options.xhtml?
             " />#{"\n" unless t[:nuke_outer_whitespace]}"
@@ -283,6 +290,14 @@ module Haml
       push_merged_text("#{text}\n", tab_change)
     end
 
+    # This method is only supported for `@options.ugly` case.
+    def push_temple(temple)
+      newlines = resolve_newlines
+      @to_merge << [:temple, [:code, newlines]] unless newlines.empty?
+      @to_merge << [:temple, temple]
+      @output_line += @generator.call(temple).count("\n")
+    end
+
     def flush_merged_text
       return if @to_merge.empty?
 
@@ -293,6 +308,8 @@ module Haml
             @temple << [:static, val]
           when :script
             @temple << [:dynamic, val]
+          when :temple
+            @temple << val
           else
             raise SyntaxError.new("[HAML BUG] Undefined entry in Haml::Compiler@to_merge.")
           end

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -1,5 +1,6 @@
 require 'haml/attribute_builder'
 require 'haml/attribute_compiler'
+require 'haml/temple_line_counter'
 
 module Haml
   class Compiler
@@ -13,7 +14,6 @@ module Haml
       @to_merge    = []
       @temple      = [:multi]
       @node        = nil
-      @generator   = Generator.new # to count newlines in generated code
       @attribute_compiler = AttributeCompiler.new
     end
 
@@ -294,7 +294,7 @@ module Haml
       newlines = resolve_newlines
       @to_merge << [:temple, [:code, newlines]] unless newlines.empty?
       @to_merge << [:temple, temple]
-      @output_line += @generator.call(temple).count("\n")
+      @output_line += TempleLineCounter.count_lines(temple)
     end
 
     def flush_merged_text

--- a/lib/haml/escapable.rb
+++ b/lib/haml/escapable.rb
@@ -1,0 +1,48 @@
+module Haml
+  # Like Temple::Filters::Escapable, but with support for escaping by
+  # Haml::Herlpers.html_escape and Haml::Herlpers.escape_once.
+  class Escapable < Temple::Filter
+    def initialize(*)
+      super
+      @escape_code = "::Haml::Helpers.html_escape((%s))"
+      @escaper = eval("proc {|v| #{@escape_code % 'v'} }")
+      @once_escape_code = "::Haml::Helpers.escape_once((%s))"
+      @once_escaper = eval("proc {|v| #{@once_escape_code % 'v'} }")
+      @escape = false
+    end
+
+    def on_escape(flag, exp)
+      old = @escape
+      @escape = flag
+      compile(exp)
+    ensure
+      @escape = old
+    end
+
+    # The same as Haml::AttributeBuilder.build_attributes
+    def on_static(value)
+      [:static,
+       if @escape == :once
+         @once_escaper[value]
+       elsif @escape
+         @escaper[value]
+       else
+         value
+       end
+      ]
+    end
+
+    # The same as Haml::AttributeBuilder.build_attributes
+    def on_dynamic(value)
+      [:dynamic,
+       if @escape == :once
+         @once_escape_code % value
+       elsif @escape
+         @escape_code % value
+       else
+         "(#{value}).to_s"
+       end
+      ]
+    end
+  end
+end

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -28,6 +28,7 @@ module Haml
 
     use :Parser,   -> { options[:parser_class] }
     use :Compiler, -> { options[:compiler_class] }
+    filter :MultiFlattener
     filter :StaticMerger
     use Generator
 

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -1,4 +1,5 @@
 require 'temple'
+require 'haml/escapable'
 require 'haml/generator'
 
 module Haml
@@ -28,6 +29,8 @@ module Haml
 
     use :Parser,   -> { options[:parser_class] }
     use :Compiler, -> { options[:compiler_class] }
+    use Escapable
+    filter :ControlFlow
     filter :MultiFlattener
     filter :StaticMerger
     use Generator

--- a/lib/haml/temple_line_counter.rb
+++ b/lib/haml/temple_line_counter.rb
@@ -1,0 +1,21 @@
+module Haml
+  # A module to count lines of expected code. This would be faster than actual code generation
+  # and counting newlines in it.
+  module TempleLineCounter
+    class UnexpectedExpression < StandardError; end
+
+    def self.count_lines(exp)
+      type, *args = exp
+      case type
+      when :multi
+        args.map { |a| count_lines(a) }.reduce(:+) || 0
+      when :dynamic, :code
+        args.first.count("\n")
+      when :static
+        0 # It has not real newline "\n" but escaped "\\n".
+      else
+        raise UnexpectedExpression.new("[HAML BUG] Unexpected Temple expression '#{type}' is given!")
+      end
+    end
+  end
+end

--- a/lib/haml/temple_line_counter.rb
+++ b/lib/haml/temple_line_counter.rb
@@ -13,6 +13,13 @@ module Haml
         args.first.count("\n")
       when :static
         0 # It has not real newline "\n" but escaped "\\n".
+      when :case
+        arg, *cases = args
+        arg.count("\n") + cases.map do |cond, e|
+          (cond == :else ? 0 : cond.count("\n")) + count_lines(e)
+        end.reduce(:+)
+      when :escape
+        count_lines(args[1])
       else
         raise UnexpectedExpression.new("[HAML BUG] Unexpected Temple expression '#{type}' is given!")
       end

--- a/test/attribute_parser_test.rb
+++ b/test/attribute_parser_test.rb
@@ -1,0 +1,104 @@
+require 'test_helper'
+require 'haml/attribute_parser'
+
+class AttributeParserTeset < Haml::TestCase
+  describe '.parse' do
+    def assert_parse(expected, haml)
+      actual = Haml::AttributeParser.parse(haml)
+      if expected.nil?
+        assert_nil actual
+      else
+        assert_equal expected, actual
+      end
+    end
+
+    it { assert_parse({}, '') }
+    it { assert_parse({}, '{}') }
+
+    describe 'invalid hash' do
+      it { assert_parse(nil, ' hash ') }
+      it { assert_parse(nil, 'hash, foo: bar') }
+      it { assert_parse(nil, ' {hash} ') }
+      it { assert_parse(nil, ' { hash, foo: bar } ') }
+    end
+
+    describe 'dynamic key' do
+      it { assert_parse(nil, 'foo => bar') }
+      it { assert_parse(nil, '[] => bar') }
+      it { assert_parse(nil, '[1,2,3] => bar') }
+    end
+
+    describe 'foo: bar' do
+      it { assert_parse({ '_' => '1' }, '_:1,') }
+      it { assert_parse({ 'foo' => 'bar' }, ' foo:  bar ') }
+      it { assert_parse({ 'a' => 'b', 'c' => ':d' }, 'a: b, c: :d') }
+      it { assert_parse({ 'a' => '[]', 'c' => '"d"' }, 'a: [], c: "d"') }
+      it { assert_parse({ '_' => '1' }, ' { _:1, } ') }
+      it { assert_parse({ 'foo' => 'bar' }, ' {  foo:  bar } ') }
+      it { assert_parse({ 'a' => 'b', 'c' => ':d' }, ' { a: b, c: :d } ') }
+      it { assert_parse({ 'a' => '[]', 'c' => '"d"' }, ' { a: [], c: "d" } ') }
+    end
+
+    describe ':foo => bar' do
+      it { assert_parse({ 'foo' => ':bar' }, '  :foo   =>  :bar  ') }
+      it { assert_parse({ '_' => '"foo"' }, ':_=>"foo"') }
+      it { assert_parse({ 'a' => '[]', 'c' => '""', 'b' => '"#{3}"' }, ':a => [], c: "", :b => "#{3}"') }
+      it { assert_parse({ 'foo' => ':bar' }, ' {   :foo   =>  :bar } ') }
+      it { assert_parse({ '_' => '"foo"' }, ' { :_=>"foo" } ') }
+      it { assert_parse({ 'a' => '[]', 'c' => '""', 'b' => '"#{3}"' }, ' { :a => [], c: "", :b => "#{3}" } ') }
+      it { assert_parse(nil, ':"f#{o}o" => bar') }
+      it { assert_parse(nil, ':"#{f}oo" => bar') }
+      it { assert_parse(nil, ':"#{foo}" => bar') }
+    end
+
+    describe '"foo" => bar' do
+      it { assert_parse({ 'foo' => '[1]' }, '"foo"=>[1]') }
+      it { assert_parse({ 'foo' => 'nya' }, " 'foo' => nya ") }
+      it { assert_parse({ 'foo' => 'bar' }, '%q[foo] => bar ') }
+      it { assert_parse({ 'foo' => '[1]' }, ' { "foo"=>[1] } ') }
+      it { assert_parse({ 'foo' => 'nya' }, " {  'foo' => nya } ") }
+      it { assert_parse({ 'foo' => 'bar' }, ' { %q[foo] => bar } ') }
+      it { assert_parse(nil, '"f#{o}o" => bar') }
+      it { assert_parse(nil, '"#{f}oo" => bar') }
+      it { assert_parse(nil, '"#{foo}" => bar') }
+      it { assert_parse({ 'f#{o}o' => 'bar' }, '%q[f#{o}o] => bar ') }
+      it { assert_parse({ 'f#{o}o' => 'bar' }, ' { %q[f#{o}o] => bar,  } ') }
+      it { assert_parse(nil, '%Q[f#{o}o] => bar ') }
+    end
+
+    if RUBY_VERSION >= '2.2.0'
+      describe '"foo": bar' do
+        it { assert_parse({ 'foo' => '()' }, '"foo":()') }
+        it { assert_parse({ 'foo' => 'nya' }, " 'foo': nya ") }
+        it { assert_parse({ 'foo' => '()' }, ' { "foo":() , }') }
+        it { assert_parse({ 'foo' => 'nya' }, " {  'foo': nya , }") }
+        it { assert_parse(nil, '"f#{o}o": bar') }
+        it { assert_parse(nil, '"#{f}oo": bar') }
+        it { assert_parse(nil, '"#{foo}": bar') }
+      end
+    end
+
+    describe 'nested array' do
+      it { assert_parse({ 'foo' => '[1,2,]' }, 'foo: [1,2,],') }
+      it { assert_parse({ 'foo' => '[1,2,[3,4],5]' }, 'foo: [1,2,[3,4],5],') }
+      it { assert_parse({ 'foo' => '[1,2,[3,4],5]', 'bar' => '[[1,2],]'}, 'foo: [1,2,[3,4],5],bar: [[1,2],],') }
+      it { assert_parse({ 'foo' => '[1,2,]' }, ' { foo: [1,2,], } ') }
+      it { assert_parse({ 'foo' => '[1,2,[3,4],5]' }, ' { foo: [1,2,[3,4],5], } ') }
+      it { assert_parse({ 'foo' => '[1,2,[3,4],5]', 'bar' => '[[1,2],]'}, ' { foo: [1,2,[3,4],5],bar: [[1,2],], } ') }
+    end
+
+    describe 'nested hash' do
+      it { assert_parse({ 'foo' => '{ }', 'bar' => '{}' }, 'foo: { }, bar: {}') }
+      it { assert_parse({ 'foo' => '{ bar: baz, hoge: fuga, }' }, 'foo: { bar: baz, hoge: fuga, }, ') }
+      it { assert_parse({ 'data' => '{ confirm: true, disable: false }', 'hello' => '{ world: foo, }' }, 'data: { confirm: true, disable: false }, :hello => { world: foo, },') }
+      it { assert_parse({ 'foo' => '{ }', 'bar' => '{}' }, ' { foo: { }, bar: {} } ') }
+      it { assert_parse({ 'foo' => '{ bar: baz, hoge: fuga, }' }, ' { foo: { bar: baz, hoge: fuga, }, } ') }
+      it { assert_parse({ 'data' => '{ confirm: true, disable: false }', 'hello' => '{ world: foo, }' }, ' { data: { confirm: true, disable: false }, :hello => { world: foo, }, } ') }
+    end
+
+    describe 'nested method' do
+      it { assert_parse({ 'foo' => 'bar(a, b)', 'hoge' => 'piyo(a, b,)' }, 'foo: bar(a, b), hoge: piyo(a, b,),') }
+      it { assert_parse({ 'foo' => 'bar(a, b)', 'hoge' => 'piyo(a, b,)' }, ' { foo: bar(a, b), hoge: piyo(a, b,), } ') }
+    end
+  end
+end

--- a/test/attribute_parser_test.rb
+++ b/test/attribute_parser_test.rb
@@ -1,5 +1,4 @@
 require 'test_helper'
-require 'haml/attribute_parser'
 
 class AttributeParserTeset < Haml::TestCase
   describe '.parse' do

--- a/test/attribute_parser_test.rb
+++ b/test/attribute_parser_test.rb
@@ -11,93 +11,95 @@ class AttributeParserTeset < Haml::TestCase
       end
     end
 
-    it { assert_parse({}, '') }
-    it { assert_parse({}, '{}') }
+    if Haml::AttributeParser.available?
+      it { assert_parse({}, '') }
+      it { assert_parse({}, '{}') }
 
-    describe 'invalid hash' do
-      it { assert_parse(nil, ' hash ') }
-      it { assert_parse(nil, 'hash, foo: bar') }
-      it { assert_parse(nil, ' {hash} ') }
-      it { assert_parse(nil, ' { hash, foo: bar } ') }
-    end
-
-    describe 'dynamic key' do
-      it { assert_parse(nil, 'foo => bar') }
-      it { assert_parse(nil, '[] => bar') }
-      it { assert_parse(nil, '[1,2,3] => bar') }
-    end
-
-    describe 'foo: bar' do
-      it { assert_parse({ '_' => '1' }, '_:1,') }
-      it { assert_parse({ 'foo' => 'bar' }, ' foo:  bar ') }
-      it { assert_parse({ 'a' => 'b', 'c' => ':d' }, 'a: b, c: :d') }
-      it { assert_parse({ 'a' => '[]', 'c' => '"d"' }, 'a: [], c: "d"') }
-      it { assert_parse({ '_' => '1' }, ' { _:1, } ') }
-      it { assert_parse({ 'foo' => 'bar' }, ' {  foo:  bar } ') }
-      it { assert_parse({ 'a' => 'b', 'c' => ':d' }, ' { a: b, c: :d } ') }
-      it { assert_parse({ 'a' => '[]', 'c' => '"d"' }, ' { a: [], c: "d" } ') }
-    end
-
-    describe ':foo => bar' do
-      it { assert_parse({ 'foo' => ':bar' }, '  :foo   =>  :bar  ') }
-      it { assert_parse({ '_' => '"foo"' }, ':_=>"foo"') }
-      it { assert_parse({ 'a' => '[]', 'c' => '""', 'b' => '"#{3}"' }, ':a => [], c: "", :b => "#{3}"') }
-      it { assert_parse({ 'foo' => ':bar' }, ' {   :foo   =>  :bar } ') }
-      it { assert_parse({ '_' => '"foo"' }, ' { :_=>"foo" } ') }
-      it { assert_parse({ 'a' => '[]', 'c' => '""', 'b' => '"#{3}"' }, ' { :a => [], c: "", :b => "#{3}" } ') }
-      it { assert_parse(nil, ':"f#{o}o" => bar') }
-      it { assert_parse(nil, ':"#{f}oo" => bar') }
-      it { assert_parse(nil, ':"#{foo}" => bar') }
-    end
-
-    describe '"foo" => bar' do
-      it { assert_parse({ 'foo' => '[1]' }, '"foo"=>[1]') }
-      it { assert_parse({ 'foo' => 'nya' }, " 'foo' => nya ") }
-      it { assert_parse({ 'foo' => 'bar' }, '%q[foo] => bar ') }
-      it { assert_parse({ 'foo' => '[1]' }, ' { "foo"=>[1] } ') }
-      it { assert_parse({ 'foo' => 'nya' }, " {  'foo' => nya } ") }
-      it { assert_parse({ 'foo' => 'bar' }, ' { %q[foo] => bar } ') }
-      it { assert_parse(nil, '"f#{o}o" => bar') }
-      it { assert_parse(nil, '"#{f}oo" => bar') }
-      it { assert_parse(nil, '"#{foo}" => bar') }
-      it { assert_parse({ 'f#{o}o' => 'bar' }, '%q[f#{o}o] => bar ') }
-      it { assert_parse({ 'f#{o}o' => 'bar' }, ' { %q[f#{o}o] => bar,  } ') }
-      it { assert_parse(nil, '%Q[f#{o}o] => bar ') }
-    end
-
-    if RUBY_VERSION >= '2.2.0'
-      describe '"foo": bar' do
-        it { assert_parse({ 'foo' => '()' }, '"foo":()') }
-        it { assert_parse({ 'foo' => 'nya' }, " 'foo': nya ") }
-        it { assert_parse({ 'foo' => '()' }, ' { "foo":() , }') }
-        it { assert_parse({ 'foo' => 'nya' }, " {  'foo': nya , }") }
-        it { assert_parse(nil, '"f#{o}o": bar') }
-        it { assert_parse(nil, '"#{f}oo": bar') }
-        it { assert_parse(nil, '"#{foo}": bar') }
+      describe 'invalid hash' do
+        it { assert_parse(nil, ' hash ') }
+        it { assert_parse(nil, 'hash, foo: bar') }
+        it { assert_parse(nil, ' {hash} ') }
+        it { assert_parse(nil, ' { hash, foo: bar } ') }
       end
-    end
 
-    describe 'nested array' do
-      it { assert_parse({ 'foo' => '[1,2,]' }, 'foo: [1,2,],') }
-      it { assert_parse({ 'foo' => '[1,2,[3,4],5]' }, 'foo: [1,2,[3,4],5],') }
-      it { assert_parse({ 'foo' => '[1,2,[3,4],5]', 'bar' => '[[1,2],]'}, 'foo: [1,2,[3,4],5],bar: [[1,2],],') }
-      it { assert_parse({ 'foo' => '[1,2,]' }, ' { foo: [1,2,], } ') }
-      it { assert_parse({ 'foo' => '[1,2,[3,4],5]' }, ' { foo: [1,2,[3,4],5], } ') }
-      it { assert_parse({ 'foo' => '[1,2,[3,4],5]', 'bar' => '[[1,2],]'}, ' { foo: [1,2,[3,4],5],bar: [[1,2],], } ') }
-    end
+      describe 'dynamic key' do
+        it { assert_parse(nil, 'foo => bar') }
+        it { assert_parse(nil, '[] => bar') }
+        it { assert_parse(nil, '[1,2,3] => bar') }
+      end
 
-    describe 'nested hash' do
-      it { assert_parse({ 'foo' => '{ }', 'bar' => '{}' }, 'foo: { }, bar: {}') }
-      it { assert_parse({ 'foo' => '{ bar: baz, hoge: fuga, }' }, 'foo: { bar: baz, hoge: fuga, }, ') }
-      it { assert_parse({ 'data' => '{ confirm: true, disable: false }', 'hello' => '{ world: foo, }' }, 'data: { confirm: true, disable: false }, :hello => { world: foo, },') }
-      it { assert_parse({ 'foo' => '{ }', 'bar' => '{}' }, ' { foo: { }, bar: {} } ') }
-      it { assert_parse({ 'foo' => '{ bar: baz, hoge: fuga, }' }, ' { foo: { bar: baz, hoge: fuga, }, } ') }
-      it { assert_parse({ 'data' => '{ confirm: true, disable: false }', 'hello' => '{ world: foo, }' }, ' { data: { confirm: true, disable: false }, :hello => { world: foo, }, } ') }
-    end
+      describe 'foo: bar' do
+        it { assert_parse({ '_' => '1' }, '_:1,') }
+        it { assert_parse({ 'foo' => 'bar' }, ' foo:  bar ') }
+        it { assert_parse({ 'a' => 'b', 'c' => ':d' }, 'a: b, c: :d') }
+        it { assert_parse({ 'a' => '[]', 'c' => '"d"' }, 'a: [], c: "d"') }
+        it { assert_parse({ '_' => '1' }, ' { _:1, } ') }
+        it { assert_parse({ 'foo' => 'bar' }, ' {  foo:  bar } ') }
+        it { assert_parse({ 'a' => 'b', 'c' => ':d' }, ' { a: b, c: :d } ') }
+        it { assert_parse({ 'a' => '[]', 'c' => '"d"' }, ' { a: [], c: "d" } ') }
+      end
 
-    describe 'nested method' do
-      it { assert_parse({ 'foo' => 'bar(a, b)', 'hoge' => 'piyo(a, b,)' }, 'foo: bar(a, b), hoge: piyo(a, b,),') }
-      it { assert_parse({ 'foo' => 'bar(a, b)', 'hoge' => 'piyo(a, b,)' }, ' { foo: bar(a, b), hoge: piyo(a, b,), } ') }
+      describe ':foo => bar' do
+        it { assert_parse({ 'foo' => ':bar' }, '  :foo   =>  :bar  ') }
+        it { assert_parse({ '_' => '"foo"' }, ':_=>"foo"') }
+        it { assert_parse({ 'a' => '[]', 'c' => '""', 'b' => '"#{3}"' }, ':a => [], c: "", :b => "#{3}"') }
+        it { assert_parse({ 'foo' => ':bar' }, ' {   :foo   =>  :bar } ') }
+        it { assert_parse({ '_' => '"foo"' }, ' { :_=>"foo" } ') }
+        it { assert_parse({ 'a' => '[]', 'c' => '""', 'b' => '"#{3}"' }, ' { :a => [], c: "", :b => "#{3}" } ') }
+        it { assert_parse(nil, ':"f#{o}o" => bar') }
+        it { assert_parse(nil, ':"#{f}oo" => bar') }
+        it { assert_parse(nil, ':"#{foo}" => bar') }
+      end
+
+      describe '"foo" => bar' do
+        it { assert_parse({ 'foo' => '[1]' }, '"foo"=>[1]') }
+        it { assert_parse({ 'foo' => 'nya' }, " 'foo' => nya ") }
+        it { assert_parse({ 'foo' => 'bar' }, '%q[foo] => bar ') }
+        it { assert_parse({ 'foo' => '[1]' }, ' { "foo"=>[1] } ') }
+        it { assert_parse({ 'foo' => 'nya' }, " {  'foo' => nya } ") }
+        it { assert_parse({ 'foo' => 'bar' }, ' { %q[foo] => bar } ') }
+        it { assert_parse(nil, '"f#{o}o" => bar') }
+        it { assert_parse(nil, '"#{f}oo" => bar') }
+        it { assert_parse(nil, '"#{foo}" => bar') }
+        it { assert_parse({ 'f#{o}o' => 'bar' }, '%q[f#{o}o] => bar ') }
+        it { assert_parse({ 'f#{o}o' => 'bar' }, ' { %q[f#{o}o] => bar,  } ') }
+        it { assert_parse(nil, '%Q[f#{o}o] => bar ') }
+      end
+
+      if RUBY_VERSION >= '2.2.0'
+        describe '"foo": bar' do
+          it { assert_parse({ 'foo' => '()' }, '"foo":()') }
+          it { assert_parse({ 'foo' => 'nya' }, " 'foo': nya ") }
+          it { assert_parse({ 'foo' => '()' }, ' { "foo":() , }') }
+          it { assert_parse({ 'foo' => 'nya' }, " {  'foo': nya , }") }
+          it { assert_parse(nil, '"f#{o}o": bar') }
+          it { assert_parse(nil, '"#{f}oo": bar') }
+          it { assert_parse(nil, '"#{foo}": bar') }
+        end
+      end
+
+      describe 'nested array' do
+        it { assert_parse({ 'foo' => '[1,2,]' }, 'foo: [1,2,],') }
+        it { assert_parse({ 'foo' => '[1,2,[3,4],5]' }, 'foo: [1,2,[3,4],5],') }
+        it { assert_parse({ 'foo' => '[1,2,[3,4],5]', 'bar' => '[[1,2],]'}, 'foo: [1,2,[3,4],5],bar: [[1,2],],') }
+        it { assert_parse({ 'foo' => '[1,2,]' }, ' { foo: [1,2,], } ') }
+        it { assert_parse({ 'foo' => '[1,2,[3,4],5]' }, ' { foo: [1,2,[3,4],5], } ') }
+        it { assert_parse({ 'foo' => '[1,2,[3,4],5]', 'bar' => '[[1,2],]'}, ' { foo: [1,2,[3,4],5],bar: [[1,2],], } ') }
+      end
+
+      describe 'nested hash' do
+        it { assert_parse({ 'foo' => '{ }', 'bar' => '{}' }, 'foo: { }, bar: {}') }
+        it { assert_parse({ 'foo' => '{ bar: baz, hoge: fuga, }' }, 'foo: { bar: baz, hoge: fuga, }, ') }
+        it { assert_parse({ 'data' => '{ confirm: true, disable: false }', 'hello' => '{ world: foo, }' }, 'data: { confirm: true, disable: false }, :hello => { world: foo, },') }
+        it { assert_parse({ 'foo' => '{ }', 'bar' => '{}' }, ' { foo: { }, bar: {} } ') }
+        it { assert_parse({ 'foo' => '{ bar: baz, hoge: fuga, }' }, ' { foo: { bar: baz, hoge: fuga, }, } ') }
+        it { assert_parse({ 'data' => '{ confirm: true, disable: false }', 'hello' => '{ world: foo, }' }, ' { data: { confirm: true, disable: false }, :hello => { world: foo, }, } ') }
+      end
+
+      describe 'nested method' do
+        it { assert_parse({ 'foo' => 'bar(a, b)', 'hoge' => 'piyo(a, b,)' }, 'foo: bar(a, b), hoge: piyo(a, b,),') }
+        it { assert_parse({ 'foo' => 'bar(a, b)', 'hoge' => 'piyo(a, b,)' }, ' { foo: bar(a, b), hoge: piyo(a, b,), } ') }
+      end
     end
   end
 end

--- a/test/temple_line_counter_test.rb
+++ b/test/temple_line_counter_test.rb
@@ -12,6 +12,16 @@ class TempleLineCounterTest < Haml::TestCase
      [:static, "foo\nbar\nbaz"],
      [:dynamic, "foo\nbar\nbaz"],
     ],
+    [:case,
+     ["'a\nb', false", [:static, "hello\n"]],
+     [:else, [:code, "raise 'error\n'"]],
+    ],
+    [:escape, true, [:dynamic, "foo\nbar"]],
+    [:escape, :once, [:dynamic, "foo\nbar"]],
+    [:escape, false, [:dynamic, "foo\nbar"]],
+    [:escape, true, [:static, "foo\nbar"]],
+    [:escape, :once, [:static, "foo\nbar"]],
+    [:escape, false, [:dynamic, "foo\nbar"]],
   ]
 
   def test_count_lines

--- a/test/temple_line_counter_test.rb
+++ b/test/temple_line_counter_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class TempleLineCounterTest < Haml::TestCase
+  TESTED_TEMPLES = [
+    [:multi,
+     [:code, "foo"],
+     [:static, "bar"],
+     [:dynamic, "baz"],
+    ],
+    [:multi,
+     [:code, "foo\nbar\nbaz"],
+     [:static, "foo\nbar\nbaz"],
+     [:dynamic, "foo\nbar\nbaz"],
+    ],
+  ]
+
+  def test_count_lines
+    TESTED_TEMPLES.each do |temple|
+      code = Haml::TempleEngine.chain.inject(temple) do |exp, (symbol, filter)|
+        case symbol
+        when :Parser, :Compiler
+          exp
+        else
+          filter.call(Haml::TempleEngine).call(exp)
+        end
+      end
+      assert_equal code.count("\n"), Haml::TempleLineCounter.count_lines(temple)
+    end
+  end
+end


### PR DESCRIPTION
## Changes
- Implement attribute compiler using Temple
  - To compile attributes, introduce attribute parser using Ripper imprted from Hamlit.
     - On Ripper-less platforms, attribute compiler isn't applied but it fallbacks to current implementation.
  - For almost all cases, we can render attributes without `Haml::Buffer#attributes`, which is a bottleneck of Haml 4.
- Apply Temple's static analyzer to render attributes beforehand

All tests passed without changing behaviors in this branch. They are the last changes I want to release in Haml 5.

## Benchmark
With Ruby 2.4.0 and  [k0kubun/haml_bench/templates/slim_bench.haml](https://github.com/k0kubun/haml_bench/blob/8d8cc944bdc1138c58629109b6ecc06e7d5ea1a7/templates/slim_bench.haml),

### before (current Haml's master)
[the result on Travis](https://travis-ci.org/k0kubun/haml_bench/jobs/199977841)

```
Rendering: /home/travis/build/k0kubun/haml_bench/templates/slim_bench.haml
Warming up --------------------------------------
          haml 4.0.7     1.621k i/100ms
   haml 5.0.0.beta.2     2.651k i/100ms
Calculating -------------------------------------
          haml 4.0.7     17.383k (± 3.6%) i/s -     87.534k in   5.042719s
   haml 5.0.0.beta.2     29.101k (± 2.7%) i/s -    145.805k in   5.014494s
Comparison:
   haml 5.0.0.beta.2:    29101.0 i/s
          haml 4.0.7:    17383.1 i/s - 1.67x  slower
```

### after (this branch)
[the result on Travis](https://travis-ci.org/k0kubun/haml_bench/jobs/199978005)

**Now Haml 5 is 3.70x faster than Haml 4.**

```
Rendering: /home/travis/build/k0kubun/haml_bench/templates/slim_bench.haml
Warming up --------------------------------------
          haml 4.0.7     1.698k i/100ms
   haml 5.0.0.beta.2     5.321k i/100ms
Calculating -------------------------------------
          haml 4.0.7     16.892k (± 9.7%) i/s -     84.900k in   5.078316s
   haml 5.0.0.beta.2     62.422k (± 8.4%) i/s -    313.939k in   5.079310s
Comparison:
   haml 5.0.0.beta.2:    62421.8 i/s
          haml 4.0.7:    16892.4 i/s - 3.70x  slower
```

Compared to other template engines ([the same build on Travis](https://travis-ci.org/k0kubun/haml_bench/jobs/199978005)), Haml is not so slow now.

```
Rendering: /home/travis/build/k0kubun/haml_bench/templates/slim_bench.haml
Warming up --------------------------------------
          haml 4.0.7     1.780k i/100ms
   haml 5.0.0.beta.2     5.914k i/100ms
          faml 0.8.1     9.624k i/100ms
        hamlit 2.7.5    12.317k i/100ms
          slim 3.0.7     9.419k i/100ms
Calculating -------------------------------------
          haml 4.0.7     18.322k (± 3.2%) i/s -     92.560k in   5.057934s
   haml 5.0.0.beta.2     62.195k (± 1.2%) i/s -    313.442k in   5.040431s
          faml 0.8.1     99.823k (± 1.5%) i/s -    500.448k in   5.014438s
        hamlit 2.7.5    136.294k (± 2.0%) i/s -    689.752k in   5.062706s
          slim 3.0.7    106.476k (± 1.5%) i/s -    536.883k in   5.043343s
Comparison:
        hamlit 2.7.5:   136293.7 i/s
          slim 3.0.7:   106475.8 i/s - 1.28x  slower
          faml 0.8.1:    99823.3 i/s - 1.37x  slower
   haml 5.0.0.beta.2:    62195.2 i/s - 2.19x  slower
          haml 4.0.7:    18321.7 i/s - 7.44x  slower
```