### PR TITLE
un-freeze TempleEngine precompiled string literals

### DIFF
--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -54,7 +54,7 @@ module Haml
     end
 
     def precompiled_with_return_value
-      "#{precompiled};#{precompiled_method_return_value}"
+      "#{precompiled};#{precompiled_method_return_value}".dup
     end
 
     # The source code that is evaluated to produce the Haml document.
@@ -77,7 +77,7 @@ ensure
 @haml_buffer = @haml_buffer.upper if @haml_buffer
 end
 END
-      "#{preamble}#{locals_code(local_names)}#{precompiled}#{postamble}"
+      "#{preamble}#{locals_code(local_names)}#{precompiled}#{postamble}".dup
     end
 
     private


### PR DESCRIPTION
Fixes #982.
This PR maintains public-API compatibility in `Haml::TempleEngine#precompiled_with_return_value` and `precompiled_with_ambles`, returning mutable strings as expected by `tilt`'s Haml template implementation (which [calls `#force_encoding` on the result](https://github.com/rtomayko/tilt/blob/70000d8af45f7020a88f796b056cc0a1be2410dd/lib/tilt/template.rb#L188-L195)).