### PR TITLE
Explain special case of `data-` and `aria-` attributes

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -294,7 +294,19 @@ or using `true` and `false`:
     %input(selected=true)
 
 This feature works only for attributes that are included in
-[`Haml::AttributeBuilder::BOOLEAN_ATTRIBUTES`](lib/haml/attribute_builder.rb).
+[`Haml::AttributeBuilder::BOOLEAN_ATTRIBUTES`](lib/haml/attribute_builder.rb),
+as well as `data-` and `aria-` attributes.
+
+    %input{'data-hidden' => false}
+    %input{'aria-hidden' => false}
+    %input{'xyz-hidden' => false}
+
+will render as:
+
+    <input>
+    <input>
+    <input xyz-hidden='false'>
+
 
 <!-- The title to the next section (Prefixed Attributes) has changed. This
 <a> tag is so old links to here still work. -->


### PR DESCRIPTION
In the updated documentation, it is explained that only the `Haml::AttributeBuilder::BOOLEAN_ATTRIBUTES` are treated as boolean attributes. While testing this, I noticed that this also still works for `data-` and `aria-` attributes.

This makes sense, since this is exactly what the code does:

https://github.com/haml/haml/blob/b3cdafdaf09433af4b0988a533414d9409e72f2a/lib/haml/attribute_compiler.rb#L55

So I think it might be a good addition to the docs to mention this explicitely.

Thanks for your consideration!