### PR TITLE
Add a PHP filter

### DIFF
--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -309,7 +309,7 @@ RUBY
       end
     end
 
-    # @private                                                                                                   [50/1896]
+    # @private 
     module PHP
       include Base
 


### PR DESCRIPTION
See Issue #949 

This patch add a :php filter support.  It simply wraps the content of the filtered content into a <?php ?> wrapper. Very useful when using a package builder like gulp or grunt to build a php (in my case WordPress) project.

