### PR TITLE
Unfreeze string literals for ParseNode#inspect

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -202,7 +202,7 @@ module Haml
       end
 
       def inspect
-        %Q[(#{type} #{value.inspect}#{children.each_with_object('') {|c, s| s << "\n#{c.inspect.gsub!(/^/, '  ')}"}})]
+        %Q[(#{type} #{value.inspect}#{children.each_with_object(''.dup) {|c, s| s << "\n#{c.inspect.gsub!(/^/, '  ')}"}})].dup
       end
     end
 

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -96,6 +96,14 @@ module Haml
       end
     end
 
+    test "inspect for node with children returns text" do
+      text = "some revealed text"
+      cond = "[cond]"
+      node = parse("/!#{cond} #{text}")
+
+      assert_equal "(root nil\n  (comment {:conditional=>\"[cond]\", :text=>\"some revealed text\", :revealed=>true, :parse=>false}))", node.inspect
+    end
+
     test "revealed conditional comments are detected" do
       text = "some revealed text"
       cond = "[cond]"


### PR DESCRIPTION
Since newrelic is using the `#inspect` method on `ParseNode` the ruby code crashes due to frozen strings in `inspect`, which are recursively called with `gsub!` causing this error:

![Screen Shot 2019-08-06 at 10 54 08](https://user-images.githubusercontent.com/5362483/62526970-904ba000-b83a-11e9-9576-849b62d4470c.png)

I added a regression test that fails with the current code.