### PR TITLE
Escape attributes regardless of whether it's SafeBuffer or not

### DIFF
--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -36,9 +36,9 @@ module Haml
 
           value =
             if escape_attrs == :once
-              Haml::Helpers.escape_once(value.to_s)
+              Haml::Helpers.escape_once_without_haml_xss(value.to_s)
             elsif escape_attrs
-              Haml::Helpers.html_escape(value.to_s)
+              Haml::Helpers.html_escape_without_haml_xss(value.to_s)
             else
               value.to_s
             end

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -171,7 +171,7 @@ module Haml
         ['false, nil', [:multi]],
         [:else, [:multi,
                  [:static, " #{id_or_class}=#{@attr_wrapper}"],
-                 [:escape, @escape_attrs, [:dynamic, var]],
+                 [:escape, Escapable::EscapeSafeBuffer.new(@escape_attrs), [:dynamic, var]],
                  [:static, @attr_wrapper]],
         ]
        ],
@@ -191,7 +191,7 @@ module Haml
         ['false, nil', [:multi]],
         [:else, [:multi,
                  [:static, " #{key}=#{@attr_wrapper}"],
-                 [:escape, @escape_attrs, [:dynamic, var]],
+                 [:escape, Escapable::EscapeSafeBuffer.new(@escape_attrs), [:dynamic, var]],
                  [:static, @attr_wrapper]],
         ]
        ],

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -607,8 +607,11 @@ MESSAGE
     # @param text [String] The string to sanitize
     # @return [String] The sanitized string
     def html_escape(text)
-      ERB::Util.html_escape(text)
+      CGI.escapeHTML(text.to_s)
     end
+
+    # Always escape text regardless of html_safe?
+    alias_method :html_escape_without_haml_xss, :html_escape
 
     HTML_ESCAPE_ONCE_REGEX = /['"><]|&(?!(?:[a-zA-Z]+|#(?:\d+|[xX][0-9a-fA-F]+));)/
 
@@ -621,6 +624,9 @@ MESSAGE
       text = text.to_s
       text.gsub(HTML_ESCAPE_ONCE_REGEX, HTML_ESCAPE)
     end
+
+    # Always escape text once regardless of html_safe?
+    alias_method :escape_once_without_haml_xss, :escape_once
 
     # Returns whether or not the current template is a Haml template.
     #

--- a/lib/haml/helpers/xss_mods.rb
+++ b/lib/haml/helpers/xss_mods.rb
@@ -8,10 +8,13 @@ module Haml
     # to work with Rails' XSS protection methods.
     module XssMods
       def self.included(base)
-        %w[html_escape find_and_preserve preserve list_of surround
-           precede succeed capture_haml haml_concat haml_internal_concat haml_indent
-           escape_once].each do |name|
+        %w[find_and_preserve preserve list_of surround
+           precede succeed capture_haml haml_concat haml_internal_concat haml_indent].each do |name|
           base.send(:alias_method, "#{name}_without_haml_xss", name)
+          base.send(:alias_method, name, "#{name}_with_haml_xss")
+        end
+        # Those two always have _without_haml_xss
+        %w[html_escape escape_once].each do |name|
           base.send(:alias_method, name, "#{name}_with_haml_xss")
         end
       end

--- a/test/results/escape_safe_buffer.xhtml
+++ b/test/results/escape_safe_buffer.xhtml
@@ -1,0 +1,4 @@
+<div data-html='&lt;foo&gt;bar&lt;/foo&gt;'></div>
+<meta content='&#39;&quot;' />
+<meta content='&#39;&quot;' />
+<meta content='&#39;&quot;' />

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -248,7 +248,18 @@ HAML
   end
 
   def test_xss_protection_in_attributes_with_safe_strings
-    assert_equal("<div data-html='<foo>bar</foo>'></div>\n", render('%div{ "data-html" => "<foo>bar</foo>".html_safe }', :action_view))
+    assert_equal("<div data-html='&lt;foo&gt;bar&lt;/foo&gt;'></div>\n", render('%div{ "data-html" => "<foo>bar</foo>".html_safe }', :action_view))
+    assert_equal(<<-HTML, render(<<-HAML, :action_view))
+<meta content='&#39;&quot;' />
+<meta content='&#39;&quot;' />
+<meta content='&#39;&quot;' />
+HTML
+%meta{ content: %{'"}.html_safe }
+- val = %{'"}.html_safe
+%meta{ content: val }
+- hash = { content: val }
+%meta{ hash }
+HAML
   end
 
   def test_xss_protection_with_bang_in_interpolation

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -248,18 +248,9 @@ HAML
   end
 
   def test_xss_protection_in_attributes_with_safe_strings
-    assert_equal("<div data-html='&lt;foo&gt;bar&lt;/foo&gt;'></div>\n", render('%div{ "data-html" => "<foo>bar</foo>".html_safe }', :action_view))
-    assert_equal(<<-HTML, render(<<-HAML, :action_view))
-<meta content='&#39;&quot;' />
-<meta content='&#39;&quot;' />
-<meta content='&#39;&quot;' />
-HTML
-%meta{ content: %{'"}.html_safe }
-- val = %{'"}.html_safe
-%meta{ content: val }
-- hash = { content: val }
-%meta{ hash }
-HAML
+    assert_renders_correctly('escape_safe_buffer') do |name|
+      render(File.read(File.expand_path("templates/#{name}.haml", __dir__)), :action_view)
+    end
   end
 
   def test_xss_protection_with_bang_in_interpolation

--- a/test/templates/escape_safe_buffer.haml
+++ b/test/templates/escape_safe_buffer.haml
@@ -1,0 +1,6 @@
+%div{ 'data-html' => '<foo>bar</foo>'.html_safe }
+%meta{ content: %{'"}.html_safe }
+- val = %{'"}.html_safe
+%meta{ content: val }
+- hash = { content: val }
+%meta{ hash }


### PR DESCRIPTION
Fixes #993, fixes #1019

Like rails helpers fixed in CVE-2016-6316, an attribute should be HTML-escaped even if it's a SafeBuffer.