### PR TITLE
Raise exception for unsafe attribute name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * The `haml` command's debug option (`-d`) no longer executes the Haml code, but
   rather checks the generated Ruby syntax for errors.
 * Support Rails 5.1 Erubi template handler.
-* Raise `Haml::InvalidAttributeNameError` when data attribute name includes invalid characters. (Takashi Kokubun)
+* Raise `Haml::InvalidAttributeNameError` when attribute name includes invalid characters. (Takashi Kokubun)
 * Drop dynamic quotes support and always escape `'` for `escape_html`/`escape_attrs` instead.
   Also, escaped results are slightly changed and always unified to the same characters. (Takashi Kokubun)
 * Don't preserve newlines in attributes. (Takashi Kokubun)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 * The `haml` command's debug option (`-d`) no longer executes the Haml code, but
   rather checks the generated Ruby syntax for errors.
 * Support Rails 5.1 Erubi template handler.
+* Raise `Haml::InvalidAttributeNameError` when data attribute name includes invalid characters. (Takashi Kokubun)
 * Drop dynamic quotes support and always escape `'` for `escape_html`/`escape_attrs` instead.
   Also, escaped results are slightly changed and always unified to the same characters. (Takashi Kokubun)
 * Don't preserve newlines in attributes. (Takashi Kokubun)

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -15,11 +15,7 @@ module Haml
             data_attributes = attributes.delete(key)
             data_attributes = flatten_data_attributes(data_attributes, '', join_char)
             data_attributes = build_data_keys(data_attributes, hyphenate_data_attrs, key)
-            data_attributes.keys.each do |key|
-              if key =~ INVALID_ATTRIBUTE_NAME_REGEX
-                raise InvalidAttributeNameError.new("Invalid attribute name '#{key}' was built!")
-              end
-            end
+            verify_attribute_names!(data_attributes.keys)
             attributes = data_attributes.merge(attributes)
           end
         end
@@ -95,6 +91,14 @@ module Haml
       def merge_values(key, *values)
         values.inject(nil) do |to, from|
           merge_value(key, to, from)
+        end
+      end
+
+      def verify_attribute_names!(attribute_names)
+        attribute_names.each do |attribute_name|
+          if attribute_name =~ INVALID_ATTRIBUTE_NAME_REGEX
+            raise InvalidAttributeNameError.new("Invalid attribute name '#{attribute_name}' was rendered")
+          end
         end
       end
 

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -1,6 +1,9 @@
 # frozen_string_literal: true
 module Haml
   module AttributeBuilder
+    # https://html.spec.whatwg.org/multipage/syntax.html#attributes-2
+    INVALID_ATTRIBUTE_NAME_REGEX = /[ \0"'>\/=]/
+
     class << self
       def build_attributes(is_html, attr_wrapper, escape_attrs, hyphenate_data_attrs, attributes = {})
         # @TODO this is an absolutely ridiculous amount of arguments. At least
@@ -12,6 +15,11 @@ module Haml
             data_attributes = attributes.delete(key)
             data_attributes = flatten_data_attributes(data_attributes, '', join_char)
             data_attributes = build_data_keys(data_attributes, hyphenate_data_attrs, key)
+            data_attributes.keys.each do |key|
+              if key =~ INVALID_ATTRIBUTE_NAME_REGEX
+                raise InvalidAttributeNameError.new("Invalid attribute name '#{key}' was built!")
+              end
+            end
             attributes = data_attributes.merge(attributes)
           end
         end

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -58,9 +58,10 @@ module Haml
         end
         hash
       end
-      attribute_values   = build_attribute_values(attributes, parsed_hashes)
-      values_by_base_key = attribute_values.group_by(&:base_key)
+      attribute_values = build_attribute_values(attributes, parsed_hashes)
+      AttributeBuilder.verify_attribute_names!(attribute_values.map(&:key))
 
+      values_by_base_key = attribute_values.group_by(&:base_key)
       [:multi, *values_by_base_key.keys.sort.map { |base_key|
         compile_attribute_values(values_by_base_key[base_key])
       }]

--- a/lib/haml/error.rb
+++ b/lib/haml/error.rb
@@ -58,4 +58,6 @@ END
   # It's not particularly interesting,
   # except in that it's a subclass of {Haml::Error}.
   class SyntaxError < Error; end
+
+  class InvalidAttributeNameError < Error; end
 end

--- a/lib/haml/error.rb
+++ b/lib/haml/error.rb
@@ -59,5 +59,5 @@ END
   # except in that it's a subclass of {Haml::Error}.
   class SyntaxError < Error; end
 
-  class InvalidAttributeNameError < Error; end
+  class InvalidAttributeNameError < SyntaxError; end
 end

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -2066,6 +2066,15 @@ HAML
     assert_equal "<p class='hello' data-trace='foo:1'></p>", result
   end
 
+  def test_unsafe_attribute_name_raises_invalid_attribute_name_error
+    assert_raises(Haml::InvalidAttributeNameError) do
+      render(<<-HAML)
+- params = { 'x /><script>alert(1);</script><div x' => 'hello' }
+%div{ data: params }
+      HAML
+    end
+  end
+
   private
 
   def assert_valid_encoding_comment(comment)

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1142,7 +1142,6 @@ HAML
   end
 
   def test_attrs_parsed_correctly
-    assert_equal("<p boom=>biddly='bar =&gt; baz'></p>\n", render("%p{'boom=>biddly' => 'bar => baz'}"))
     assert_equal("<p foo,bar='baz, qux'></p>\n", render("%p{'foo,bar' => 'baz, qux'}"))
     assert_equal("<p escaped='quo4te'></p>\n", render("%p{ :escaped => \"quo\#{2 + 2}te\"}"))
   end
@@ -2066,11 +2065,19 @@ HAML
     assert_equal "<p class='hello' data-trace='foo:1'></p>", result
   end
 
-  def test_unsafe_attribute_name_raises_invalid_attribute_name_error
+  def test_unsafe_dynamic_attribute_name_raises_invalid_attribute_name_error
     assert_raises(Haml::InvalidAttributeNameError) do
       render(<<-HAML)
 - params = { 'x /><script>alert(1);</script><div x' => 'hello' }
 %div{ data: params }
+      HAML
+    end
+  end
+
+  def test_unsafe_static_attribute_name_raises_invalid_attribute_name_error
+    assert_raises(Haml::InvalidAttributeNameError) do
+      render(<<-HAML)
+%div{ 'x /><script>alert(1);</script><div x' => 'hello' }
       HAML
     end
   end


### PR DESCRIPTION
close https://github.com/haml/haml/issues/891

Developers should never embed user's input as attribute name. User's input can include invalid characters defined in [HTML spec](https://html.spec.whatwg.org/multipage/syntax.html#attributes-2). So I changed Haml to raise an error for that case.
For some exceptional cases that developers want to use user's input like `params`'s keys in attribute name, they should handle this exception and respond 4XX errors. It should be 5XX for normal cases.