### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/haml

### DIFF
--- a/haml.gemspec
+++ b/haml.gemspec
@@ -21,6 +21,8 @@ Gem::Specification.new do |spec|
 
   spec.metadata      = { 'rubygems_mfa_required' => 'true' }
 
+  spec.metadata["changelog_uri"] = spec.homepage + "/blob/main/CHANGELOG.md"
+
   spec.required_ruby_version = '>= 2.1.0'
 
   spec.add_dependency 'temple', '>= 0.8.2'


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/haml which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/