### PR TITLE
Require entire bundle in tests, add test case for Rails 5.0 with Erubi

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ rvm:
 gemfile:
   - test/gemfiles/Gemfile.rails-5.1.x
   - test/gemfiles/Gemfile.rails-5.0.x
+  - test/gemfiles/Gemfile.rails-5.0.x.erubi
   - test/gemfiles/Gemfile.rails-4.2.x
   - test/gemfiles/Gemfile.rails-4.1.x
   - test/gemfiles/Gemfile.rails-4.0.x
@@ -24,8 +25,12 @@ matrix:
       gemfile: test/gemfiles/Gemfile.rails-5.1.x
     - rvm: 2.0.0
       gemfile: test/gemfiles/Gemfile.rails-5.0.x
+    - rvm: 2.0.0
+      gemfile: test/gemfiles/Gemfile.rails-5.0.x.erubi
     - rvm: 2.1.10
       gemfile: test/gemfiles/Gemfile.rails-5.0.x
+    - rvm: 2.1.10
+      gemfile: test/gemfiles/Gemfile.rails-5.0.x.erubi
     - rvm: 2.4.1
       gemfile: test/gemfiles/Gemfile.rails-4.0.x
     - rvm: 2.4.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,5 +43,6 @@ matrix:
   allow_failures:
     - rvm: rbx-3
     - gemfile: test/gemfiles/Gemfile.rails-edge
+    - gemfile: test/gemfiles/Gemfile.rails-5.0.x.erubi
   fast_finish: true
 script: "bundle exec rake submodules test"

--- a/test/gemfiles/Gemfile.rails-5.0.x.erubi
+++ b/test/gemfiles/Gemfile.rails-5.0.x.erubi
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem 'rails', '~> 5.0.0'
+gem 'erubi'
+gemspec :path => '../..'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -12,7 +12,8 @@ if ENV["COVERAGE"]
   SimpleCov.start
 end
 
-require 'bundler/setup'
+require 'bundler'
+Bundler.require(:default)
 require 'minitest/autorun'
 require 'action_pack'
 require 'action_controller'


### PR DESCRIPTION
We found an issue, fixed in #948, that was caused by Erubi being loaded. The way to reproduce this was to require erubi while Rails 5.0 is in use.

I wanted to add test coverage for this, so I added a gemfile that includes rails 5.0 and erubi. This didn't reproduce the issue though, because in test_helper, only specific gems are required directly. Since `Bundler.require` is not used, only dependencies that are directly required will be available in the tests.

There seem to be two options:
1. Add `require` calls for erubi and rescue from failure.
2. Add `Bundler.require` to test_helper and allow it to load everything that's included in each gemfile.

I advocate 2 because it is closest to the way Rails works. I assume that the long-term goal is to remove Rails from this project completely in favor of haml-rails, but until it's removed, it seems to make sense to test with an environment as close to Rails as possible. 

Anyway, by making this change, I was able to [show the failure caused by having Erubi in the bundle with Rails 5.0](https://travis-ci.org/RobinDaugherty/haml/builds/265407307).

(The erubi-variant of the gemfile is currently an allowed failure, since it's not yet fixed.)

