### PR TITLE
Add constant for default content_tag_with_haml options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Haml Changelog
 
+* Add constant for default options in `lib/haml/helpers/action_view_mods.rb` [#966](https://github.com/haml/haml/pull/966) (thanks [Dillon Welch](https://github.com/oniofchaos))
 * Add erubis to gemspec so that `benchmark.rb` works [#964](https://github.com/haml/haml/pull/964) (thanks [Dillon Welch](https://github.com/oniofchaos))
 
 ## 5.0.4

--- a/lib/haml/helpers/action_view_mods.rb
+++ b/lib/haml/helpers/action_view_mods.rb
@@ -52,10 +52,12 @@ module ActionView
     end
 
     module TagHelper
+      DEFAULT_PRESERVE_OPTIONS = %w(textarea pre code).freeze
+
       def content_tag_with_haml(name, *args, &block)
         return content_tag_without_haml(name, *args, &block) unless is_haml?
 
-        preserve = haml_buffer.options.fetch(:preserve, %w[textarea pre code]).include?(name.to_s)
+        preserve = haml_buffer.options.fetch(:preserve, DEFAULT_PRESERVE_OPTIONS).include?(name.to_s)
 
         if block_given? && block_is_haml?(block) && preserve
           return content_tag_without_haml(name, *args) do


### PR DESCRIPTION
This saves an array allocation each time the method is called.

```ruby
begin
  require "bundler/inline"
rescue LoadError => e
  $stderr.puts "Bundler version 1.10 or later is required. Please update
                your Bundler"
  raise e
end

gemfile(true) do
  source "https://rubygems.org"

  gem "benchmark-ips"
  gem "rails"
end

def allocate_count
  GC.disable
  before = ObjectSpace.count_objects
  yield
  after = ObjectSpace.count_objects
  after.each { |k,v| after[k] = v - before[k] }
  after[:T_HASH] -= 1 # probe effect - we created the before hash.
  GC.enable
  result = after.reject { |k,v| v == 0 }
  GC.start
  result
end

DEFAULT_PRESERVE_OPTIONS = %w(textarea pre code).freeze
@hash = {}

def master_version
  {}.fetch(:preserve, %w(textarea pre code))
end

def fast_version
  {}.fetch(:preserve, DEFAULT_PRESERVE_OPTIONS)
end

puts "master_version"
puts allocate_count { 1000.times { master_version } }
puts "fast_version"
puts allocate_count { 1000.times { fast_version } }

Benchmark.ips do |x|
  x.report("master_version") { master_version }
  x.report("fast_version")     { fast_version }
  x.compare!
end
```

```ruby
master_version
{:FREE=>-1812, :T_STRING=>52, :T_ARRAY=>1000, :T_HASH=>1000}
fast_version
{:FREE=>-1001, :T_HASH=>1000}
Warming up --------------------------------------
      master_version   127.040k i/100ms
        fast_version    79.789k i/100ms
Calculating -------------------------------------
      master_version      3.310M (±35.6%) i/s -     13.212M in   5.007796s
        fast_version      5.899M (±19.3%) i/s -     28.166M in   5.016644s

Comparison:
        fast_version:  5899290.2 i/s
      master_version:  3310098.8 i/s - 1.78x  slower
```

Results of `benchmark.rb`
```
                                         Haml |     ERB |  Erubis |
-------------------------------------------------------------------
Cached                                  0.089 |   0.080 |   0.062 |
ActionView                             18.273 |  12.743 |         |
ActionView with deep partials          44.632 |  43.307 |         |
```

compared to current master:
```
                                         Haml |     ERB |  Erubis |
-------------------------------------------------------------------
Cached                                  0.174 |   0.420 |   0.224 |
ActionView                             21.360 |  11.631 |         |
ActionView with deep partials          43.563 |  39.238 |         |
```