### PR TITLE
Use the rails template path as filename

### DIFF
--- a/lib/haml/rails_template.rb
+++ b/lib/haml/rails_template.rb
@@ -28,7 +28,9 @@ module Haml
       options = RailsTemplate.options
 
       # Make the filename available in parser etc.
-      options[:filename] = template.identifier
+      if template.respond_to?(:identifier)
+        options = options.merge(filename: template.identifier)
+      end
 
       # https://github.com/haml/haml/blob/4.0.7/lib/haml/template/plugin.rb#L19-L20
       # https://github.com/haml/haml/blob/4.0.7/lib/haml/options.rb#L228

--- a/lib/haml/rails_template.rb
+++ b/lib/haml/rails_template.rb
@@ -27,6 +27,9 @@ module Haml
       source ||= template.source
       options = RailsTemplate.options
 
+      # Make the filename available in parser etc.
+      options[:filename] = template.identifier
+
       # https://github.com/haml/haml/blob/4.0.7/lib/haml/template/plugin.rb#L19-L20
       # https://github.com/haml/haml/blob/4.0.7/lib/haml/options.rb#L228
       if template.respond_to?(:type) && template.type == 'text/xml'


### PR DESCRIPTION
I want to make haml autogenerate id attributes for all elements. The ids should be static at runtime, so my idea was to use a hash of "#{filename}:#{line}". While trying to implement it, I noticed the filename is currently not set. This tiny patch fixes it.