### PR TITLE
Add support to `Haml::Plugin` for Rails 6

### DIFF
--- a/lib/haml/plugin.rb
+++ b/lib/haml/plugin.rb
@@ -5,7 +5,7 @@ module Haml
   class Plugin
     def handles_encoding?; true; end
 
-    def compile(template)
+    def compile(template, source)
       options = Haml::Template.options.dup
       if template.respond_to?(:type)
         options[:mime_type] = template.type
@@ -13,14 +13,16 @@ module Haml
         options[:mime_type] = template.mime_type
       end
       options[:filename] = template.identifier
-      Haml::Engine.new(template.source, options).compiler.precompiled_with_ambles(
+      Haml::Engine.new(source, options).compiler.precompiled_with_ambles(
         [],
         after_preamble: '@output_buffer = output_buffer ||= ActionView::OutputBuffer.new if defined?(ActionView::OutputBuffer)',
       )
     end
 
-    def self.call(template)
-      new.compile(template)
+    def self.call(template, source = nil)
+      source ||= template.source
+
+      new.compile(template, source)
     end
 
     def cache_fragment(block, name = {}, options = nil)


### PR DESCRIPTION
In Rails 6 the API for template handlers is changing, a template handler
must now take two arguments [1], the template and the source, otherwise you
will see the following deprecation warning:

```
ActiveSupport::DeprecationException: DEPRECATION WARNING: Single arity
template handlers are deprecated.  Template handlers must now accept two
parameters, the view object and the source for the view object.
Change:
  >> Class#call(template)
To:
  >> Class#call(template, source)
```

I have attempted to retain support for older versions of Rails by
providing a default source of `nil`.

[1] https://www.github.com/rails/rails/commit/28f88e0074