### PR TITLE
Re-fix Erubi on Rails < 5.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,6 +43,5 @@ matrix:
   allow_failures:
     - rvm: rbx-3
     - gemfile: test/gemfiles/Gemfile.rails-edge
-    - gemfile: test/gemfiles/Gemfile.rails-5.0.x.erubi
   fast_finish: true
 script: "bundle exec rake submodules test"

--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -26,7 +26,7 @@ module Haml
           require "haml/sass_rails_filter"
         end
 
-        if defined? ActionView::Template::Handlers::ERB::Erubi
+        if defined?(::Erubi) && const_defined?('ActionView::Template::Handlers::ERB::Erubi')
           require "haml/helpers/safe_erubi_template"
           Haml::Filters::RailsErb.template_class = Haml::SafeErubiTemplate
         else

--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -26,7 +26,15 @@ module Haml
           require "haml/sass_rails_filter"
         end
 
-        if defined?(::Erubi) && const_defined?('ActionView::Template::Handlers::ERB::Erubi')
+        # Any object under ActionView::Template will be defined as the root constant with the same
+        # name if it exists. If Erubi is loaded at all, ActionView::Template::Handlers::ERB::Erubi
+        # will turn out to be a reference to the ::Erubi module.
+        # In Rails 4.2, calling const_defined? results in odd exceptions, which seems to be
+        # solved by looking for ::Erubi first.
+        # However, in JRuby, the const_defined? finds it anyway, so we must make sure that it's
+        # not just a reference to ::Erubi.
+        if defined?(::Erubi) && const_defined?('ActionView::Template::Handlers::ERB::Erubi') &&
+            ActionView::Template::Handlers::ERB::Erubi != ::Erubi
           require "haml/helpers/safe_erubi_template"
           Haml::Filters::RailsErb.template_class = Haml::SafeErubiTemplate
         else


### PR DESCRIPTION
This was attempted in #948, but we made a small change after the PR was first opened. Turns out we must use check for Erubi using `defined?` and Rails' Erubi object using `const_defined?`.

If we call `defined?` with Rails's object, it gets defined by Rails. Calling `const_defined?` with the constant as a string seems to be the only way for us to see if it's been defined without _causing it to be defined_.

Without the `defined?` in front of the `const_defined?` call, Rails 4.2 raises a weird exception. Together, they seem to do the job.

I've set Travis to require the erubi gemfile tests to pass.
