### PR TITLE
add default_format method to RailsTemplate for Turbo compatibility

### DIFF
--- a/lib/haml/rails_template.rb
+++ b/lib/haml/rails_template.rb
@@ -48,6 +48,11 @@ module Haml
       Engine.new(options).call(source)
     end
 
+    # Rails Turbo looks for this
+    def default_format
+      :html
+    end
+
     def supports_streaming?
       RailsTemplate.options[:streaming]
     end


### PR DESCRIPTION
as discussed in 'issues'