### PR TITLE
Do not load modules early when in rails

### DIFF
--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -1,41 +1,19 @@
-if defined?(ActiveSupport)
-  require 'haml/template/options'
-  ActiveSupport.on_load(:before_initialize) do
-    ActiveSupport.on_load(:action_view) do
-      require "haml/template"
-    end
-  end
-end
+require 'haml/template/options'
 
 module Haml
   class Railtie < ::Rails::Railtie
     initializer :haml do |app|
-      if defined?(ActiveSupport)
-        ActiveSupport.on_load(:before_initialize) do
-          ActiveSupport.on_load(:action_view) do
-            if defined?(::Sass::Rails::SassTemplate) && app.config.assets.enabled
-              require "haml/sass_rails_filter"
-            end
-          end
-        end
-      else
+
+      ActiveSupport.on_load(:action_view) do
         require "haml/template"
+
         if defined?(::Sass::Rails::SassTemplate) && app.config.assets.enabled
           require "haml/sass_rails_filter"
         end
+
+        require "haml/helpers/safe_erubis_template"
+        Haml::Filters::Erb.template_class = Haml::SafeErubisTemplate
       end
     end
   end
-end
-
-if defined?(ActiveSupport)
-  ActiveSupport.on_load(:before_initialize) do
-    ActiveSupport.on_load(:action_view) do
-      require "haml/helpers/safe_erubis_template"
-      Haml::Filters::Erb.template_class = Haml::SafeErubisTemplate
-    end
-  end
-else
-  require "haml/helpers/safe_erubis_template"
-  Haml::Filters::Erb.template_class = Haml::SafeErubisTemplate
 end

--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -10,13 +10,33 @@ end
 module Haml
   class Railtie < ::Rails::Railtie
     initializer :haml do |app|
-      require "haml/template"
-      if defined?(::Sass::Rails::SassTemplate) && app.config.assets.enabled
-        require "haml/sass_rails_filter"
+      if defined?(ActiveSupport)
+        ActiveSupport.on_load(:before_initialize) do
+          ActiveSupport.on_load(:action_view) do
+            if defined?(::Sass::Rails::SassTemplate) && app.config.assets.enabled
+              require "haml/sass_rails_filter"
+            end
+          end
+        end
+      else
+        require "haml/template"
+        if defined?(::Sass::Rails::SassTemplate) && app.config.assets.enabled
+          require "haml/sass_rails_filter"
+        end
       end
     end
   end
 end
 
-require "haml/helpers/safe_erubis_template"
-Haml::Filters::Erb.template_class = Haml::SafeErubisTemplate
+if defined?(ActiveSupport)
+  require 'haml/template/options'
+  ActiveSupport.on_load(:before_initialize) do
+    ActiveSupport.on_load(:action_view) do
+      require "haml/helpers/safe_erubis_template"
+      Haml::Filters::Erb.template_class = Haml::SafeErubisTemplate
+    end
+  end
+else
+  require "haml/helpers/safe_erubis_template"
+  Haml::Filters::Erb.template_class = Haml::SafeErubisTemplate
+end

--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -29,7 +29,6 @@ module Haml
 end
 
 if defined?(ActiveSupport)
-  require 'haml/template/options'
   ActiveSupport.on_load(:before_initialize) do
     ActiveSupport.on_load(:action_view) do
       require "haml/helpers/safe_erubis_template"


### PR DESCRIPTION
Early loading causes a conflict with rspec and view specs.

See issue to reproduce: https://github.com/haml/haml/issues/883

I tried to ensure all the modules are loaded using the `ActiveSupport.on_load` mechanism to avoid further problems. Because I'm not sure all the situations that haml is used in, I did a fairly robust (conservative) approach.

This fix should be forward ported to `haml5`.