### PR TITLE
Add support for case-in statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,12 +146,6 @@ Once this is complete, you should be able to run the test suite:
 rake
 ~~~
 
-You'll get a warning that you need to install haml-spec, so run this:
-
-~~~sh
-git submodule update --init
-~~~
-
 At this point `rake` should run without error or warning and you are ready to
 start working on your patch!
 

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -78,7 +78,7 @@ module Haml
     #
     BLOCK_WITH_SPACES = /do\s*\|\s*[^\|]*\s+\|\z/
 
-    MID_BLOCK_KEYWORDS = %w[else elsif rescue ensure end when].freeze
+    MID_BLOCK_KEYWORDS = %w[else elsif rescue ensure end when in].freeze
     START_BLOCK_KEYWORDS = %w[if begin case unless].freeze
     # Try to parse assignments to block starters as best as possible
     START_BLOCK_KEYWORD_REGEX = /(?:\w+(?:,\s*\w+)*\s*=\s*)?(#{START_BLOCK_KEYWORDS.join('|')})/

--- a/test/haml/engine/silent_script_test.rb
+++ b/test/haml/engine/silent_script_test.rb
@@ -164,6 +164,19 @@ describe Haml::Engine do
       HAML
     end
 
+    it 'renders case-in' do
+      skip 'pattern-matching not supported' if RUBY_VERSION < '2.7' || RUBY_ENGINE == 'truffleruby'
+      assert_render(<<-HTML.unindent, <<-'HAML'.unindent)
+        ok
+      HTML
+        - case [:foo, 'ok']
+        - in [:foo, msg]
+          = msg
+        - else
+          ng
+      HAML
+    end
+
     it 'renders begin-rescue' do
       assert_render(<<-HTML.unindent, <<-HAML.unindent)
         hello

--- a/test/haml/helper_test.rb
+++ b/test/haml/helper_test.rb
@@ -22,6 +22,7 @@ class HelperTest < Haml::TestCase
   end
 
   def setup
+    template_path = File.expand_path("../templates", __FILE__)
     @base = Class.new(ActionView::Base) do
       def nested_tag
         content_tag(:span) {content_tag(:div) {"something"}}
@@ -34,8 +35,7 @@ class HelperTest < Haml::TestCase
       def compiled_method_container
         self.class
       end
-    end.new(ActionView::LookupContext.new(''), {}, ActionController::Base.new)
-    @base.view_paths << File.expand_path("../templates", __FILE__)
+    end.new(ActionView::LookupContext.new(template_path), {}, ActionController::Base.new)
     @base.instance_variable_set(:@post, Post.new("Foo bar\nbaz", nil, PostErrors.new))
   end
 


### PR DESCRIPTION
WDYT to adding case-in support?

```haml
- case type_and_details
- in [:user_account, user]
  Profile #{user.name}
- in [:post, post]
  Post #{post.title}

```
Let me know if you think it needs more tests. I looked at adding some to engine_tests.rb, but they seem more like regression tests, wasn't sure of the best place to add it.