### PR TITLE
Opt-in for MFA requirement

### DIFF
--- a/haml.gemspec
+++ b/haml.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.metadata      = { 'rubygems_mfa_required' => 'true' }
+
   if /java/ === RUBY_PLATFORM
     spec.platform = 'java'
   else


### PR DESCRIPTION
Make the gem more secure by requiring that all privileged operations by any of the owners require OTP.

Ref: https://guides.rubygems.org/mfa-requirement-opt-in/