### PR TITLE
Frozen string literal changes

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'haml/attribute_builder'
 require 'haml/attribute_compiler'
 require 'haml/temple_line_counter'
@@ -315,7 +315,7 @@ module Haml
 
       case last.first
       when :text
-        last[1].rstrip!
+        last[1] = last[1].rstrip
         if last[1].empty?
           @to_merge.slice! index
           rstrip_buffer! index

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -315,7 +315,7 @@ module Haml
 
       case last.first
       when :text
-        last[1].rstrip!
+        last[1] = last[1].rstrip
         if last[1].empty?
           @to_merge.slice! index
           rstrip_buffer! index

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 require 'haml/attribute_builder'
 require 'haml/attribute_compiler'
 require 'haml/temple_line_counter'
@@ -315,7 +315,7 @@ module Haml
 
       case last.first
       when :text
-        last[1] = last[1].rstrip
+        last[1].rstrip!
         if last[1].empty?
           @to_merge.slice! index
           rstrip_buffer! index

--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'haml/attribute_builder'
 require 'haml/attribute_compiler'
 require 'haml/temple_line_counter'

--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'forwardable'
 
 require 'haml/parser'
@@ -166,8 +166,13 @@ module Haml
       end
 
       begin
-        eval("Proc.new { |*_haml_locals| _haml_locals = _haml_locals[0] || {};" <<
-             @temple_engine.precompiled_with_ambles(local_names) << "}\n", scope, @options.filename, @options.line)
+        str = @temple_engine.precompiled_with_ambles(local_names)
+        eval(
+          "Proc.new { |*_haml_locals| _haml_locals = _haml_locals[0] || {}; #{str}}\n",
+          scope,
+          @options.filename,
+          @options.line
+        )
       rescue ::SyntaxError => e
         raise SyntaxError, e.message
       end

--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require "tilt"
 
 module Haml
@@ -183,8 +183,7 @@ RUBY
           end
 
           rendered = Haml::Helpers::find_and_preserve(filter.render_with_options(text, compiler.options), compiler.options[:preserve])
-          rendered.rstrip!
-          push_text("#{rendered}\n")
+          push_text("#{rendered.rstrip}\n")
         end
       end
     end
@@ -247,10 +246,7 @@ RUBY
 
       # @see Base#render
       def render(text)
-        text = "\n#{text}"
-        text.rstrip!
-        text.gsub!("\n", "\n    ")
-        "<![CDATA[#{text}\n]]>"
+        "<![CDATA[#{"\n#{text.rstrip}".gsub("\n", "\n    ")}\n]]>"
       end
     end
 

--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require "tilt"
 
 module Haml
@@ -247,10 +247,8 @@ RUBY
 
       # @see Base#render
       def render(text)
-        text = "\n#{text}"
-        text.rstrip!
-        text.gsub!("\n", "\n    ")
-        "<![CDATA[#{text}\n]]>"
+        text = text.rstrip.gsub("\n", "\n    ")
+        "<![CDATA[\n    #{text}\n]]>"
       end
     end
 

--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 require "tilt"
 
 module Haml
@@ -247,8 +247,10 @@ RUBY
 
       # @see Base#render
       def render(text)
-        text = text.rstrip.gsub("\n", "\n    ")
-        "<![CDATA[\n    #{text}\n]]>"
+        text = "\n#{text}"
+        text.rstrip!
+        text.gsub!("\n", "\n    ")
+        "<![CDATA[#{text}\n]]>"
       end
     end
 

--- a/lib/haml/generator.rb
+++ b/lib/haml/generator.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 module Haml
   # Ruby code generator, which is a limited version of Temple::Generator.
   # Limit methods since Haml doesn't need most of them.

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'erb'
 
 module Haml
@@ -109,10 +109,7 @@ MESSAGE
     #   @yield The block within which to escape newlines
     def find_and_preserve(input = nil, tags = haml_buffer.options[:preserve], &block)
       return find_and_preserve(capture_haml(&block), input || tags) if block
