### PR TITLE
Reorder Class Names Follow Up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Fix crash in the attribute optimizer when `#inspect` is overridden in TrueClass / FalseClass [#972](https://github.com/haml/haml/issues/972)
 * Do not HTML-escape templates that are declared to be plaintext [#1014](https://github.com/haml/haml/issues/1014) (Thanks [@cesarizu](https://github.com/cesarizu))
+* Class names are no longer ordered alphabetically, and now follow a new specification as laid out in REFERENCE [#306](https://github.com/haml/haml/issues/306)
 
 ## 5.1.2
 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -517,6 +517,24 @@ and is compiled to:
       </div>
     </div>
 
+#### Class Name Merging and Ordering
+
+Class names are ordered in the following way:
+
+1) Tag identifiers in order (aka, ".alert.me" => "alert me")
+2) Classes appearing in HTML-style attributes
+3) Classes appearing in Hash-style attributes
+
+For instance, this is a complicated and unintuitive test case illustrating the ordering
+
+    .foo.moo{:class => ['bar', 'alpha']}(class='baz')
+
+The resulting HTML would be as follows:
+
+    <div class='foo moo baz bar alpha'></div>
+
+*Versions of Haml prior to 5.0 would alphabetically sort class names.*
+
 ### Empty (void) Tags: `/`
 
 The forward slash character, when placed at the end of a tag definition, causes

--- a/test/engine_test.rb
+++ b/test/engine_test.rb
@@ -1681,7 +1681,7 @@ HAML
   def test_new_attribute_classes
     assert_equal("<div class='foo bar'></div>\n", render(".foo(class='bar')"))
     assert_equal("<div class='foo baz bar'></div>\n", render(".foo{:class => 'bar'}(class='baz')"))
-    assert_equal("<div class='foo bar baz'></div>\n", render(".foo(class='bar'){:class => 'baz'}"))
+    assert_equal("<div class='foo moo baz bar alpha'></div>\n", render(".foo.moo{:class => ['bar', 'alpha']}(class='baz')"))
     foo = User.new(42)
     assert_equal("<div class='foo bar baz struct_user' id='struct_user_42'></div>\n",
       render(".foo(class='bar'){:class => 'baz'}[foo]", :locals => {:foo => foo}))


### PR DESCRIPTION
Update the haml-spec submodule, added text to the REFERENCE file specifying this behaviour, and also added a more comprehensive test case.