### PR TITLE
Remove mention of `Haml::Engine` in favor of `Haml::Template`

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -75,8 +75,8 @@ this, install the gem with RubyGems:
 
     gem install haml
 
-You can then use it by including the "haml" gem in Ruby code, and using
-{Haml::Engine} like so:
+You can then use it by including the `haml` gem in Ruby code, and using
+{Haml::Template} like so:
 
     engine = Haml::Template.new { "%p Haml code!" }
     engine.render #=> "<p>Haml code!</p>\n"


### PR DESCRIPTION
In Haml 6, the suggested code for using Haml programmatically was changed from `Haml::Engine` to `Haml::Template`. This PR adjusts the mention of `Haml::Engine` in the line before to be in line with the example code.