### PR TITLE
Authorize `@` and `#` characters in attribute name

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -724,7 +724,7 @@ module Haml
     end
 
     def parse_new_attribute(scanner)
-      unless (name = scanner.scan(/[\.-:@#\w]+/))
+      unless (name = scanner.scan(/[-:@#\w\.]+/))
         return if scanner.scan(/\)/)
         return false
       end

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -724,7 +724,7 @@ module Haml
     end
 
     def parse_new_attribute(scanner)
-      unless (name = scanner.scan(/[-:@#\w]+/))
+      unless (name = scanner.scan(/[\.-:@#\w]+/))
         return if scanner.scan(/\)/)
         return false
       end

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -724,7 +724,7 @@ module Haml
     end
 
     def parse_new_attribute(scanner)
-      unless (name = scanner.scan(/[-:\w]+/))
+      unless (name = scanner.scan(/[-:@#\w]+/))
         return if scanner.scan(/\)/)
         return false
       end


### PR DESCRIPTION
Those characters are valid attributes name, and are used for example in VueJs