### PR TITLE
Drop Haml::Buffer dependency from attributes

### DIFF
--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -51,7 +51,8 @@ module Haml
     # @param dynamic_attributes [Haml::Parser::DynamicAttributes]
     # @return [String] Attributes rendering code
     def compile_runtime_build(attributes, object_ref, dynamic_attributes)
-      "_hamlout.attributes(#{to_literal(attributes)}, #{object_ref}, #{dynamic_attributes.to_literal})"
+      arguments = [@is_html, @attr_wrapper, @escape_attrs, @hyphenate_data_attrs].map(&method(:to_literal)).join(', ')
+      "::Haml::AttributeBuilder.build(#{to_literal(attributes)}, #{object_ref}, #{arguments}, #{dynamic_attributes.to_literal})"
     end
 
     # Build array of grouped values whose sort order may go back and forth, which is also sorted with key name.
@@ -106,7 +107,8 @@ module Haml
       hash_content = values.group_by(&:key).map do |key, values_for_key|
         "#{frozen_string(key)} => #{merged_value(key, values_for_key)}"
       end.join(', ')
-      [:dynamic, "_hamlout.attributes({ #{hash_content} }, nil)"]
+      arguments = [@is_html, @attr_wrapper, @escape_attrs, @hyphenate_data_attrs].map(&method(:to_literal)).join(', ')
+      [:dynamic, "::Haml::AttributeBuilder.build({ #{hash_content} }, nil, #{arguments})"]
     end
 
     # Renders attribute values statically.

--- a/lib/haml/buffer.rb
+++ b/lib/haml/buffer.rb
@@ -130,18 +130,6 @@ module Haml
       @real_tabs += tab_change
     end
 
-    def attributes(class_id, obj_ref, *attributes_hashes)
-      attributes = class_id
-      attributes_hashes.each do |old|
-        result = {}
-        old.each { |k, v| result[k.to_s] = v }
-        AttributeBuilder.merge_attributes!(attributes, result)
-      end
-      AttributeBuilder.merge_attributes!(attributes, parse_object_ref(obj_ref)) if obj_ref
-      AttributeBuilder.build_attributes(
-        html?, @options[:attr_wrapper], @options[:escape_attrs], @options[:hyphenate_data_attrs], attributes)
-    end
-
     # Remove the whitespace from the right side of the buffer string.
     # Doesn't do anything if we're at the beginning of a capture_haml block.
     def rstrip!
@@ -189,50 +177,6 @@ module Haml
     def tabs(count = 0)
       tabs = [count + @tabulation, 0].max
       @@tab_cache[tabs] ||= '  ' * tabs
-    end
-
-    # Takes an array of objects and uses the class and id of the first
-    # one to create an attributes hash.
-    # The second object, if present, is used as a prefix,
-    # just like you can do with `dom_id()` and `dom_class()` in Rails
-    def parse_object_ref(ref)
-      prefix = ref[1]
-      ref = ref[0]
-      # Let's make sure the value isn't nil. If it is, return the default Hash.
-      return {} if ref.nil?
-      class_name =
-        if ref.respond_to?(:haml_object_ref)
-          ref.haml_object_ref
-        else
-          underscore(ref.class)
-        end
-      ref_id =
-        if ref.respond_to?(:to_key)
-          key = ref.to_key
-          key.join('_') unless key.nil?
-        else
-          ref.id
-        end
-      id = "#{class_name}_#{ref_id || 'new'}"
-      if prefix
-        class_name = "#{ prefix }_#{ class_name}"
-        id = "#{ prefix }_#{ id }"
-      end
-
-      { 'id'.freeze => id, 'class'.freeze => class_name }
-    end
-
-    # Changes a word from camel case to underscores.
-    # Based on the method of the same name in Rails' Inflector,
-    # but copied here so it'll run properly without Rails.
-    def underscore(camel_cased_word)
-      word = camel_cased_word.to_s.dup
-      word.gsub!(/::/, '_')
-      word.gsub!(/([A-Z]+)([A-Z][a-z])/, '\1_\2')
-      word.gsub!(/([a-z\d])([A-Z])/, '\1_\2')
-      word.tr!('-', '_')
-      word.downcase!
-      word
     end
   end
 end


### PR DESCRIPTION
This is one obvious way to reduce `Haml::Buffer` dependencies. This should have no impact.