### PR TITLE
Fix buffer_options test to assume Rails environment

### DIFF
--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -25,12 +25,6 @@ module Haml
           Haml::Filters::Erb.template_class = Haml::SafeErubisTemplate
         end
       end
-
-      Haml::Options.buffer_defaults.keys.each do |key|
-        if Haml::Template.options.key?(key)
-          Haml::Options.buffer_defaults[key] = Haml::Template.options[key]
-        end
-      end
     end
   end
 end

--- a/lib/haml/template/options.rb
+++ b/lib/haml/template/options.rb
@@ -6,11 +6,20 @@ module Haml
   module Template
     extend self
 
-    @options = {}
+    class Options < Hash
+      def []=(key, value)
+        super
+        if Haml::Options.buffer_defaults.key?(key)
+          Haml::Options.buffer_defaults[key] = value
+        end
+      end
+    end
+
+    @options = ::Haml::Template::Options.new
     # The options hash for Haml when used within Rails.
     # See {file:REFERENCE.md#options the Haml options documentation}.
     #
-    # @return [{Symbol => Object}]
+    # @return [Haml::Template::Options<Symbol => Object>]
     attr_accessor :options
   end
 end

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -9,10 +9,11 @@ module Haml
       )
     end
 
-    def test_buffer_defaults_values_are_default_options
+    def test_buffer_defaults_values_are_the_same_as_rails_defaults
+      rails_defaults = Haml::Options.defaults.merge(Haml::Template.options)
       Haml::Options.buffer_option_keys.each do |key|
         assert_equal(
-          Haml::Options.defaults[key],
+          rails_defaults[key],
           Haml::Options.buffer_defaults[key], "key: #{key}"
         )
       end


### PR DESCRIPTION
Fix test failure caused by https://github.com/haml/haml/commit/c9472d0633d8c93c642876c2100f57a9ab21721a.

@amatsuda WDYT?