### PR TITLE
Avoid loading ActionView::Base too early

### DIFF
--- a/lib/haml/rails_template.rb
+++ b/lib/haml/rails_template.rb
@@ -52,4 +52,6 @@ end
 
 # Haml extends Haml::Helpers in ActionView each time.
 # It costs much, so Haml includes a compatible module at first.
-ActionView::Base.send :include, Haml::RailsHelpers
+ActiveSupport.on_load(:action_view) do
+  include Haml::RailsHelpers
+end


### PR DESCRIPTION
Currently haml forces ActionView::Base to load very early in the initialization process, which can cause it to ignore config settings in config/initializers. How about this change to delay the `include Haml::RailsHelpers` until ActionView is ready?