### PR TITLE
Resurrect block capturing support for non-Rails environments

### DIFF
--- a/lib/haml/compiler.rb
+++ b/lib/haml/compiler.rb
@@ -16,7 +16,7 @@ module Haml
       @comment_compiler       = CommentCompiler.new
       @doctype_compiler       = DoctypeCompiler.new(options)
       @filter_compiler        = Filters.new(options)
-      @script_compiler        = ScriptCompiler.new(identity)
+      @script_compiler        = ScriptCompiler.new(identity, options)
       @silent_script_compiler = SilentScriptCompiler.new
       @tag_compiler           = TagCompiler.new(identity, options)
     end

--- a/lib/haml/compiler/script_compiler.rb
+++ b/lib/haml/compiler/script_compiler.rb
@@ -15,8 +15,9 @@ module Haml
         end
       end
 
-      def initialize(identity)
+      def initialize(identity, options)
         @identity = identity
+        @disable_capture = options[:disable_capture]
       end
 
       def compile(node, &block)
@@ -88,7 +89,7 @@ module Haml
         else
           [:multi,
            [:block, "#{var} = #{node.value[:text]}",
-            [:multi, [:newline], yield(node)],
+            [:multi, [:newline], @disable_capture ? yield(node) : [:capture, Temple::Utils.unique_name, yield(node)]]
            ],
           ]
         end

--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -21,6 +21,7 @@ module Haml
                        hr img input isindex keygen link menuitem meta
                        param source track wbr),
       filename:     "",
+      disable_capture: false,
     )
 
     use Parser

--- a/lib/haml/rails_template.rb
+++ b/lib/haml/rails_template.rb
@@ -14,6 +14,7 @@ module Haml
           use_html_safe: true,
           streaming:     true,
           buffer_class:  'ActionView::OutputBuffer',
+          disable_capture: true,
         }
       end
 
@@ -33,8 +34,10 @@ module Haml
       end
 
       if ActionView::Base.try(:annotate_rendered_view_with_filenames) && template.format == :html
-        options[:preamble] = "<!-- BEGIN #{template.short_identifier} -->\n"
-        options[:postamble] = "<!-- END #{template.short_identifier} -->\n"
+        options = options.merge(
+          preamble: "<!-- BEGIN #{template.short_identifier} -->\n",
+          postamble: "<!-- END #{template.short_identifier} -->\n",
+        )
       end
 
       Engine.new(options).call(source)

--- a/test/hamlit/engine/script_test.rb
+++ b/test/hamlit/engine/script_test.rb
@@ -58,7 +58,7 @@ describe Haml::Engine do
     end
 
     it 'renders block script' do
-      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+      assert_render(<<-HTML.unindent, <<-HAML.unindent, disable_capture: true)
         0
         1
         2
@@ -71,7 +71,7 @@ describe Haml::Engine do
     end
 
     it 'renders tag internal block script' do
-      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+      assert_render(<<-HTML.unindent, <<-HAML.unindent, disable_capture: true)
         <span>
         0
         1</span>

--- a/test/hamlit/engine/whitespace_test.rb
+++ b/test/hamlit/engine/whitespace_test.rb
@@ -41,7 +41,7 @@ describe Haml::Engine do
     end
 
     it 'removes whitespaces inside block script' do
-      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+      assert_render(<<-HTML.unindent, <<-HAML.unindent, disable_capture: true)
         <span>foofoo2<span>bar</span></span>
       HTML
         %span<
@@ -62,7 +62,7 @@ describe Haml::Engine do
     end
 
     it 'removes whitespace inside script recursively' do
-      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+      assert_render(<<-HTML.unindent, <<-HAML.unindent, disable_capture: true)
         <div class='foo'>bar1bar1bar1bar12</div>
       HTML
         .foo<
@@ -104,7 +104,7 @@ describe Haml::Engine do
     end
 
     it 'does not nuke inside script' do
-      assert_render(%Q|<div><span>\nhello\n</span>1</div>|, <<-HAML.unindent)
+      assert_render(%Q|<div><span>\nhello\n</span>1</div>|, <<-HAML.unindent, disable_capture: true)
         %div><
           = 1.times do
             %span>

--- a/test/hamlit/line_number_test.rb
+++ b/test/hamlit/line_number_test.rb
@@ -25,7 +25,7 @@ describe Haml::Engine do
     end
 
     it 'renders dynamic script with children' do
-      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+      assert_render(<<-HTML.unindent, <<-HAML.unindent, disable_capture: true)
         1
         3
         3


### PR DESCRIPTION
This resurrects the block-capturing support of `Tilt::HamlTemplate` https://github.com/rtomayko/tilt/issues/325. It has been broken since v5, and this pull request fixes it by porting Hamlit 3's patch https://github.com/k0kubun/hamlit/compare/v2.16.0...v3.0.0 to Haml 6.