### PR TITLE
Docs: Help people upgrade to 5 by classifying changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,29 @@
 Released on April 26, 2017
 ([diff](https://github.com/haml/haml/compare/4.0.7...v5.0.0)).
 
+Breaking Changes
+
 * Haml now requires Ruby 2.0.0 or above.
 * Rails 3 is no longer supported, matching the official
   [Maintenance Policy for Ruby on Rails](http://weblog.rubyonrails.org/2013/2/24/maintenance-policy-for-ruby-on-rails/).
   (Tee Parham)
+* The `haml` command's debug option (`-d`) no longer executes the Haml code, but
+  rather checks the generated Ruby syntax for errors.
+* Drop parser/compiler accessor from `Haml::Engine`. Modify `Haml::Engine#initialize` options
+  or `Haml::Template.options` instead. (Takashi Kokubun)
+
+Added
+
+* Add a tracing option. When enabled, Haml will output a data-trace attribute on each tag showing the path
+  to the source Haml file from which it was generated. Thanks [Alex Babkin](https://github.com/ababkin).
+* Add `haml_tag_if` to render a block, conditionally wrapped in another element (Matt Wildig)
+* Support Rails 5.1 Erubi template handler.
+* Support Sprockets 3. Thanks [Sam Davies](https://github.com/samphilipd) and [Jeremy Venezia](https://github.com/jvenezia).
+* Analyze attribute values by Ripper and render static attributes beforehand. (Takashi Kokubun)
+* Optimize attribute rendering about 3x faster. (Takashi Kokubun)
+
+Fixed
+
 * Fix for attribute merging. When an attribute method (or literal nested hash)
   was used in an old style attribute hash and there is also a (non-static) new
   style hash there is an error. The fix can result in different behavior in
@@ -17,15 +36,8 @@ Released on April 26, 2017
 * Make escape_once respect hexadecimal references. (Matt Wildig)
 * General performance and memory usage improvements. (Akira Matsuda)
 * Don't treat the 'data' attribute specially when merging attribute hashes. (Matt Wildig and Norman Clarke)
-* Add a tracing option. When enabled, Haml will output a data-trace attribute on each tag showing the path
-  to the source Haml file from which it was generated. Thanks [Alex Babkin](https://github.com/ababkin).
 * Fix #@foo and #$foo style interpolation that was not working in html_safe mode. (Akira Matsuda)
-* Add `haml_tag_if` to render a block, conditionally wrapped in another element (Matt Wildig)
 * Escape Ruby script interpolated in filters. (Matt Wildig)
-* The `haml` command's debug option (`-d`) no longer executes the Haml code, but
-  rather checks the generated Ruby syntax for errors.
-* Support Rails 5.1 Erubi template handler.
-* Support Sprockets 3. Thanks [Sam Davies](https://github.com/samphilipd) and [Jeremy Venezia](https://github.com/jvenezia).
 * Allow `@` as tag's class name. Thanks [Joe Bartlett](https://github.com/redoPop).
 * Raise `Haml::InvalidAttributeNameError` when attribute name includes invalid characters. (Takashi Kokubun)
 * Drop dynamic quotes support and always escape `'` for `escape_html`/`escape_attrs` instead.
@@ -33,11 +45,7 @@ Released on April 26, 2017
 * Don't preserve newlines in attributes. (Takashi Kokubun)
 * Add temple gem as dependency and create `Haml::TempleEngine` class.
   Some methods in `Haml::Compiler` are migrated to `Haml::TempleEngine`. (Takashi Kokubun)
-* Drop parser/compiler accessor from `Haml::Engine`. Modify `Haml::Engine#initialize` options
-  or `Haml::Template.options` instead. (Takashi Kokubun)
 * Don't ignore unexpected exceptions on initializing `ActionView::OutputBuffer`. (Takashi Kokubun)
-* Analyze attribute values by Ripper and render static attributes beforehand. (Takashi Kokubun)
-* Optimize attribute rendering about 3x faster. (Takashi Kokubun)
 
 ## 4.0.7
 


### PR DESCRIPTION
By identifying breaking changes in the changelog, it will be much easier for people to upgrade to 5.

Not being a HAML expert, I may have missed some breaking changes, but this should be a good start.