### PR TITLE
Implement multiline attributes

### DIFF
--- a/test/cases/attribute_test.rb
+++ b/test/cases/attribute_test.rb
@@ -109,4 +109,19 @@ HAML
 %a{h1, :aria => h2}
     HAML
   end
+
+  def test_multiline_attributes
+    assert_equal(<<HTML, render(<<HAML))
+<div class='haml' data-content='/:|}' data-haml-info-url='https://haml.info' id='info'>Haml</div>
+HTML
+.haml#info{
+  "data": {
+    "content": "/:|}",
+    "haml-info": {
+      "url": "https://haml.info",
+    }
+  }
+} Haml
+HAML
+  end
 end

--- a/test/cases/exception_test.rb
+++ b/test/cases/exception_test.rb
@@ -56,9 +56,9 @@ class ExceptionTest < TestBase
       "%p{'foo' => 'bar' 'bar' => 'baz'}"                    => :compile,
       "%p{:foo => }"                                         => :compile,
       "%p{=> 'bar'}"                                         => :compile,
-      "%p{'foo => 'bar'}"                                    => :compile,
-      "%p{:foo => 'bar}"                                     => :compile,
-      "%p{:foo => 'bar\"}"                                   => :compile,
+      "%p{'foo => 'bar'}"                                    => error(:unbalanced_brackets),
+      "%p{:foo => 'bar}"                                     => error(:unbalanced_brackets),
+      "%p{:foo => 'bar\"}"                                   => error(:unbalanced_brackets),
       # Regression tests
       "foo\n\n\n  bar"                                       => [error(:illegal_nesting_plain), 4],
       "%p/\n\n  bar"                                         => [error(:illegal_nesting_self_closing), 3],


### PR DESCRIPTION
Fixes #981.

This is ported from [Hamlit v1 code](https://github.com/k0kubun/hamlit/blob/v1.7.2/lib/hamlit/parsers/attribute.rb#L29-L43) which supported multiline attributes. It was dropped when Hamlit started using Haml's parser in v2, but I'd be happy to resurrect the support. Please read the code comments for design decision details.