### PR TITLE
Optimize string transformation using `String#tr`

### DIFF
--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -105,7 +105,7 @@ module Haml::AttributeBuilder
             if k.nil?
               flattened[key] = v
             else
-              flattened["#{key}-#{k.to_s.gsub(/_/, '-')}"] = v
+              flattened["#{key}-#{k.to_s.tr('_', '-')}"] = v
             end
           end
         else


### PR DESCRIPTION
Hello, this is my first contribution to production code. I've checked `git blame` 6d71b6e757d1e5759d85a68e98ed421c552b72e1 and the usage of `gsub` does not look intended, so maybe this change is legit.

Benchmarks have been executed on M1 Pro, Ruby 3.3.4 x64

---

This change was flagged by RuboCop and has been verified for correctness and performance improvement. While Ruby 2.1 is no longer tested in CI, `String#tr` is supported since that version, ensuring backwards compatibility.

- Replace `gsub(/_/, '-')` with `tr('_', '-')` for better performance
- Improve `bench benchmark/data_attribute.haml` execution time by 20%
- Maintain compatibility with Ruby 2.1 (Haml's minimum required version)

Before:
```
### IPS
         haml v6.3.0     94.400k i/s (0.011ms) -    473.668k

### Memory
         haml v6.3.0     3.264k memsize (   600.000  retained)
                        41.000  objects (     9.000  retained)
                        19.000  strings (     6.000  retained)
```

After:
```
### IPS
         haml v6.3.0    113.201k i/s (0.009ms) -    568.672k

### Memory
         haml v6.3.0     2.808k memsize (   360.000  retained)
                        37.000  objects (     6.000  retained)
                        19.000  strings (     5.000  retained)
```

Refs:
- https://docs.ruby-lang.org/en/2.1.0/String.html#method-i-tr
- https://docs.rubocop.org/rubocop-performance/cops_performance.html#performancestringreplacement