### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ In fact, when you're using the `<div>` tag, it becomes _even easier_. Because
 `<div>` is such a common element, a tag without a name defaults to a div. So
 
 ~~~haml
-#foo Hello!
+# foo Hello!
 ~~~
 
 becomes


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
