### PR TITLE
Modernize Gem::Specification#files and remove test from it

### DIFF
--- a/haml.gemspec
+++ b/haml.gemspec
@@ -10,8 +10,9 @@ Gem::Specification.new do |spec|
 
   readmes          = Dir['*'].reject{ |x| x =~ /(^|[^.a-z])[a-z]+/ || x == "TODO" }
   spec.executables = ['haml']
-  spec.files       = Dir['lib/**/*', 'bin/*', 'test/**/*',
-                         'Rakefile', '.yardopts'] + readmes
+  spec.files       = `git ls-files -z`.split("\x0").reject do |f|
+    f.match(%r{\Atest/})
+  end
   spec.homepage    = 'http://haml.info/'
   spec.has_rdoc    = false
   spec.test_files  = Dir["test/**/*_test.rb"]


### PR DESCRIPTION
Since Haml includes symlink in test directory and doesn't exclude in gem package, gem installation is broken on Windows https://github.com/haml/haml/issues/919.

Current files are just legacy as it's originally defined in 11 years ago https://github.com/haml/haml/commit/b88841e6d30cfd5fffc0744994fb7d5ad2d9f07d.
To remove at least `test/*` files to fix #919, I replaced it with [bundle gem's template](https://github.com/bundler/bundler/blob/1624e5775acab1b18743aabfb4ed2045d368d9e9/lib/bundler/templates/newgem/newgem.gemspec.tt#L28-L30) modified a little.

## Changes of "files"
### Removed
```
test/attribute_parser_test.rb
test/engine_test.rb
test/erb/_av_partial_1.erb
test/erb/_av_partial_2.erb
test/erb/action_view.erb
test/erb/standard.erb
test/filters_test.rb
test/gemfiles/Gemfile.rails-4.0.x
test/gemfiles/Gemfile.rails-4.1.x
test/gemfiles/Gemfile.rails-4.2.x
test/gemfiles/Gemfile.rails-5.0.x
test/gemfiles/Gemfile.rails-5.1.x
test/helper_test.rb
test/markaby/standard.mab
test/mocks/article.rb
test/options_test.rb
test/parser_test.rb
test/results/bemit.xhtml
test/results/content_for_layout.xhtml
test/results/eval_suppressed.xhtml
test/results/helpers.xhtml
test/results/helpful.xhtml
test/results/just_stuff.xhtml
test/results/list.xhtml
test/results/nuke_inner_whitespace.xhtml
test/results/nuke_outer_whitespace.xhtml
test/results/original_engine.xhtml
test/results/partial_layout.xhtml
test/results/partial_layout_erb.xhtml
test/results/partials.xhtml
test/results/render_layout.xhtml
test/results/silent_script.xhtml
test/results/standard.xhtml
test/results/tag_parsing.xhtml
test/results/very_basic.xhtml
test/results/whitespace_handling.xhtml
test/template_test.rb
test/template_test_helper.rb
test/templates/_av_partial_1.haml
test/templates/_av_partial_2.haml
test/templates/_layout.erb
test/templates/_layout_for_partial.haml
test/templates/_partial.haml
test/templates/_text_area.haml
test/templates/_text_area_helper.html.haml
test/templates/action_view.haml
test/templates/bemit.haml
test/templates/breakage.haml
test/templates/content_for_layout.haml
test/templates/eval_suppressed.haml
test/templates/helpers.haml
test/templates/helpful.haml
test/templates/just_stuff.haml
test/templates/list.haml
test/templates/nuke_inner_whitespace.haml
test/templates/nuke_outer_whitespace.haml
test/templates/original_engine.haml
test/templates/partial_layout.haml
test/templates/partial_layout_erb.erb
test/templates/partialize.haml
test/templates/partials.haml
test/templates/render_layout.haml
test/templates/silent_script.haml
test/templates/standard.haml
test/templates/standard_ugly.haml
test/templates/tag_parsing.haml
test/templates/very_basic.haml
test/templates/whitespace_handling.haml
test/templates/with_bom.haml
test/temple_line_counter_test.rb
test/test_helper.rb
test/util_test.rb
```

### Added
```
.gitignore
.gitmodules
.travis.yml
Gemfile
TODO
benchmark.rb
haml.gemspec
lib/haml/.gitattributes
yard/default/.gitignore
yard/default/fulldoc/html/css/common.sass
yard/default/layout/html/footer.erb
```

@haml/committers WDYT?