### PR TITLE
Attributes wrapped correctly on escape_attrs=false

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Note that you can also run just one test out of the test suite if you're working
 on a specific area:
 
 ~~~sh
-ruby -Itest test/helper_test.rb -n test_buffer_access
+bunle exec ruby -Itest test/helper_test.rb -n test_buffer_access
 ~~~
 
 Haml currently supports Ruby 2.0.0 and higher, so please make sure your changes run on 2.0+.

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -34,16 +34,16 @@ module Haml
             next
           end
 
-          value =
-            if escape_attrs == :once
-              Haml::Helpers.escape_once(value.to_s)
-            elsif escape_attrs
-              Haml::Helpers.html_escape(value.to_s)
-            else
-              value.to_s
-            end
+          if escape_attrs == :once
+            value = Haml::Helpers.escape_once(value.to_s)
+          elsif escape_attrs
+            value = Haml::Helpers.html_escape(value.to_s)
+          else
+            next " #{attr}=#{value.to_s.inspect}"
+          end
           " #{attr}=#{attr_wrapper}#{value}#{attr_wrapper}"
         end
+
         result.compact!
         result.sort!
         result.join

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -692,7 +692,7 @@ HAML
 
   def test_escape_attrs_false
     assert_equal(<<HTML, render(<<HAML, :escape_attrs => false))
-<div class='<?php echo "&quot;" ?>' id='foo'>
+<div class="<?php echo \\\"&quot;\\\" ?>" id="foo">
 bar
 </div>
 HTML
@@ -2139,6 +2139,11 @@ HAML
 %div{ 'x /><script>alert(1);</script><div x' => 'hello' }
       HAML
     end
+  end
+
+  def test_escape_attrs_quotes
+    html = render(%{ %a{ :href => '/', :'@click' => "callback('a')" } link }.strip, :escape_attrs => false)
+    assert_equal html.strip, %{ <a @click="callback('a')" href="/">link</a> }.strip
   end
 
   def test_engine_reflects_defaults


### PR DESCRIPTION
When an attribute has quotes, and we need to disable `escape_attrs`, the quotes aren't escaped correctly, this PR fixes it.