### PR TITLE
Replace interpolated interpolation with cleaner method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Haml Changelog
 
+* Performance/memory improvement in `lib/haml/util.rb` that saves a string allocation [#965](https://github.com/haml/haml/pull/965) (thanks [Dillon Welch](https://github.com/oniofchaos))
 * Add constant for default options in `lib/haml/helpers/action_view_mods.rb` [#966](https://github.com/haml/haml/pull/966) (thanks [Dillon Welch](https://github.com/oniofchaos))
 * Performance/memory usage improvement in `lib/haml/buffer.rb` [#963](https://github.com/haml/haml/pull/963) (thanks [Dillon Welch](https://github.com/oniofchaos))
 * Add erubis to gemspec so that `benchmark.rb` works [#964](https://github.com/haml/haml/pull/964) (thanks [Dillon Welch](https://github.com/oniofchaos))

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -212,7 +212,7 @@ MSG
           else
             scan.scan(/\w+/)
           end
-          content = eval('"' + interpolated + '"')
+          content = eval("\"#{interpolated}\"")
           content.prepend(char) if char == '@' || char == '$'
           content = "Haml::Helpers.html_escape((#{content}))" if escape_html
 


### PR DESCRIPTION
In micro-benchmarking, this change performs within margin of error of
the existing code but saves a string allocation each time the method is
called (assuming the quote strings in the old code were frozen).

```
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update
                your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  gem "benchmark-ips"
end

def allocate_count
  GC.disable
  before = ObjectSpace.count_objects
  yield
  after = ObjectSpace.count_objects
  after.each { |k,v| after[k] = v - before[k] }
  after[:T_HASH] -= 1 # probe effect - we created the before hash.
  GC.enable
  result = after.reject { |k,v| v == 0 }
  GC.start
  result
end

interpolated = "hi"

  puts "'"' + interpolated + '"'"
  puts allocate_count { 1000.times { '"' + interpolated + '"' } }
  puts "%(\"\#{interpolated}\")"
  puts allocate_count { 1000.times { %("#{interpolated}") } }
  puts "\"\#{interpolated}\""
  puts allocate_count { 1000.times { "\"#{interpolated}\"" } }

Benchmark.ips do |x|
  x.report("'"' + interpolated + '"'") { '"' + interpolated + '"' }
  x.report("%(\"\#{interpolated}\")")  { %("#{interpolated}") }
  x.report("\"\#{interpolated}\"")     { "\"#{interpolated}\"" }
  x.compare!
end
```
```
' + interpolated + '
{:FREE=>-1892, :T_STRING=>2052}
%("#{interpolated}")
{:FREE=>-1001, :T_STRING=>1000}
"#{interpolated}"
{:FREE=>-1001, :T_STRING=>1000}
Warming up --------------------------------------
' + interpolated + '    81.706k i/100ms
%("#{interpolated}")   106.128k i/100ms
   "#{interpolated}"   137.855k i/100ms
Calculating -------------------------------------
' + interpolated + '      3.892M (±23.2%) i/s -     17.975M in   5.007068s
%("#{interpolated}")      3.722M (±17.3%) i/s -     17.830M in   5.022549s
   "#{interpolated}"      3.725M (±15.0%) i/s -     18.059M in   5.023493s

Comparison:
' + interpolated + ':  3892392.6 i/s
   "#{interpolated}":  3725385.8 i/s - same-ish: difference falls within error
%("#{interpolated}"):  3722401.7 i/s - same-ish: difference falls within error
```

results of `benchmark.rb`
```
                                         Haml |     ERB |  Erubis |
-------------------------------------------------------------------
Cached                                  0.094 |   0.083 |   0.073 |
ActionView                             16.937 |  11.760 |         |
ActionView with deep partials          38.459 |  40.428 |         |
```

compared to current master
```
                                         Haml |     ERB |  Erubis |
-------------------------------------------------------------------
Cached                                  0.174 |   0.420 |   0.224 |
ActionView                             21.360 |  11.631 |         |
ActionView with deep partials          43.563 |  39.238 |         |
```