### PR TITLE
Fix Erubi on Rails < 5.1

### DIFF
--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -26,7 +26,7 @@ module Haml
           require "haml/sass_rails_filter"
         end
 
-        if const_defined?('ActionView::Template::Handlers::ERB::Erubi')
+        if defined? ActionView::Template::Handlers::ERB::Erubi
           require "haml/helpers/safe_erubi_template"
           Haml::Filters::RailsErb.template_class = Haml::SafeErubiTemplate
         else

--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -26,7 +26,7 @@ module Haml
           require "haml/sass_rails_filter"
         end
 
-        if defined?(::Erubi) && const_defined?('ActionView::Template::Handlers::ERB::Erubi')
+        if const_defined?('ActionView::Template::Handlers::ERB::Erubi')
           require "haml/helpers/safe_erubi_template"
           Haml::Filters::RailsErb.template_class = Haml::SafeErubiTemplate
         else

--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -26,7 +26,7 @@ module Haml
           require "haml/sass_rails_filter"
         end
 
-        if defined? Erubi
+        if defined?(::Erubi) && const_defined?('ActionView::Template::Handlers::ERB::Erubi')
           require "haml/helpers/safe_erubi_template"
           Haml::Filters::RailsErb.template_class = Haml::SafeErubiTemplate
         else


### PR DESCRIPTION
ActionView prior to 5.1 does not support Erubi. haml was looking for existence of `Erubi` in the bundle, and then assuming that ActionView would support it.

This checks directly for ActionView to support Erubi rather than only looking to see if Erubi is in the bundle at all. In effect, this causes haml to use Erubis in Rails prior to 5.1.

This change is necessary because `Haml::ErubiTemplateHandler` inherits from `ActionView::Template::Handlers::ERB::Erubi`, which in Rails prior to 5.1 is actually a reference to the `Erubi` _module_, not actually a useable class. A class inheriting from a module causes a fatal exception (which can be seen in #946).

I tested this with Rails 5.0 with and without erubi in the bundle, and with Rails 5.1 with and without erubis in the bundle. (I mention this because I don't think that the CI matrix includes erubi and erubis bundle variants.)

Fixes #946.