### PR TITLE
Use Erubi/Erubis only in Rails template handler

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -14,6 +14,7 @@ module Haml
       @to_merge    = []
       @temple      = [:multi]
       @node        = nil
+      @filters     = Filters.defined.merge(options[:filters])
       @attribute_compiler = AttributeCompiler.new(@options)
     end
 
@@ -168,7 +169,7 @@ module Haml
     end
 
     def compile_filter
-      unless filter = Filters.defined[@node.value[:name]]
+      unless filter = @filters[@node.value[:name]]
         name = @node.value[:name]
         if ["maruku", "textile"].include?(name)
           raise Error.new(Error.message(:install_haml_contrib, name), @node.line - 1)

--- a/lib/haml/helpers/safe_erubi_template.rb
+++ b/lib/haml/helpers/safe_erubi_template.rb
@@ -15,13 +15,5 @@ module Haml
       @options.merge! engine_class: Haml::ErubiTemplateHandler
       super
     end
-
-    def precompiled_preamble(locals)
-      [super, "@output_buffer = ActionView::OutputBuffer.new;"].join("\n")
-    end
-
-    def precompiled_postamble(locals)
-      [super, '@output_buffer.to_s'].join("\n")
-    end
   end
 end

--- a/lib/haml/options.rb
+++ b/lib/haml/options.rb
@@ -164,6 +164,9 @@ module Haml
     # the path will be the full path.
     attr_accessor :trace
 
+    # Key is filter name in String and value is Class to use. Defaults to {}.
+    attr_accessor :filters
+
     def initialize(values = {}, &block)
       defaults.each {|k, v| instance_variable_set :"@#{k}", v}
       values.each {|k, v| send("#{k}=", v) if defaults.has_key?(k) && !v.nil?}

--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -9,6 +9,14 @@ if (activesupport_spec = Gem.loaded_specs['activesupport'])
 end
 
 module Haml
+  module Filters
+    module RailsErb
+      extend Plain
+      extend TiltFilter
+      extend PrecompiledTiltFilter
+    end
+  end
+
   class Railtie < ::Rails::Railtie
     initializer :haml do |app|
       ActiveSupport.on_load(:action_view) do
@@ -20,11 +28,12 @@ module Haml
 
         if defined? Erubi
           require "haml/helpers/safe_erubi_template"
-          Haml::Filters::Erb.template_class = Haml::SafeErubiTemplate
+          Haml::Filters::RailsErb.template_class = Haml::SafeErubiTemplate
         else
           require "haml/helpers/safe_erubis_template"
-          Haml::Filters::Erb.template_class = Haml::SafeErubisTemplate
+          Haml::Filters::RailsErb.template_class = Haml::SafeErubisTemplate
         end
+        Haml::Template.options[:filters] = { 'erb' => Haml::Filters::RailsErb }
       end
     end
   end

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -25,6 +25,7 @@ module Haml
       parser_class:         ::Haml::Parser,
       compiler_class:       ::Haml::Compiler,
       trace:                false,
+      filters:              {},
     )
 
     use :Parser,   -> { options[:parser_class] }

--- a/test/filters_test.rb
+++ b/test/filters_test.rb
@@ -138,11 +138,6 @@ class ErbFilterTest < Haml::TestCase
     assert_equal(html, render(haml, :scope => scope))
   end
 
-  test "should use Rails's XSS safety features" do
-    assert_equal("&lt;img&gt;\n", render(":erb\n  <%= '<img>' %>"))
-    assert_equal("<img>\n", render(":erb\n  <%= '<img>'.html_safe %>"))
-  end
-
 end
 
 class JavascriptFilterTest < Haml::TestCase

--- a/test/filters_test.rb
+++ b/test/filters_test.rb
@@ -126,14 +126,14 @@ end
 
 class ErbFilterTest < Haml::TestCase
   test "multiline expressions should work" do
-    html = "foobarbaz\n"
+    html = "foobarbaz\n\n"
     haml = %Q{:erb\n  <%= "foo" +\n      "bar" +\n      "baz" %>}
     assert_equal(html, render(haml))
   end
 
   test "should evaluate in the same context as Haml" do
     haml  = ":erb\n  <%= foo %>"
-    html  = "bar\n"
+    html  = "bar\n\n"
     scope = Object.new.instance_eval {foo = "bar"; nil if foo; binding}
     assert_equal(html, render(haml, :scope => scope))
   end

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -251,8 +251,13 @@ HAML
   end
 
   def test_xss_protection_with_erb_filter
-    assert_equal("&lt;img&gt;\n", render(":erb\n  <%= '<img>' %>", :action_view))
-    assert_equal("<img>\n", render(":erb\n  <%= '<img>'.html_safe %>", :action_view))
+    if defined?(Haml::SafeErubiTemplate)
+      assert_equal("&lt;img&gt;\n\n", render(":erb\n  <%= '<img>' %>", :action_view))
+      assert_equal("<img>\n\n", render(":erb\n  <%= '<img>'.html_safe %>", :action_view))
+    else # For Haml::SafeErubisTemplate
+      assert_equal("&lt;img&gt;\n", render(":erb\n  <%= '<img>' %>", :action_view))
+      assert_equal("<img>\n", render(":erb\n  <%= '<img>'.html_safe %>", :action_view))
+    end
   end
 
   def test_rendered_string_is_html_safe

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -250,6 +250,11 @@ HAML
     assert_equal("Foo & Bar &amp; Baz\n", render('Foo #{Haml::Util.html_safe("&")} Bar #{"&"} Baz', :action_view))
   end
 
+  def test_xss_protection_with_erb_filter
+    assert_equal("&lt;img&gt;\n", render(":erb\n  <%= '<img>' %>", :action_view))
+    assert_equal("<img>\n", render(":erb\n  <%= '<img>'.html_safe %>", :action_view))
+  end
+
   def test_rendered_string_is_html_safe
     assert(render("Foo").html_safe?)
   end


### PR DESCRIPTION
## Summary
To avoid changing template handler globally, I added `:filters` option to override filter compiler with Rails-specific template handler. With this change, Erubi/Erubis handler in ActionView is never used for non-Rails apps.

## Effects for existing apps
You may notice "test/filters_test.rb" is changed. But such change may occur only in the situation both Rails and non-Rails app rendering Haml templates exist (in other words, they will have breaking change. However, duplicating last newline may not affect a behavior on browser). Thus in pure Sinatra environment, there'll be no breaking change.

While Erubi and Erubis renders templates slightly differently for last newline, I think that's Rails' breaking change and not Haml's one.