### PR TITLE
Usage of double colon when referencing Rails

### DIFF
--- a/lib/haml/sass_rails_filter.rb
+++ b/lib/haml/sass_rails_filter.rb
@@ -6,7 +6,7 @@ module Haml
     class SassRailsTemplate < ::Sass::Rails::SassTemplate
       if Gem::Version.new(Sprockets::VERSION) >= Gem::Version.new('3.0.0')
         def render(scope=Object.new, locals={}, &block)
-          environment = ::Sprockets::Railtie.build_environment(Rails.application)
+          environment = ::Sprockets::Railtie.build_environment(::Rails.application)
           scope = environment.context_class.new(
             environment: environment,
             filename: "/",


### PR DESCRIPTION
This is related to https://github.com/haml/haml/pull/868

I got next error when using :sass filter:
 NoMethodError - undefined method `application' for Haml::Rails:Module.

Just adding double colon to Rails.application solved the error to me.