### PR TITLE
add escape_interpolated_html option

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -1121,7 +1121,7 @@ is compiled to
     </div>
 
 Note that `#{}` interpolation within filters is HTML-escaped if you specify
-{Haml::Options#escape_html `:escape_html`} option.
+{Haml::Options#escape_interpolated_html `:escape_interpolated_html`} option.
 
 The functionality of some filters such as Markdown can be provided by many
 different libraries. Usually you don't have to worry about this - you can just

--- a/lib/haml/filters.rb
+++ b/lib/haml/filters.rb
@@ -164,7 +164,11 @@ module Haml
           if contains_interpolation?(text)
             return if options[:suppress_eval]
 
-            text = unescape_interpolation(text, options[:escape_html]).gsub(/(\\+)n/) do |s|
+            escape = options[:escape_interpolated_html]
+            # `escape_interpolated_html` defaults to `escape_html` if unset.
+            escape = options[:escape_html] if escape.nil?
+
+            text = unescape_interpolation(text, escape).gsub(/(\\+)n/) do |s|
               escapes = $1.size
               next s if escapes % 2 == 0
               "#{'\\' * (escapes - 1)}\n"

--- a/lib/haml/options.rb
+++ b/lib/haml/options.rb
@@ -8,7 +8,7 @@ module Haml
     @valid_formats = [:html4, :html5, :xhtml]
 
     @buffer_option_keys = [:autoclose, :preserve, :attr_wrapper, :format,
-      :encoding, :escape_html, :escape_attrs, :hyphenate_data_attrs, :cdata]
+      :encoding, :escape_html, :escape_interpolated_html, :escape_attrs, :hyphenate_data_attrs, :cdata]
 
     # The default option values.
     # @return Hash
@@ -84,6 +84,13 @@ module Haml
     #
     # Defaults to false.
     attr_accessor :escape_html
+
+    # Sets whether or not to escape HTML-sensitive characters in interpolated strings.
+    # See also {file:REFERENCE.md#escaping_html Escaping HTML} and
+    # {file:REFERENCE.md#unescaping_html Unescaping HTML}.
+    #
+    # Defaults to the current value of `escape_html`.
+    attr_accessor :escape_interpolated_html
 
     # The name of the Haml file being parsed.
     # This is only used as information when exceptions are raised. This is

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -13,6 +13,7 @@ module Haml
       encoding:             nil,
       escape_attrs:         true,
       escape_html:          false,
+      escape_interpolated_html: nil,
       filename:             '(haml)',
       format:               :html5,
       hyphenate_data_attrs: true,


### PR DESCRIPTION
Addresses points raised in (closed issue) #940, by allowing optional backwards compatibility to work around breaking changes introduced by #770 (released in [`5.0.0`](https://github.com/haml/haml/blob/master/CHANGELOG.md#500)).

This PR is mostly intended for migrating large/legacy applications written against the v4 API, that want to upgrade to v5 while avoiding time-intensive application refactoring (e.g., https://github.com/haml/haml/issues/940#issuecomment-329769397).

My particular use-case is a need to upgrade `haml` to `>= 5.0.4` for [Ruby 2.5 support](https://github.com/haml/haml/blob/master/CHANGELOG.md#504) without refactoring large amounts of existing application code.

Introduces a new `escape_interpolated_html` option (defaults to the current value of `escape_html` for backwards compatibility with existing `5.x` default behavior), which can be used to override the behavior for escaping HTML in interpolated strings separately from other html-escaping behavior.

With this option, it's possible to set `Haml::Template.options[:escape_interpolated_html] = false` (e.g., in a Rails initializer) for full backwards compatibility with v4 behavior, without any further changes to existing application code.