### PR TITLE
Freeze strings to prevent re-allocation of newline/empty strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Haml Changelog
 
+* Freeze and cache strings to prevent re-allocation of newlines, empty strings, and common content tags. [#961](https://github.com/haml/haml/pull/961) (thanks [Dillon Welch](https://github.com/oniofchaos))
+
 ## 5.0.4
 
 Released on October 13, 2017

--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -132,7 +132,9 @@ module Haml
     def attributes(class_id, obj_ref, *attributes_hashes)
       attributes = class_id
       attributes_hashes.each do |old|
-        AttributeBuilder.merge_attributes!(attributes, Hash[old.map {|k, v| [k.to_s, v]}])
+        result = {}
+        old.each { |k, v| result[k.to_s] = v }
+        AttributeBuilder.merge_attributes!(attributes, result)
       end
       AttributeBuilder.merge_attributes!(attributes, parse_object_ref(obj_ref)) if obj_ref
       AttributeBuilder.build_attributes(

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -103,7 +103,7 @@ module Haml
       end
 
       if @options[:trace]
-        t[:attributes].merge!({"data-trace" => @options.filename.split('/views').last << ":" << @node.line.to_s})
+        t[:attributes].merge!({"data-trace".freeze => @options.filename.split('/views'.freeze).last << ":".freeze << @node.line.to_s})
       end
 
       push_text("<#{t[:name]}")
@@ -179,36 +179,36 @@ module Haml
     end
 
     def text_for_doctype
-      if @node.value[:type] == "xml"
+      if @node.value[:type] == "xml".freeze
         return nil if @options.html?
         wrapper = @options.attr_wrapper
         return "<?xml version=#{wrapper}1.0#{wrapper} encoding=#{wrapper}#{@node.value[:encoding] || "utf-8"}#{wrapper} ?>"
       end
 
       if @options.html5?
-        '<!DOCTYPE html>'
+        '<!DOCTYPE html>'.freeze
       else
         if @options.xhtml?
-          if @node.value[:version] == "1.1"
-            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">'
-          elsif @node.value[:version] == "5"
-            '<!DOCTYPE html>'
+          if @node.value[:version] == "1.1".freeze
+            '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">'.freeze
+          elsif @node.value[:version] == "5".freeze
+            '<!DOCTYPE html>'.freeze
           else
             case @node.value[:type]
-            when "strict";   '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">'
-            when "frameset"; '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">'
-            when "mobile";   '<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">'
-            when "rdfa";     '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">'
-            when "basic";    '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN" "http://www.w3.org/TR/xhtml-basic/xhtml-basic11.dtd">'
-            else             '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'
+            when "strict".freeze;   '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">'.freeze
+            when "frameset".freeze; '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Frameset//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-frameset.dtd">'.freeze
+            when "mobile".freeze;   '<!DOCTYPE html PUBLIC "-//WAPFORUM//DTD XHTML Mobile 1.2//EN" "http://www.openmobilealliance.org/tech/DTD/xhtml-mobile12.dtd">'.freeze
+            when "rdfa".freeze;     '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML+RDFa 1.0//EN" "http://www.w3.org/MarkUp/DTD/xhtml-rdfa-1.dtd">'.freeze
+            when "basic".freeze;    '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML Basic 1.1//EN" "http://www.w3.org/TR/xhtml-basic/xhtml-basic11.dtd">'.freeze
+            else             '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">'.freeze
             end
           end
 
         elsif @options.html4?
           case @node.value[:type]
-          when "strict";   '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">'
-          when "frameset"; '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">'
-          else             '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">'
+          when "strict".freeze;   '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN" "http://www.w3.org/TR/html4/strict.dtd">'.freeze
+          when "frameset".freeze; '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Frameset//EN" "http://www.w3.org/TR/html4/frameset.dtd">'.freeze
+          else             '<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3.org/TR/html4/loose.dtd">'.freeze
           end
         end
       end
@@ -219,7 +219,7 @@ module Haml
     def push_silent(text, can_suppress = false)
       flush_merged_text
       return if can_suppress && @options.suppress_eval?
-      newline = (text == "end") ? ";" : "\n".freeze
+      newline = (text == "end".freeze) ? ";".freeze : "\n".freeze
       @temple << [:code, "#{resolve_newlines}#{text}#{newline}"]
       @output_line = @output_line + text.count("\n".freeze) + newline.count("\n".freeze)
     end
@@ -246,7 +246,7 @@ module Haml
         when :script
           @temple << [:dynamic, val]
         else
-          raise SyntaxError.new("[HAML BUG] Undefined entry in Haml::Compiler@to_merge.")
+          raise SyntaxError.new("[HAML BUG] Undefined entry in Haml::Compiler@to_merge.".freeze)
         end
       end
 
@@ -281,7 +281,7 @@ module Haml
       push_silent "haml_temp = #{text}"
       yield
       push_silent('end', :can_suppress) unless @node.value[:dont_push_end]
-      @temple << [:dynamic, no_format ? 'haml_temp.to_s;' : build_script_formatter('haml_temp', opts)]
+      @temple << [:dynamic, no_format ? 'haml_temp.to_s;'.freeze : build_script_formatter('haml_temp', opts)]
     end
 
     def build_script_formatter(text, opts)
@@ -318,7 +318,7 @@ module Haml
     def rstrip_buffer!(index = -1)
       last = @to_merge[index]
       if last.nil?
-        push_silent("_hamlout.rstrip!", false)
+        push_silent("_hamlout.rstrip!".freeze, false)
         return
       end
 
@@ -330,10 +330,10 @@ module Haml
           rstrip_buffer! index
         end
       when :script
-        last[1].gsub!(/\(haml_temp, (.*?)\);$/, '(haml_temp.rstrip, \1);')
+        last[1].gsub!(/\(haml_temp, (.*?)\);$/, '(haml_temp.rstrip, \1);'.freeze)
         rstrip_buffer! index - 1
       else
-        raise SyntaxError.new("[HAML BUG] Undefined entry in Haml::Compiler@to_merge.")
+        raise SyntaxError.new("[HAML BUG] Undefined entry in Haml::Compiler@to_merge.".freeze)
       end
     end
   end

--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -167,7 +167,7 @@ module Haml
 
       begin
         eval("Proc.new { |*_haml_locals| _haml_locals = _haml_locals[0] || {};" <<
-             @temple_engine.precompiled_with_ambles(local_names) << "}\n", scope, @options.filename, @options.line)
+             @temple_engine.precompiled_with_ambles(local_names) << "}\n".freeze, scope, @options.filename, @options.line)
       rescue ::SyntaxError => e
         raise SyntaxError, e.message
       end

--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -42,7 +42,7 @@ module Haml
       end
 
       filter = const_set(name, Module.new)
-      filter.extend const_get(options[:extend] || "Plain")
+      filter.extend const_get(options[:extend] || "Plain".freeze)
       filter.extend TiltFilter
       filter.extend PrecompiledTiltFilter if options.has_key? :precompiled
 
@@ -105,7 +105,7 @@ module Haml
       #
       # @param base [Module, Class] The module that this is included in
       def self.included(base)
-        Filters.defined[base.name.split("::").last.downcase] = base
+        Filters.defined[base.name.split("::".freeze).last.downcase] = base
         base.extend(base)
       end
 
@@ -175,7 +175,7 @@ module Haml
             # filter name). Then we need to escape the trailing
             # newline so that the whole filter block doesn't take up
             # too many.
-            text = %[\n#{text.sub(/\n"\Z/, "\\n\"")}]
+            text = %[\n#{text.sub(/\n"\Z/, "\\n\"".freeze)}]
             push_script <<RUBY.rstrip, :escape_html => false
 find_and_preserve(#{filter.inspect}.render_with_options(#{text}, _hamlout.options))
 RUBY
@@ -206,15 +206,15 @@ RUBY
 
       # @see Base#render_with_options
       def render_with_options(text, options)
-        indent = options[:cdata] ? '    ' : '  ' # 4 or 2 spaces
+        indent = options[:cdata] ? '    '.freeze : '  '.freeze # 4 or 2 spaces
         if options[:format] == :html5
-          type = ''
+          type = ''.freeze
         else
           type = " type=#{options[:attr_wrapper]}text/javascript#{options[:attr_wrapper]}"
         end
 
         text = text.rstrip
-        text.gsub!("\n", "\n#{indent}")
+        text.gsub!("\n".freeze, "\n#{indent}")
 
         %!<script#{type}>\n#{"  //<![CDATA[\n" if options[:cdata]}#{indent}#{text}\n#{"  //]]>\n" if options[:cdata]}</script>!
       end
@@ -227,15 +227,15 @@ RUBY
 
       # @see Base#render_with_options
       def render_with_options(text, options)
-        indent = options[:cdata] ? '    ' : '  ' # 4 or 2 spaces
+        indent = options[:cdata] ? '    '.freeze : '  '.freeze # 4 or 2 spaces
         if options[:format] == :html5
-          type = ''
+          type = ''.freeze
         else
           type = " type=#{options[:attr_wrapper]}text/css#{options[:attr_wrapper]}"
         end
 
         text = text.rstrip
-        text.gsub!("\n", "\n#{indent}")
+        text.gsub!("\n".freeze, "\n#{indent}")
 
         %(<style#{type}>\n#{"  /*<![CDATA[*/\n" if options[:cdata]}#{indent}#{text}\n#{"  /*]]>*/\n" if options[:cdata]}</style>)
       end
@@ -249,7 +249,7 @@ RUBY
       def render(text)
         text = "\n#{text}"
         text.rstrip!
-        text.gsub!("\n", "\n    ")
+        text.gsub!("\n".freeze, "\n    ".freeze)
         "<![CDATA[#{text}\n]]>"
       end
     end
@@ -282,9 +282,9 @@ RUBY
       def compile(compiler, text)
         return if compiler.options[:suppress_eval]
         compiler.instance_eval do
-          push_silent "#{<<-FIRST.tr("\n", ';')}#{text}#{<<-LAST.tr("\n", ';')}"
+          push_silent "#{<<-FIRST.tr("\n".freeze, ';'.freeze)}#{text}#{<<-LAST.tr("\n", ';')}"
             begin
-              haml_io = StringIO.new(_hamlout.buffer, 'a')
+              haml_io = StringIO.new(_hamlout.buffer, 'a'.freeze)
           FIRST
             ensure
               haml_io.close
@@ -320,7 +320,7 @@ RUBY
           @template_class = Tilt["t.#{tilt_extension}"] or
             raise Error.new(Error.message(:cant_run_filter, tilt_extension))
         rescue LoadError => e
-          dep = e.message.split('--').last.strip
+          dep = e.message.split('--'.freeze).last.strip
           raise Error.new(Error.message(:gem_install_filter_deps, tilt_extension, dep))
         end
       end

--- a/lib/haml/generator.rb
+++ b/lib/haml/generator.rb
@@ -13,7 +13,7 @@ module Haml
     end
 
     def on_multi(*exp)
-      exp.map { |e| compile(e) }.join('; ')
+      exp.map { |e| compile(e) }.join('; '.freeze)
     end
 
     def on_static(text)

--- a/lib/haml/generator.rb
+++ b/lib/haml/generator.rb
@@ -29,7 +29,7 @@ module Haml
     end
 
     def on_newline
-      "\n"
+      "\n".freeze
     end
 
     private

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -134,9 +134,9 @@ MESSAGE
     #   @yield The block within which to escape newlines
     def preserve(input = nil, &block)
       return preserve(capture_haml(&block)) if block
-      s = input.to_s.chomp("\n")
-      s.gsub!(/\n/, '&#x000A;')
-      s.delete!("\r")
+      s = input.to_s.chomp("\n".freeze)
+      s.gsub!(/\n/, '&#x000A;'.freeze)
+      s.delete!("\r".freeze)
       s
     end
     alias_method :flatten, :preserve
@@ -204,14 +204,14 @@ MESSAGE
       enum.each_with_object('') do |i, ret|
         result = capture_haml(i, &block)
 
-        if result.count("\n") > 1
-          result.gsub!("\n", "\n  ")
+        if result.count("\n".freeze) > 1
+          result.gsub!("\n".freeze, "\n  ".freeze)
           result = "\n  #{result.strip}\n"
         else
           result.strip!
         end
 
-        ret << "\n" unless ret.empty?
+        ret << "\n".freeze unless ret.empty?
         ret << %Q!<li#{opts_attributes}>#{result}</li>!
       end
     end
@@ -228,9 +228,13 @@ MESSAGE
     #
     # @param lang [String] The value of `xml:lang` and `lang`
     # @return [{#to_s => String}] The attribute hash
-    def html_attrs(lang = 'en-US')
+    def html_attrs(lang = 'en-US'.freeze)
       if haml_buffer.options[:format] == :xhtml
-        {:xmlns => "http://www.w3.org/1999/xhtml", 'xml:lang' => lang, :lang => lang}
+        {
+          :xmlns => "http://www.w3.org/1999/xhtml".freeze,
+          'xml:lang' => lang,
+          :lang => lang
+        }
       else
         {:lang => lang}
       end
@@ -374,7 +378,7 @@ MESSAGE
     # @yield [args] A block of Haml code that will be converted to a string
     # @yieldparam args [Array] `args`
     def capture_haml(*args, &block)
-      buffer = eval('if defined? _hamlout then _hamlout else nil end', block.binding) || haml_buffer
+      buffer = eval('if defined? _hamlout then _hamlout else nil end'.freeze, block.binding) || haml_buffer
       with_haml_buffer(buffer) do
         position = haml_buffer.buffer.length
 
@@ -396,7 +400,7 @@ MESSAGE
     # Outputs text directly to the Haml buffer, with the proper indentation.
     #
     # @param text [#to_s] The text to output
-    def haml_concat(text = "")
+    def haml_concat(text = "".freeze)
       haml_internal_concat text
       ErrorReturn.new("haml_concat")
     end
@@ -413,11 +417,11 @@ MESSAGE
     # @param text [#to_s] The text to output
     # @param newline [Boolean] Whether to add a newline after the text
     # @param indent [Boolean] Whether to add indentation to the first line
-    def haml_internal_concat(text = "", newline = true, indent = true)
+    def haml_internal_concat(text = "".freeze, newline = true, indent = true)
       if haml_buffer.tabulation == 0
-        haml_buffer.buffer << "#{text}#{"\n" if newline}"
+        haml_buffer.buffer << "#{text}#{"\n".freeze if newline}"
       else
-        haml_buffer.buffer << %[#{haml_indent if indent}#{text.to_s.gsub("\n", "\n#{haml_indent}")}#{"\n" if newline}]
+        haml_buffer.buffer << %[#{haml_indent if indent}#{text.to_s.gsub("\n".freeze, "\n#{haml_indent}")}#{"\n".freeze if newline}]
       end
     end
     private :haml_internal_concat
@@ -505,7 +509,7 @@ MESSAGE
         attrs)
 
       if text.nil? && block.nil? && (haml_buffer.options[:autoclose].include?(name) || flags.include?(:/))
-        haml_internal_concat_raw "<#{name}#{attributes}#{' /' if haml_buffer.options[:format] == :xhtml}>"
+        haml_internal_concat_raw "<#{name}#{attributes}#{' /'.freeze if haml_buffer.options[:format] == :xhtml}>"
         return ret
       end
 
@@ -518,7 +522,7 @@ MESSAGE
       end_tag = "</#{name}>"
       if block.nil?
         text = text.to_s
-        if text.include?("\n")
+        if text.include?("\n".freeze)
           haml_internal_concat_raw tag
           tab_up
           haml_internal_concat text
@@ -596,7 +600,13 @@ MESSAGE
     end
 
     # Characters that need to be escaped to HTML entities from user input
-    HTML_ESCAPE = { '&' => '&amp;', '<' => '&lt;', '>' => '&gt;', '"' => '&quot;', "'" => '&#39;' }
+    HTML_ESCAPE = {
+      '&'.freeze => '&amp;'.freeze,
+      '<'.freeze => '&lt;'.freeze,
+      '>'.freeze => '&gt;'.freeze,
+      '"'.freeze => '&quot;'.freeze,
+      "'".freeze => '&#39;'.freeze
+    }.freeze
 
     HTML_ESCAPE_REGEX = /['"><&]/
 
@@ -652,7 +662,7 @@ MESSAGE
       # skip merging if no ids or classes found in name
       return name, attributes_hash unless name =~ /^(.+?)?([\.#].*)$/
 
-      return $1 || "div", AttributeBuilder.merge_attributes!(
+      return $1 || "div".freeze, AttributeBuilder.merge_attributes!(
         Haml::Parser.parse_class_and_id($2), attributes_hash)
     end
 

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -383,7 +383,7 @@ MESSAGE
 
         captured = haml_buffer.buffer.slice!(position..-1)
 
-        if captured == '' and value != haml_buffer.buffer
+        if captured == ''.freeze and value != haml_buffer.buffer
           captured = (value.is_a?(String) ? value : nil)
         end
 
@@ -641,7 +641,7 @@ MESSAGE
     # @param block [Proc] A Ruby block
     # @return [Boolean] Whether or not `block` is defined directly in a Haml template
     def block_is_haml?(block)
-      eval('!!defined?(_hamlout)', block.binding)
+      eval('!!defined?(_hamlout)'.freeze, block.binding)
     end
 
     private
@@ -704,4 +704,3 @@ class Object
     false
   end
 end
-

--- a/lib/haml/helpers/action_view_mods.rb
+++ b/lib/haml/helpers/action_view_mods.rb
@@ -55,7 +55,9 @@ module ActionView
       def content_tag_with_haml(name, *args, &block)
         return content_tag_without_haml(name, *args, &block) unless is_haml?
 
-        preserve = haml_buffer.options.fetch(:preserve, %w[textarea pre code]).include?(name.to_s)
+        @_content_tag_name_cache ||= {}
+        name_string = @_content_tag_name_cache[name] ||= name.to_s
+        preserve = haml_buffer.options.fetch(:preserve, %w[textarea pre code]).include?(name_string)
 
         if block_given? && block_is_haml?(block) && preserve
           return content_tag_without_haml(name, *args) do

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -559,9 +559,9 @@ module Haml
         case type
         when '.'
           if attributes[CLASS_KEY]
-            attributes[CLASS_KEY] += " "
+            attributes[CLASS_KEY] += " ".freeze
           else
-            attributes[CLASS_KEY] = ""
+            attributes[CLASS_KEY] = "".freeze
           end
           attributes[CLASS_KEY] += property
         when '#'; attributes[ID_KEY] = property
@@ -637,7 +637,7 @@ module Haml
       end
 
       if value.nil?
-        value = ''
+        value = ''.freeze
       else
         value.strip!
       end

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -698,7 +698,7 @@ module Haml
       end
 
       static_attributes = {}
-      dynamic_attributes = ["{".freeze]
+      dynamic_attributes = "{"
       attributes.each do |name, (type, val)|
         if type == :static
           static_attributes[name] = val
@@ -707,7 +707,6 @@ module Haml
         end
       end
       dynamic_attributes << "}".freeze
-      dynamic_attributes = dynamic_attributes.join(''.freeze)
       dynamic_attributes = nil if dynamic_attributes == "{}".freeze
 
       return [static_attributes, dynamic_attributes], scanner.rest, last_line

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -106,7 +106,7 @@ module Haml
         Line.new(whitespace, text.rstrip, full, index, self, false)
       end
       # Append special end-of-document marker
-      @template << Line.new(nil, '-#', '-#', @template.size, self, true)
+      @template << Line.new(nil, '-#'.freeze, '-#'.freeze, @template.size, self, true)
 
       @root = @parent = ParseNode.new(:root)
       @flat = false
@@ -123,7 +123,7 @@ module Haml
 
         if flat?
           text = @line.full.dup
-          text = "" unless text.gsub!(/^#{@flat_spaces}/, '')
+          text = "".freeze unless text.gsub!(/^#{@flat_spaces}/, ''.freeze)
           @filter_buffer << "#{text}\n"
           @line = @next_line
           next
@@ -210,14 +210,14 @@ module Haml
     class DynamicAttributes < Struct.new(:new, :old)
       def old=(value)
         unless value =~ /\A{.*}\z/m
-          raise ArgumentError.new('Old attributes must start with "{" and end with "}"')
+          raise ArgumentError.new('Old attributes must start with "{" and end with "}"'.freeze)
         end
         super
       end
 
       # This will be a literal for Haml::Buffer#attributes's last argument, `attributes_hashes`.
       def to_literal
-        [new, stripped_old].compact.join(', ')
+        [new, stripped_old].compact.join(', '.freeze)
       end
 
       private
@@ -225,7 +225,7 @@ module Haml
       # For `%foo{ { foo: 1 }, bar: 2 }`, :old is "{ { foo: 1 }, bar: 2 }" and this method returns " { foo: 1 }, bar: 2 " for last argument.
       def stripped_old
         return nil if old.nil?
-        old.sub!(/\A{/, '').sub!(/}\z/m, '')
+        old.sub!(/\A{/, ''.freeze).sub!(/}\z/m, ''.freeze)
       end
     end
 
@@ -258,10 +258,10 @@ module Haml
       when ELEMENT; push tag(line)
       when COMMENT; push comment(line.text[1..-1].lstrip)
       when SANITIZE
-        return push plain(line.strip!(3), :escape_html) if line.text[1, 2] == '=='
+        return push plain(line.strip!(3), :escape_html) if line.text[1, 2] == '=='.freeze
         return push script(line.strip!(2), :escape_html) if line.text[1] == SCRIPT
         return push flat_script(line.strip!(2), :escape_html) if line.text[1] == FLAT_SCRIPT
-        return push plain(line.strip!(1), :escape_html) if line.text[1] == ?\s || line.text[1..2] == '#{'
+        return push plain(line.strip!(1), :escape_html) if line.text[1] == ?\s || line.text[1..2] == '#{'.freeze
         push plain(line)
       when SCRIPT
         return push plain(line.strip!(2)) if line.text[1] == SCRIPT
@@ -273,11 +273,11 @@ module Haml
         push silent_script(line)
       when FILTER; push filter(line.text[1..-1].downcase)
       when DOCTYPE
-        return push doctype(line.text) if line.text[0, 3] == '!!!'
-        return push plain(line.strip!(3), false) if line.text[1, 2] == '=='
+        return push doctype(line.text) if line.text[0, 3] == '!!!'.freeze
+        return push plain(line.strip!(3), false) if line.text[1, 2] == '=='.freeze
         return push script(line.strip!(2), false) if line.text[1] == SCRIPT
         return push flat_script(line.strip!(2), false) if line.text[1] == FLAT_SCRIPT
-        return push plain(line.strip!(1), false) if line.text[1] == ?\s || line.text[1..2] == '#{'
+        return push plain(line.strip!(1), false) if line.text[1] == ?\s || line.text[1..2] == '#{'.freeze
         push plain(line)
       when ESCAPE
         line.text = line.text[1..-1]
@@ -311,7 +311,7 @@ module Haml
     end
 
     def script(line, escape_html = nil, preserve = false)
-      raise SyntaxError.new(Error.message(:no_ruby_code, '=')) if line.text.empty?
+      raise SyntaxError.new(Error.message(:no_ruby_code, '='.freeze)) if line.text.empty?
       line = handle_ruby_multiline(line)
       escape_html = @options.escape_html if escape_html.nil?
 
@@ -323,7 +323,7 @@ module Haml
     end
 
     def flat_script(line, escape_html = nil)
-      raise SyntaxError.new(Error.message(:no_ruby_code, '~')) if line.text.empty?
+      raise SyntaxError.new(Error.message(:no_ruby_code, '~'.freeze)) if line.text.empty?
       script(line, escape_html, :preserve)
     end
 
@@ -335,12 +335,12 @@ module Haml
 
       check_push_script_stack(keyword)
 
-      if ["else", "elsif", "when"].include?(keyword)
+      if ["else".freeze, "elsif".freeze, "when".freeze].include?(keyword)
         if @script_level_stack.empty?
           raise Haml::SyntaxError.new(Error.message(:missing_if, keyword), @line.index)
         end
 
-        if keyword == 'when' and !@script_level_stack.last[2]
+        if keyword == 'when'.freeze and !@script_level_stack.last[2]
           if @script_level_stack.last[1] + 1 == @line.tabs
             @script_level_stack.last[1] += 1
           end
@@ -358,11 +358,11 @@ module Haml
     end
 
     def check_push_script_stack(keyword)
-      if ["if", "case", "unless"].include?(keyword)
+      if ["if".freeze, "case".freeze, "unless".freeze].include?(keyword)
         # @script_level_stack contents are arrays of form
         # [:keyword, stack_level, other_info]
         @script_level_stack.push([keyword.to_sym, @line.tabs])
-        @script_level_stack.last << false if keyword == 'case'
+        @script_level_stack.last << false if keyword == 'case'.freeze
         @tab_up = true
       end
     end
@@ -386,18 +386,18 @@ module Haml
 
       preserve_tag = @options.preserve.include?(tag_name)
       nuke_inner_whitespace ||= preserve_tag
-      escape_html = (action == '&' || (action != '!' && @options.escape_html))
+      escape_html = (action == '&'.freeze || (action != '!'.freeze && @options.escape_html))
 
       case action
-      when '/'; self_closing = true
-      when '~'; parse = preserve_script = true
-      when '='
+      when '/'.freeze; self_closing = true
+      when '~'.freeze; parse = preserve_script = true
+      when '='.freeze
         parse = true
         if value[0] == ?=
           value = unescape_interpolation(value[1..-1].strip, escape_html)
           escape_html = false
         end
-      when '&', '!'
+      when '&'.freeze, '!'.freeze
         if value[0] == ?= || value[0] == ?~
           parse = true
           preserve_script = (value[0] == ?~)
@@ -465,7 +465,7 @@ module Haml
 
     # Renders an XHTML comment.
     def comment(text)
-      if text[0..1] == '!['
+      if text[0..1] == '!['.freeze
         revealed = true
         text = text[1..-1]
       else
@@ -530,12 +530,12 @@ module Haml
     end
 
     def close_silent_script(node)
-      @script_level_stack.pop if ["if", "case", "unless"].include? node.value[:keyword]
+      @script_level_stack.pop if ["if".freeze, "case".freeze, "unless".freeze].include? node.value[:keyword]
 
       # Post-process case statements to normalize the nesting of "when" clauses
-      return unless node.value[:keyword] == "case"
+      return unless node.value[:keyword] == "case".freeze
       return unless first = node.children.first
-      return unless first.type == :silent_script && first.value[:keyword] == "when"
+      return unless first.type == :silent_script && first.value[:keyword] == "when".freeze
       return if first.children.empty?
       # If the case node has a "when" child with children, it's the
       # only child. Then we want to put everything nested beneath it
@@ -564,7 +564,7 @@ module Haml
             attributes[CLASS_KEY] = "".freeze
           end
           attributes[CLASS_KEY] += property
-        when '#'; attributes[ID_KEY] = property
+        when '#'.freeze; attributes[ID_KEY] = property
         end
       end
       attributes
@@ -698,7 +698,7 @@ module Haml
       end
 
       static_attributes = {}
-      dynamic_attributes = "{"
+      dynamic_attributes = ["{".freeze]
       attributes.each do |name, (type, val)|
         if type == :static
           static_attributes[name] = val
@@ -706,8 +706,9 @@ module Haml
           dynamic_attributes << "#{inspect_obj(name)} => #{val},"
         end
       end
-      dynamic_attributes << "}"
-      dynamic_attributes = nil if dynamic_attributes == "{}"
+      dynamic_attributes << "}".freeze
+      dynamic_attributes = dynamic_attributes.join(''.freeze)
+      dynamic_attributes = nil if dynamic_attributes == "{}".freeze
 
       return [static_attributes, dynamic_attributes], scanner.rest, last_line
     end
@@ -731,7 +732,7 @@ module Haml
       content = []
       loop do
         return false unless scanner.scan(re)
-        content << [:str, scanner[1].gsub(/\\(.)/, '\1')]
+        content << [:str, scanner[1].gsub(/\\(.)/, '\1'.freeze)]
         break if scanner[2] == quote
         content << [:ruby, balance(scanner, ?{, ?}, 1).first[0...-1]]
       end

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -64,14 +64,14 @@ module Haml
     #
     # @return [String]
     def precompiled_with_ambles(local_names, after_preamble: '')
-      preamble = <<END.tr!("\n", ';')
+      preamble = <<END.tr!("\n".freeze, ';'.freeze)
 begin
 extend Haml::Helpers
 _hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, #{Options.new(options).for_buffer.inspect})
 _erbout = _hamlout.buffer
 #{after_preamble}
 END
-      postamble = <<END.tr!("\n", ';')
+      postamble = <<END.tr!("\n".freeze, ';'.freeze)
 #{precompiled_method_return_value}
 ensure
 @haml_buffer = @haml_buffer.upper if @haml_buffer

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -6,18 +6,18 @@ require 'haml/generator'
 module Haml
   class TempleEngine < Temple::Engine
     define_options(
-      attr_wrapper:         "'",
+      attr_wrapper:         "'".freeze,
       autoclose:            %w(area base basefont br col command embed frame
                                hr img input isindex keygen link menuitem meta
                                param source track wbr),
       encoding:             nil,
       escape_attrs:         true,
       escape_html:          false,
-      filename:             '(haml)',
+      filename:             '(haml)'.freeze,
       format:               :html5,
       hyphenate_data_attrs: true,
       line:                 1,
-      mime_type:            'text/html',
+      mime_type:            'text/html'.freeze,
       preserve:             %w(textarea pre code),
       remove_whitespace:    false,
       suppress_eval:        false,
@@ -48,7 +48,7 @@ module Haml
     #
     # @return [String]
     def precompiled
-      encoding = Encoding.find(@encoding || '')
+      encoding = Encoding.find(@encoding || ''.freeze)
       return @precompiled.force_encoding(encoding) if encoding == Encoding::ASCII_8BIT
       return @precompiled.encode(encoding)
     end
@@ -63,7 +63,7 @@ module Haml
     # (see {file:REFERENCE.md#encodings the `:encoding` option}).
     #
     # @return [String]
-    def precompiled_with_ambles(local_names, after_preamble: '')
+    def precompiled_with_ambles(local_names, after_preamble: ''.freeze)
       preamble = <<END.tr!("\n".freeze, ';'.freeze)
 begin
 extend Haml::Helpers

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -64,9 +64,9 @@ module Haml
         # Get rid of the Unicode BOM if possible
         # Shortcut for UTF-8 which might be the majority case
         if str.encoding == Encoding::UTF_8
-          return str.gsub(/\A\uFEFF/, '')
+          return str.gsub(/\A\uFEFF/, ''.freeze)
         elsif str.encoding.name =~ /^UTF-(16|32)(BE|LE)?$/
-          return str.gsub(Regexp.new("\\A\uFEFF".encode(str.encoding)), '')
+          return str.gsub(Regexp.new("\\A\uFEFF".encode(str.encoding)), ''.freeze)
         else
           return str
         end

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -212,7 +212,7 @@ MSG
           else
             scan.scan(/\w+/)
           end
-          content = eval(%("#{interpolated}"))
+          content = eval("\"#{interpolated}\"")
           content.prepend(char) if char == '@'.freeze || char == '$'.freeze
           content = "Haml::Helpers.html_escape((#{content}))" if escape_html
 

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -183,15 +183,15 @@ MSG
     # @return [String] The name of the indentation (e.g. `"12 spaces"`, `"1 tab"`)
     def human_indentation(indentation)
       if !indentation.include?(?\t)
-        noun = 'space'
+        noun = 'space'.freeze
       elsif !indentation.include?(?\s)
-        noun = 'tab'
+        noun = 'tab'.freeze
       else
         return indentation.inspect
       end
 
       singular = indentation.length == 1
-      "#{indentation.length} #{noun}#{'s' unless singular}"
+      "#{indentation.length} #{noun}#{'s'.freeze unless singular}"
     end
 
     def contains_interpolation?(str)
@@ -207,13 +207,13 @@ MSG
         if escapes % 2 == 1
           res << "\##{char}"
         else
-          interpolated = if char == '{'
+          interpolated = if char == '{'.freeze
             balance(scan, ?{, ?}, 1)[0][0...-1]
           else
             scan.scan(/\w+/)
           end
-          content = eval('"' + interpolated + '"')
-          content.prepend(char) if char == '@' || char == '$'
+          content = eval(%("#{interpolated}"))
+          content.prepend(char) if char == '@'.freeze || char == '$'.freeze
           content = "Haml::Helpers.html_escape((#{content}))" if escape_html
 
           res << "\#{#{content}}"


### PR DESCRIPTION
Most of these were discovered when profiling performance issues on a page with 1000s of links generated via `link_to` in Rails.