### PR TITLE
Compile html attributes statically

### DIFF
--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -98,7 +98,7 @@ module Haml
     def compile_boolean!(temple, key, values)
       exp = literal_for(values.last)
 
-      if Temple::StaticAnalyzer.static?(exp)
+      if values.last.first == :static || Temple::StaticAnalyzer.static?(exp)
         value = eval(exp)
         case value
         when true then temple << [:html, :attr, key, @format == :xhtml ? [:static, key] : [:multi]]

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -11,6 +11,11 @@ describe 'optimization' do
       assert_equal true, compiled_code(haml).include?(%|href='1'|)
     end
 
+    it 'renders html attributes statically' do
+      haml = %|%span(data-boolean data-string="str")|
+      assert_equal true, compiled_code(haml).include?(%|<span data-boolean data-string='str'>|)
+    end
+
     it 'renders static script statically' do
       haml = <<-HAML.unindent
         %span


### PR DESCRIPTION
HTML boolean attributes (like `%input(disabled)` or `%span(data-string="string")` were not recognized as static code, causing results like
```
case ((_haml_compiler1 = (true.freeze)));
when true; _buf << (" disabled".freeze);
when false, nil;
else; _buf << ((%Q disabled='#{::Haml::Util.escape_html(((_haml_compiler1).to_s))}').to_s);
end;
```
(linebreaks added by me for legibility)

I didn't find any tests for these types of attributes, please tell me if I should write my tests elsewhere.