### PR TITLE
Enable frozen string literal

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ rvm:
   - 2.6
   - 2.5
   - jruby-9.2
+env:
+  - RUBYOPT="--enable-frozen-string-literal"
+  - RUBYOPT=""
 gemfile:
   - test/gemfiles/Gemfile.rails-6.0.x
   - test/gemfiles/Gemfile.rails-5.2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,24 +29,60 @@ matrix:
       gemfile: test/gemfiles/Gemfile.rails-4.1.x
     - rvm: 2.5
       gemfile: test/gemfiles/Gemfile.rails-4.2.x
+    - rvm: 2.5
+      gemfile: test/gemfiles/Gemfile.rails-5.0.x
+      env: RUBYOPT="--enable-frozen-string-literal"
+    - rvm: 2.5
+      gemfile: test/gemfiles/Gemfile.rails-5.0.x.erubi
+      env: RUBYOPT="--enable-frozen-string-literal"
+    - rvm: 2.5
+      gemfile: test/gemfiles/Gemfile.rails-5.1.x
+      env: RUBYOPT="--enable-frozen-string-literal"
     - rvm: 2.6
       gemfile: test/gemfiles/Gemfile.rails-4.0.x
     - rvm: 2.6
       gemfile: test/gemfiles/Gemfile.rails-4.1.x
     - rvm: 2.6
       gemfile: test/gemfiles/Gemfile.rails-4.2.x
+    - rvm: 2.6
+      gemfile: test/gemfiles/Gemfile.rails-5.0.x
+      env: RUBYOPT="--enable-frozen-string-literal"
+    - rvm: 2.6
+      gemfile: test/gemfiles/Gemfile.rails-5.0.x.erubi
+      env: RUBYOPT="--enable-frozen-string-literal"
+    - rvm: 2.6
+      gemfile: test/gemfiles/Gemfile.rails-5.1.x
+      env: RUBYOPT="--enable-frozen-string-literal"
     - rvm: 2.7
       gemfile: test/gemfiles/Gemfile.rails-4.0.x
     - rvm: 2.7
       gemfile: test/gemfiles/Gemfile.rails-4.1.x
     - rvm: 2.7
       gemfile: test/gemfiles/Gemfile.rails-4.2.x
+    - rvm: 2.7
+      gemfile: test/gemfiles/Gemfile.rails-5.0.x
+      env: RUBYOPT="--enable-frozen-string-literal"
+    - rvm: 2.7
+      gemfile: test/gemfiles/Gemfile.rails-5.0.x.erubi
+      env: RUBYOPT="--enable-frozen-string-literal"
+    - rvm: 2.7
+      gemfile: test/gemfiles/Gemfile.rails-5.1.x
+      env: RUBYOPT="--enable-frozen-string-literal"
     - rvm: ruby-head
       gemfile: test/gemfiles/Gemfile.rails-4.0.x
     - rvm: ruby-head
       gemfile: test/gemfiles/Gemfile.rails-4.1.x
     - rvm: ruby-head
       gemfile: test/gemfiles/Gemfile.rails-4.2.x
+    - rvm: jruby-9.2
+      gemfile: test/gemfiles/Gemfile.rails-5.0.x
+      env: RUBYOPT="--enable-frozen-string-literal"
+    - rvm: jruby-9.2
+      gemfile: test/gemfiles/Gemfile.rails-5.0.x.erubi
+      env: RUBYOPT="--enable-frozen-string-literal"
+    - rvm: jruby-9.2
+      gemfile: test/gemfiles/Gemfile.rails-5.1.x
+      env: RUBYOPT="--enable-frozen-string-literal"
   include:
     - rvm: 2.7
       gemfile: test/gemfiles/Gemfile.rails-edge

--- a/haml.gemspec
+++ b/haml.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rbench'
   spec.add_development_dependency 'minitest', '>= 4.0'
   spec.add_development_dependency 'nokogiri'
-  spec.add_development_dependency 'simplecov', '0.17.1' # Locked to this version due to https://github.com/codeclimate/test-reporter/issues/418
+  spec.add_development_dependency 'simplecov'
 
   spec.description = <<-END
 Haml (HTML Abstraction Markup Language) is a layer on top of HTML or XML that's

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -213,7 +213,7 @@ MSG
             scan.scan(/\w+/)
           end
           content = eval("\"#{interpolated}\"")
-          content.prepend(char) if char == '@' || char == '$'
+          content = "#{char}#{content}" if char == '@' || char == '$'
           content = "Haml::Helpers.html_escape((#{content}))" if escape_html
 
           res << "\#{#{content}}"

--- a/test/cases/engine_internals_test.rb
+++ b/test/cases/engine_internals_test.rb
@@ -37,7 +37,7 @@ class EngineInternalsTest < TestBase
         print Haml::Engine.new('%div{ foo: true, bar: false }').render
       HAML
       f.close
-      out = IO.popen([RbConfig.ruby, f.path], &:read)
+      out = IO.popen([RbConfig.ruby, '-W0', f.path], &:read)
       assert_equal true, $?.success?
       assert_equal "<div foo></div>\n", out
     end

--- a/test/cases/nesting_test.rb
+++ b/test/cases/nesting_test.rb
@@ -160,7 +160,7 @@ c
 b
 a
 HTML
-- str = "abcde"
+- str = +"abcde"
 - if true
   = str.slice!(-1).chr
 - end until str.empty?

--- a/test/cases/ruby_multiline_test.rb
+++ b/test/cases/ruby_multiline_test.rb
@@ -187,7 +187,7 @@ bar, , true, bang
 <p>bar</p>
 HTML
 = ["bar",
-   "  ".strip!,
+   "  ".strip,
    "".empty?,
    "bang"].join(", ")
 %p foo


### PR DESCRIPTION
https://github.com/haml/haml/pull/967 added the frozen string literal magic comments on all ruby files.

To ensure that the strings are not modified in the future, I think the tests also should cover it. This PR fixes a string mutation case and runs tests with `RUBYOPT=--enable-frozen-string-literal`, where the ruby interpreter will ensure the frozen strings.