### PR TITLE
Fix Test Suite with Bundler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /.yardoc
 /coverage
 /doc

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,8 +14,7 @@ if ENV["COVERAGE"]
   SimpleCov.start
 end
 
-require 'bundler'
-Bundler.setup
+require 'bundler/setup'
 require 'minitest/autorun'
 require 'action_pack'
 require 'action_controller'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,7 @@ if ENV["COVERAGE"]
 end
 
 require 'bundler'
+Bundler.setup
 require 'minitest/autorun'
 require 'action_pack'
 require 'action_controller'


### PR DESCRIPTION
The README specifies that you can run `rake` in order to successfully pass the test suite.

Unfortunately, due to the include order in the test_helper, you actually have to run `bundler exec rake`.

We were already partially setting up Bundler in the `test_helper`, and this makes it startup properly.