### PR TITLE
Backtrace format has been changed since Ruby 3.4

### DIFF
--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -97,7 +97,7 @@ class EngineTest < Haml::TestCase
     unless options[:filename]
       # use caller method name as fake filename. useful for debugging
       i = -1
-      caller[i+=1] =~ /`(.+?)'/ until $1 and $1.index('test_') == 0
+      caller[i+=1] =~ /[`'](?:.+?#)?(.+?)'/ until $1 and $1.index('test_') == 0
       options[:filename] = "(#{$1})"
     end
     options


### PR DESCRIPTION
Method names are quoted with ''
https://bugs.ruby-lang.org/issues/16495

Method names include method owner
https://bugs.ruby-lang.org/issues/19117

I hope this would fix the broken CI.