### PR TITLE
Fix list_of helper with multi-line content

### DIFF
--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -206,7 +206,7 @@ MESSAGE
 
         if result.count("\n") > 1
           result.gsub!("\n", "\n  ")
-          result = "\n  #{result.strip!}\n"
+          result = "\n  #{result.strip}\n"
         else
           result.strip!
         end

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -83,6 +83,8 @@ HAML
     assert_equal("<li>[1]</li>", render("= list_of([[1]]) do |i|\n  = i.inspect"))
     assert_equal("<li>\n  <h1>Fee</h1>\n  <p>A word!</p>\n</li>\n<li>\n  <h1>Fi</h1>\n  <p>A word!</p>\n</li>\n<li>\n  <h1>Fo</h1>\n  <p>A word!</p>\n</li>\n<li>\n  <h1>Fum</h1>\n  <p>A word!</p>\n</li>",
       render("= list_of(['Fee', 'Fi', 'Fo', 'Fum']) do |title|\n  %h1= title\n  %p A word!"))
+    assert_equal("<li>\n  <f>a\n  \n  a</f>\n</li>\n<li>\n  <f>a\n  \n  a</f>\n</li>",
+      render("= list_of(['Fee', 'Fi']) do |title|\n  %f>= \"a\\n\\na\""))
     assert_equal("<li c='3'>1</li>\n<li c='3'>2</li>", render("= list_of([1, 2], {:c => 3}) do |i|\n  = i"))
     assert_equal("<li c='3'>[1]</li>", render("= list_of([[1]], {:c => 3}) do |i|\n  = i.inspect"))
     assert_equal("<li c='3'>\n  <h1>Fee</h1>\n  <p>A word!</p>\n</li>\n<li c='3'>\n  <h1>Fi</h1>\n  <p>A word!</p>\n</li>\n<li c='3'>\n  <h1>Fo</h1>\n  <p>A word!</p>\n</li>\n<li c='3'>\n  <h1>Fum</h1>\n  <p>A word!</p>\n</li>",


### PR DESCRIPTION
Hello,

The current `list_of` helper in haml 5.0.1 seem to have an issue when running in rails (at least in 5.0.0.1) when inserting multi-line content. 

In my rails app when I do a block `link_to` in the `list_of`, the content of the list is removed:
```
= list_of array do |type|               
  = link_to helper_url(type) do            
    = myhellper(type)                                         
    = type.humanize 
```

It seem to be linked to the use of `strip!` instead of `strip` the `!` version will actually return [nil if does nothing](https://ruby-doc.org/core-2.2.0/String.html#method-i-strip-21).

I managed to add a test that seem to replicate the issue without rails. It could also probably be fixed using an `result.strip! || result` which would not copy `result`.

Thanks again for HAML and saving me from ERB !