### PR TITLE
Fix textareas only after preserved timing

### DIFF
--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -159,7 +159,7 @@ module Haml
     # @since Haml 4.0.1
     # @private
     def fix_textareas!(input)
-      return input unless toplevel? && input.include?('<textarea'.freeze)
+      return input unless input.include?('<textarea'.freeze)
 
       pattern = /<(textarea)([^>]*)>(\n|&#x000A;)(.*?)<\/textarea>/im
       input.gsub!(pattern) do |s|

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -287,11 +287,11 @@ module Haml
         text = "(#{text}).strip"
       end
       if opts[:preserve_tag]
-        text = "::Haml::Helpers.preserve(#{text})"
+        text = "_hamlout.fix_textareas!(::Haml::Helpers.preserve(#{text}))"
       elsif opts[:preserve_script]
-        text = "::Haml::Helpers.find_and_preserve(#{text}, _hamlout.options[:preserve])"
+        text = "_hamlout.fix_textareas!(::Haml::Helpers.find_and_preserve(#{text}, _hamlout.options[:preserve]))"
       end
-      "_hamlout.fix_textareas!(#{text});"
+      "#{text};"
     end
 
     def push_generated_script(text)

--- a/lib/haml/helpers/action_view_mods.rb
+++ b/lib/haml/helpers/action_view_mods.rb
@@ -58,11 +58,15 @@ module ActionView
         preserve = haml_buffer.options.fetch(:preserve, %w[textarea pre code]).include?(name.to_s)
 
         if block_given? && block_is_haml?(block) && preserve
-          return content_tag_without_haml(name, *args) {preserve(&block)}
+          return content_tag_without_haml(name, *args) do
+            haml_buffer.fix_textareas!(Haml::Helpers.preserve(&block)).html_safe
+          end
         end
 
         content = content_tag_without_haml(name, *args, &block)
-        content = Haml::Helpers.preserve(content) if preserve && content
+        if preserve && content
+          content = haml_buffer.fix_textareas!(Haml::Helpers.preserve(content)).html_safe
+        end
         content
       end
 


### PR DESCRIPTION
## Description
We call `Haml::Buffer#fix_textareas!` to rollback textarea content's first `&#x000A;`, which is unexpectedly preserved from `\n` by `Haml::Helpers#preserve`, to `\n` for every script.

But it means that we need to call `Haml::Buffer#fix_textareas!` only after we call `preserve`. So I fixed to do so.

## Benchmark
With Ruby 2.4.0 and [k0kubun/haml_bench/templates/slim_bench.haml](https://github.com/k0kubun/haml_bench/blob/833f04306bc138261d8d2102a4f0cceb3a78eca7/templates/slim_bench.haml),

### before
```
Calculating -------------------------------------
          haml 4.0.7     41.534k (± 1.4%) i/s -    210.652k in   5.072717s
          haml 5.0.1    138.067k (± 1.5%) i/s -    700.872k in   5.077348s

Comparison:
          haml 5.0.1:   138067.3 i/s
          haml 4.0.7:    41534.1 i/s - 3.32x  slower
```

### after
```
Calculating -------------------------------------
          haml 4.0.7     39.466k (± 2.1%) i/s -    199.206k in   5.049870s
          haml 5.0.1    148.617k (± 1.9%) i/s -    750.109k in   5.049201s

Comparison:
          haml 5.0.1:   148616.6 i/s
          haml 4.0.7:    39466.1 i/s - 3.77x  slower
```

Now `_hamlout`'s dependency is only `_hamlout.attributes` call for Hash in that benchmark template. It means that we have new optimization chance to lazily initialize `Haml::Buffer` instance, which is the current bottleneck of Haml.