-      tags = tags.each_with_object('') do |t, s|
-        s << '|' unless s.empty?
-        s << Regexp.escape(t)
-      end
+      tags = tags.map { |tag| Regexp.escape(tag) }.join('|')
       re = /<(#{tags})([^>]*)>(.*?)(<\/\1>)/im
       input.to_s.gsub(re) do |s|
         s =~ re # Can't rely on $1, etc. existing since Rails' SafeBuffer#gsub is incompatible
@@ -200,8 +197,8 @@ MESSAGE
     # @yield [item] A block which contains Haml code that goes within list items
     # @yieldparam item An element of `enum`
     def list_of(enum, opts={}, &block)
-      opts_attributes = opts.each_with_object('') {|(k, v), s| s << " #{k}='#{v}'"}
-      enum.each_with_object('') do |i, ret|
+      opts_attributes = opts.map { |k, v| " #{k}='#{v}'" }.join
+      enum.map do |i|
         result = capture_haml(i, &block)
 
         if result.count("\n") > 1
@@ -211,9 +208,8 @@ MESSAGE
           result.strip!
         end
 
-        ret << "\n" unless ret.empty?
-        ret << %Q!<li#{opts_attributes}>#{result}</li>!
-      end
+        %Q!<li#{opts_attributes}>#{result}</li>!
+      end.join("\n")
     end
 
     # Returns a hash containing default assignments for the `xmlns`, `lang`, and `xml:lang`
@@ -704,4 +700,3 @@ class Object
     false
   end
 end
-

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 require 'strscan'
 
 module Haml
@@ -788,7 +788,7 @@ module Haml
     end
 
     def handle_ruby_multiline(line)
-      line.text = line.text.rstrip
+      line.text.rstrip!
       return line unless is_ruby_multiline?(line.text)
       begin
         # Use already fetched @next_line in the first loop. Otherwise, fetch next

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 require 'temple'
 require 'haml/escapable'
 require 'haml/generator'
@@ -64,14 +64,14 @@ module Haml
     #
     # @return [String]
     def precompiled_with_ambles(local_names, after_preamble: '')
-      preamble = <<END.tr("\n", ';')
+      preamble = <<END.tr!("\n", ';')
 begin
 extend Haml::Helpers
 _hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, #{Options.new(options).for_buffer.inspect})
 _erbout = _hamlout.buffer
 #{after_preamble}
 END
-      postamble = <<END.tr("\n", ';')
+      postamble = <<END.tr!("\n", ';')
 #{precompiled_method_return_value}
 ensure
 @haml_buffer = @haml_buffer.upper if @haml_buffer
@@ -99,13 +99,12 @@ END
     def locals_code(names)
       names = names.keys if Hash === names
 
-      code = []
-      names.map do |name|
+      names.each_with_object('') do |name, code|
         # Can't use || because someone might explicitly pass in false with a symbol
         sym_local = "_haml_locals[#{inspect_obj(name.to_sym)}]"
         str_local = "_haml_locals[#{inspect_obj(name.to_s)}]"
         code << "#{name} = #{sym_local}.nil? ? #{str_local} : #{sym_local};"
-      end.join
+      end
     end
 
     def inspect_obj(obj)

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -49,7 +49,7 @@ module Haml
     # @return [String]
     def precompiled
       encoding = Encoding.find(@encoding || '')
-      return @precompiled.force_encoding(encoding) if encoding == Encoding::ASCII_8BIT
+      return @precompiled.dup.force_encoding(encoding) if encoding == Encoding::ASCII_8BIT
       return @precompiled.encode(encoding)
     end
 

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -99,12 +99,11 @@ END
     def locals_code(names)
       names = names.keys if Hash === names
 
-      code = []
       names.map do |name|
         # Can't use || because someone might explicitly pass in false with a symbol
         sym_local = "_haml_locals[#{inspect_obj(name.to_sym)}]"
         str_local = "_haml_locals[#{inspect_obj(name.to_s)}]"
-        code << "#{name} = #{sym_local}.nil? ? #{str_local} : #{sym_local};"
+        "#{name} = #{sym_local}.nil? ? #{str_local} : #{sym_local};"
       end.join
     end
 

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -99,12 +99,13 @@ END
     def locals_code(names)
       names = names.keys if Hash === names
 
-      names.each_with_object('') do |name, code|
+      code = []
+      names.map do |name|
         # Can't use || because someone might explicitly pass in false with a symbol
         sym_local = "_haml_locals[#{inspect_obj(name.to_sym)}]"
         str_local = "_haml_locals[#{inspect_obj(name.to_s)}]"
         code << "#{name} = #{sym_local}.nil? ? #{str_local} : #{sym_local};"
-      end
+      end.join
     end
 
     def inspect_obj(obj)

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'temple'
 require 'haml/escapable'
 require 'haml/generator'
@@ -64,14 +64,14 @@ module Haml
     #
     # @return [String]
     def precompiled_with_ambles(local_names, after_preamble: '')
-      preamble = <<END.tr!("\n", ';')
+      preamble = <<END.tr("\n", ';')
 begin
 extend Haml::Helpers
 _hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, #{Options.new(options).for_buffer.inspect})
 _erbout = _hamlout.buffer
 #{after_preamble}
 END
-      postamble = <<END.tr!("\n", ';')
+      postamble = <<END.tr("\n", ';')
 #{precompiled_method_return_value}
 ensure
 @haml_buffer = @haml_buffer.upper if @haml_buffer

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'temple'
 require 'haml/escapable'
 require 'haml/generator'
@@ -64,14 +64,14 @@ module Haml
     #
     # @return [String]
     def precompiled_with_ambles(local_names, after_preamble: '')
-      preamble = <<END.tr!("\n", ';')
+      preamble = <<END.tr("\n", ';')
 begin
 extend Haml::Helpers
 _hamlout = @haml_buffer = Haml::Buffer.new(haml_buffer, #{Options.new(options).for_buffer.inspect})
 _erbout = _hamlout.buffer
 #{after_preamble}
 END
-      postamble = <<END.tr!("\n", ';')
+      postamble = <<END.tr("\n", ';')
 #{precompiled_method_return_value}
 ensure
 @haml_buffer = @haml_buffer.upper if @haml_buffer
@@ -99,12 +99,13 @@ END
     def locals_code(names)
       names = names.keys if Hash === names
 
-      names.each_with_object('') do |name, code|
+      code = []
+      names.map do |name|
         # Can't use || because someone might explicitly pass in false with a symbol
         sym_local = "_haml_locals[#{inspect_obj(name.to_sym)}]"
         str_local = "_haml_locals[#{inspect_obj(name.to_s)}]"
         code << "#{name} = #{sym_local}.nil? ? #{str_local} : #{sym_local};"
-      end
+      end.join
     end
 
     def inspect_obj(obj)

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -166,14 +166,14 @@ MSG
     #   and the rest of the string.
     #   `["Foo (Bar (Baz bang) bop)", " (Bang (bop bip))"]` in the example above.
     def balance(scanner, start, finish, count = 0)
-      str = []
+      str = ''
       scanner = StringScanner.new(scanner) unless scanner.is_a? StringScanner
       regexp = Regexp.new("(.*?)[\\#{start.chr}\\#{finish.chr}]", Regexp::MULTILINE)
       while scanner.scan(regexp)
         str << scanner.matched
         count += 1 if scanner.matched[-1] == start
         count -= 1 if scanner.matched[-1] == finish
-        return [str.join.strip, scanner.rest] if count == 0
+        return [str.strip, scanner.rest] if count == 0
       end
     end
 
@@ -199,7 +199,7 @@ MSG
     end
 
     def unescape_interpolation(str, escape_html = nil)
-      res = []
+      res = ''
       rest = Haml::Util.handle_interpolation str.dump do |scan|
         escapes = (scan[2].size - 1) / 2
         char = scan[3] # '{', '@' or '$'
@@ -219,7 +219,7 @@ MSG
           res << "\#{#{content}}"
         end
       end
-      "#{res.join}#{rest}"
+      res + rest
     end
 
     private

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 begin
   require 'erubis/tiny'

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 begin
   require 'erubis/tiny'
@@ -166,7 +166,7 @@ MSG
     #   and the rest of the string.
     #   `["Foo (Bar (Baz bang) bop)", " (Bang (bop bip))"]` in the example above.
     def balance(scanner, start, finish, count = 0)
-      str = ''
+      str = ''.dup
       scanner = StringScanner.new(scanner) unless scanner.is_a? StringScanner
       regexp = Regexp.new("(.*?)[\\#{start.chr}\\#{finish.chr}]", Regexp::MULTILINE)
       while scanner.scan(regexp)
@@ -199,7 +199,7 @@ MSG
     end
 
     def unescape_interpolation(str, escape_html = nil)
-      res = ''
+      res = ''.dup
       rest = Haml::Util.handle_interpolation str.dump do |scan|
         escapes = (scan[2].size - 1) / 2
         char = scan[3] # '{', '@' or '$'

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 
 begin
   require 'erubis/tiny'
@@ -166,14 +166,14 @@ MSG
     #   and the rest of the string.
     #   `["Foo (Bar (Baz bang) bop)", " (Bang (bop bip))"]` in the example above.
     def balance(scanner, start, finish, count = 0)
-      str = ''
+      str = []
       scanner = StringScanner.new(scanner) unless scanner.is_a? StringScanner
       regexp = Regexp.new("(.*?)[\\#{start.chr}\\#{finish.chr}]", Regexp::MULTILINE)
       while scanner.scan(regexp)
         str << scanner.matched
         count += 1 if scanner.matched[-1] == start
         count -= 1 if scanner.matched[-1] == finish
-        return [str.strip, scanner.rest] if count == 0
+        return [str.join.strip, scanner.rest] if count == 0
       end
     end
 
@@ -199,7 +199,7 @@ MSG
     end
 
     def unescape_interpolation(str, escape_html = nil)
-      res = ''
+      res = []
       rest = Haml::Util.handle_interpolation str.dump do |scan|
         escapes = (scan[2].size - 1) / 2
         char = scan[3] # '{', '@' or '$'
@@ -219,7 +219,7 @@ MSG
           res << "\#{#{content}}"
         end
       end
-      res + rest
+      "#{res.join}#{rest}"
     end
 
     private

--- a/test/attribute_parser_test.rb
+++ b/test/attribute_parser_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class AttributeParserTeset < Haml::TestCase

--- a/test/filters_test.rb
+++ b/test/filters_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class FiltersTest < Haml::TestCase

--- a/test/helper_test.rb
+++ b/test/helper_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require "active_model/naming"
 

--- a/test/options_test.rb
+++ b/test/options_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 module Haml

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 module Haml
@@ -66,7 +67,7 @@ module Haml
         flunk 'else clause after if containing unless should be accepted'
       end
     end
-    
+
     test "loud script with else is accepted" do
       begin
         parse "= if true\n  - 'A'\n-else\n  - 'B'"

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -1,4 +1,3 @@
-# frozen_string_literal: true
 require 'test_helper'
 require 'mocks/article'
 

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 require 'mocks/article'
 

--- a/test/template_test_helper.rb
+++ b/test/template_test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module TemplateTestHelper
   TEMPLATE_PATH = File.join(__dir__, "templates")
 end

--- a/test/temple_line_counter_test.rb
+++ b/test/temple_line_counter_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class TempleLineCounterTest < Haml::TestCase

--- a/test/util_test.rb
+++ b/test/util_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require 'test_helper'
 
 class UtilTest < Haml::TestCase


### PR DESCRIPTION
I was able to get `frozen_string_literal: true` turned on in two files. Unfortunately I wasn't able to get them on in the rest, the majority of which were because of various calls to `rstrip!` and `tr!` which are more performant in micro-benchmarks and in memory usage. I made other changes in these files to string builder logic such that they no longer mutate strings, based on [this](https://stackoverflow.com/questions/6549074/whats-the-fastest-way-to-build-a-string-in-ruby) StackOverflow post.

String mutations preventing `frozen_string_literal: true`
`lib/haml/compiler.rb` - [rstrip!](https://github.com/q-centrix/haml/blob/master/lib/haml/compiler.rb#L318)
`lib/haml/filters` - [rstrip!](https://github.com/q-centrix/haml/blob/master/lib/haml/filters.rb#L251)
`lib/haml/template_engine.rb` - [force_encoding](https://github.com/haml/haml/blob/master/lib/haml/temple_engine.rb#L52), [tr!](https://github.com/q-centrix/haml/blob/master/lib/haml/temple_engine.rb#L67)
`lib/haml/parser.rb` - [rstrip!](https://github.com/q-centrix/haml/blob/master/lib/haml/parser.rb#L785)

I wanted to keep the commit history for discussion about the various changes. Once everything is approved I can squash the commits and add a changelog entry.


Result of `ruby benchmark.rb`
```
                                         Haml |     ERB |   Erubi |
-------------------------------------------------------------------
Cached                                  0.088 |   0.073 |   0.051 |
ActionView                             15.558 |         |  10.493 |
ActionView with deep partials          41.512 |         |  37.338 |
```

Current master
```
                                         Haml |     ERB |   Erubi |
-------------------------------------------------------------------
Cached                                  0.085 |   0.073 |   0.070 |
ActionView                             18.001 |         |  10.954 |
ActionView with deep partials          46.022 |         |  34.406 |
```