### PR TITLE
Authorize characters in attribute name for vuejs.

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -749,7 +749,7 @@ module Haml
     end
 
     def parse_new_attribute(scanner)
-      unless (name = scanner.scan(/[-:\w]+/))
+      unless (name = scanner.scan(/[-:@#\w\.]+/))
         return if scanner.scan(/\)/)
         return false
       end

--- a/test/haml/engine/new_attribute_test.rb
+++ b/test/haml/engine/new_attribute_test.rb
@@ -34,6 +34,30 @@ describe Haml::Engine do
       HAML
     end
 
+    it 'renders @ attributes properly' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <p @foo='bar'>bar</p>
+      HTML
+        %p(@foo='bar') bar
+      HAML
+    end
+
+    it 'renders # attributes properly' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <p #foo='bar'>bar</p>
+      HTML
+        %p(#foo='bar') bar
+      HAML
+    end
+
+    it 'renders . attributes properly' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <p .foo='bar'>bar</p>
+      HTML
+        %p(.foo='bar') bar
+      HAML
+    end
+
     describe 'html escape' do
       it 'escapes attribute values on static attributes' do
         assert_render(<<-HTML.unindent, <<-'HAML'.unindent)


### PR DESCRIPTION
 Authorize @, #, and characters in attribute name.
 Those characters are valid attributes name, and are used for example in VueJs.