### PR TITLE
Tidy up --exclude options in .yardopts

### DIFF
--- a/.yardopts
+++ b/.yardopts
@@ -7,7 +7,6 @@
 --title            "Haml Documentation"
 --query            'object.type != :classvariable'
 --query            'object.type != :constant || @api && @api.text == "public"'
---exclude          lib/haml/template/patch.rb
 --exclude          lib/haml/template/plugin.rb
 --exclude          lib/haml/railtie.rb
 --exclude          lib/haml/helpers/action_view_mods.rb

--- a/.yardopts
+++ b/.yardopts
@@ -7,7 +7,7 @@
 --title            "Haml Documentation"
 --query            'object.type != :classvariable'
 --query            'object.type != :constant || @api && @api.text == "public"'
---exclude          lib/haml/template/plugin.rb
+--exclude          lib/haml/plugin.rb
 --exclude          lib/haml/railtie.rb
 --exclude          lib/haml/helpers/action_view_mods.rb
 --exclude          lib/haml/helpers/xss_mods.rb


### PR DESCRIPTION
Updating the `--exclude` path to `plugin.rb`, and removing the entry for `patch.rb` in `.yardopts` file.