### PR TITLE
Do not run escape_html on text/plain files

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -307,7 +307,7 @@ module Haml
         return ParseNode.new(:plain, line.index + 1, :text => line.text)
       end
 
-      escape_html = @options.escape_html if escape_html.nil?
+      escape_html = @options.escape_html && @options.mime_type != 'text/plain' if escape_html.nil?
       line.text = unescape_interpolation(line.text, escape_html)
       script(line, false)
     end

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1458,6 +1458,10 @@ HAML
     end
   end
 
+  def test_mime_type_text_plain_with_interpolation
+    assert_equal("&\n", render("\#{'&'}", :escape_html => true, :mime_type => 'text/plain'))
+  end
+
   def test_static_hashes
     assert_equal("<a b='a =&gt; b'></a>\n", render("%a{:b => 'a => b'}", :suppress_eval => true))
     assert_equal("<a b='a, b'></a>\n", render("%a{:b => 'a, b'}", :suppress_eval => true))


### PR DESCRIPTION
Currently `text.haml` files are html escaped. This PR fixes that.

Related to haml/haml#1014 and haml/haml-rails#163