### PR TITLE
Add support for annotate_rendered_view_with_filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Haml Changelog
 
+## Unreleased
+
+* Support for adding Annotations to Haml output (a Rails feature 6.1+)
+
 ## 5.2.1
 
 Released on November 30, 2020

--- a/lib/haml/plugin.rb
+++ b/lib/haml/plugin.rb
@@ -24,8 +24,10 @@ module Haml
       postamble = ''
 
       if self.class.annotate_rendered_view_with_filenames
-        preamble += "haml_concat '<!-- BEGIN #{template.short_identifier} -->'.html_safe;"
-        postamble += "haml_concat '<!-- END #{template.short_identifier} -->'.html_safe;"
+        # short_identifier is only available in Rails 6+. On older versions, 'inspect' gives similar results.
+        ident = template.respond_to?(:short_identifier) ? template.short_identifier : template.inspect
+        preamble += "haml_concat '<!-- BEGIN #{ident} -->'.html_safe;"
+        postamble += "haml_concat '<!-- END #{ident} -->'.html_safe;"
       end
 
       Haml::Engine.new(source, options).compiler.precompiled_with_ambles(

--- a/lib/haml/railtie.rb
+++ b/lib/haml/railtie.rb
@@ -42,6 +42,11 @@ module Haml
           Haml::Filters::RailsErb.template_class = Haml::SafeErubisTemplate
         end
         Haml::Template.options[:filters] = { 'erb' => Haml::Filters::RailsErb }
+
+        if app.config.respond_to?(:action_view) &&
+           app.config.action_view.annotate_rendered_view_with_filenames
+          Haml::Plugin.annotate_rendered_view_with_filenames = true
+        end
       end
     end
   end

--- a/lib/haml/temple_engine.rb
+++ b/lib/haml/temple_engine.rb
@@ -65,7 +65,7 @@ module Haml
     # (see {file:REFERENCE.md#encodings the `:encoding` option}).
     #
     # @return [String]
-    def precompiled_with_ambles(local_names, after_preamble: '')
+    def precompiled_with_ambles(local_names, after_preamble: '', before_postamble: '')
       preamble = <<END.tr("\n", ';')
 begin
 extend Haml::Helpers
@@ -74,6 +74,7 @@ _erbout = _hamlout.buffer
 #{after_preamble}
 END
       postamble = <<END.tr("\n", ';')
+#{before_postamble}
 #{precompiled_method_return_value}
 ensure
 @haml_buffer = @haml_buffer.upper if @haml_buffer

--- a/test/template_test.rb
+++ b/test/template_test.rb
@@ -293,6 +293,16 @@ HAML
     assert_equal("Foo & Bar", render('- safe_concat "Foo & Bar"', :action_view))
   end
 
+  def test_annotated_template_names
+    original_setting = Haml::Plugin.annotate_rendered_view_with_filenames
+    Haml::Plugin.annotate_rendered_view_with_filenames = true
+    result = @base.render(partial: "partial")
+    assert_equal("<!-- BEGIN test/templates/_partial.haml -->\n", result.lines.first)
+    assert_equal("<!-- END test/templates/_partial.haml -->\n", result.lines.last)
+  ensure
+    Haml::Plugin.annotate_rendered_view_with_filenames = original_setting
+  end
+
   ## Regression
 
   def test_xss_protection_with_nested_haml_tag


### PR DESCRIPTION
Rails 6.1 adds a `ActionView::Base.annotate_rendered_view_with_filenames` option, but it's ERB-only (https://github.com/rails/rails/blob/89b52a8dd35cd90e0de05aa2ddc3f5b61832a269/actionview/lib/action_view/template/handlers/erb.rb#L53-L56)

How about something like this?  It adds filename comments into the html looking like, eg:

```html
<div class='navbar-light navbar-collapse collapse wi-100 d-md-none' id='navbar-collapse'>
    <div class='navbar-nav phm mbm' role='menu'>
        <!-- BEGIN app/views/page_header/_user_profile_links.html.haml -->
        <a class="nav-link" href="/profile">Profile</a>
        <a class="nav-link" href="/account/edit">Settings</a>
        <div class='dropdown-divider'></div>
        <a class="nav-link" href="/logout">Log out</a>
        <!-- END app/views/page_header/_user_profile_links.html.haml -->

```

Not sure how clean the implementation is, let me know if there's a more suitable place to insert these.

