### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
           - '2.6'
           - '2.7'
           - '3.0'
+          - '3.1'
           - jruby
           - truffleruby-head
     steps:


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix