### PR TITLE
Docs: Clarify changes to escaping of quotes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ Breaking Changes
 * Drop dynamic quotes support and always escape `'` for `escape_html`/`escape_attrs` instead.
   Also, escaped results are slightly changed and always unified to the same characters. (Takashi Kokubun)
 * Don't preserve newlines in attributes. (Takashi Kokubun)
+* HTML escape interpolated code in filters.
+  [#770](https://github.com/haml/haml/pull/770)
+  (Matt Wildig)
+
+        :javascript
+          #{JSON.generate(foo: "bar")}
+        Haml 4 output: {"foo":"bar"}
+        Haml 5 output: {&quot;foo&quot;:&quot;bar&quot;}
 
 Added
 


### PR DESCRIPTION
An example will help people (like me) understand this breaking change.

I think that JSON is a common place where this breaking change will affect people. It caught me. That's why I chose JSON for the example, but maybe a simpler example would be better?

[ci skip]