### PR TITLE
Resolve overhead of calling Haml::Buffer#format_script

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -277,9 +277,19 @@ module Haml
     end
 
     def build_script_formatter(text, opts)
-      args = [:preserve_script, :preserve_tag, :escape_html, :nuke_inner_whitespace]
-      args.map! {|name| !!opts[name]}
-      "_hamlout.format_script(#{text},#{args.join(',')});"
+      text = "(#{text}).to_s"
+      if opts[:escape_html]
+        text = "::Haml::Helpers.html_escape(#{text})"
+      end
+      if opts[:nuke_inner_whitespace]
+        text = "(#{text}).strip"
+      end
+      if opts[:preserve_tag]
+        text = "::Haml::Helpers.preserve(#{text})"
+      elsif opts[:preserve_script]
+        text = "::Haml::Helpers.find_and_preserve(#{text}, _hamlout.options[:preserve])"
+      end
+      "_hamlout.fix_textareas!(#{text});"
     end
 
     def push_generated_script(text)

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -261,14 +261,10 @@ module Haml
     def push_script(text, opts = {})
       return if @options.suppress_eval?
 
-      args = [:preserve_script, :preserve_tag, :escape_html, :nuke_inner_whitespace]
-      args.map! {|name| !!opts[name]}
-
       no_format = !(opts[:preserve_script] || opts[:preserve_tag] || opts[:escape_html])
 
       unless block_given?
-        format_script_method = "_hamlout.format_script((#{text}\n),#{args.join(',')});"
-        push_generated_script(no_format ? "(#{text}\n).to_s" : format_script_method)
+        push_generated_script(no_format ? "(#{text}\n).to_s" : build_script_formatter("(#{text}\n)", opts))
         push_text("\n") unless opts[:in_tag] || opts[:nuke_inner_whitespace]
         return
       end
@@ -277,8 +273,13 @@ module Haml
       push_silent "haml_temp = #{text}"
       yield
       push_silent('end', :can_suppress) unless @node.value[:dont_push_end]
-      format_script_method = "_hamlout.format_script(haml_temp,#{args.join(',')});"
-      @temple << [:dynamic, no_format ? "haml_temp.to_s;" : format_script_method]
+      @temple << [:dynamic, no_format ? 'haml_temp.to_s;' : build_script_formatter('haml_temp', opts)]
+    end
+
+    def build_script_formatter(text, opts)
+      args = [:preserve_script, :preserve_tag, :escape_html, :nuke_inner_whitespace]
+      args.map! {|name| !!opts[name]}
+      "_hamlout.format_script(#{text},#{args.join(',')});"
     end
 
     def push_generated_script(text)


### PR DESCRIPTION
I changed to generate `_hamlout.fix_textareas!(::Haml::Helpers.html_escape(i[:name].to_s))` instead of `_hamlout.format_script(i[:name],false,false,true,false)`.

With this change, we can avoid some unnecessary method calls' overhead without changing behaviors.

## benchmark
With Ruby 2.4.0 and [k0kubun/haml_bench/templates/slim_bench.haml](https://github.com/k0kubun/haml_bench/blob/833f04306bc138261d8d2102a4f0cceb3a78eca7/templates/slim_bench.haml),

### [before](https://travis-ci.org/k0kubun/haml_bench/jobs/205838755)

```
Rendering: /home/travis/build/k0kubun/haml_bench/templates/slim_bench.haml
Warming up --------------------------------------
          haml 4.0.7     1.648k i/100ms
   haml 5.0.0.beta.2     5.737k i/100ms
Calculating -------------------------------------
          haml 4.0.7     18.380k (± 2.4%) i/s -     92.288k in   5.024238s
   haml 5.0.0.beta.2     64.617k (± 1.4%) i/s -    327.009k in   5.061712s
Comparison:
   haml 5.0.0.beta.2:    64617.1 i/s
          haml 4.0.7:    18380.4 i/s - 3.52x  slower
```

### [after](https://travis-ci.org/k0kubun/haml_bench/jobs/205847380)
```
Rendering: /home/travis/build/k0kubun/haml_bench/templates/slim_bench.haml
Warming up --------------------------------------
          haml 4.0.7     1.441k i/100ms
   haml 5.0.0.beta.2     6.074k i/100ms
Calculating -------------------------------------
          haml 4.0.7     16.558k (± 8.0%) i/s -     83.578k in   5.084622s
   haml 5.0.0.beta.2     65.486k (±11.2%) i/s -    321.922k in   5.028385s
Comparison:
   haml 5.0.0.beta.2:    65486.2 i/s
          haml 4.0.7:    16558.4 i/s - 3.95x  slower
```