### PR TITLE
Support multiline syntax to break up long utility CSS class chains

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -807,7 +807,11 @@ module Haml
         break if new_line.eod?
         next @template.shift if new_line.text.strip.empty?
         break unless is_multiline?(new_line.text.strip)
-        line.text << new_line.text.strip[0...-1]
+        stripped_new_line = new_line.text.strip[0...-1]
+        if stripped_new_line[0] == DIV_CLASS || stripped_new_line[0] == DIV_ID
+          line.text.rstrip!
+        end
+        line.text << stripped_new_line
         @template.shift
       end
     end

--- a/test/haml/engine/tag_test.rb
+++ b/test/haml/engine/tag_test.rb
@@ -1,3 +1,5 @@
+require_relative '../../test_helper'
+
 describe Haml::Engine do
   include RenderHelper
 
@@ -106,6 +108,27 @@ describe Haml::Engine do
         <span class='b d' id='c'>hello</span>
       HTML
         %span#a.b#c.d hello
+      HAML
+    end
+
+    it 'renders multiline classes with inline content' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <span class='a b c d e'>hello</span>
+      HTML
+        %span.a.b.c     |
+             .d.e hello |
+      HAML
+    end
+
+    it 'renders multiline classes with nested content' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <span class='a b c d e'>
+        hello
+        </span>
+      HTML
+        %span.a.b.c |
+             .d.e   |
+          hello
       HAML
     end
 


### PR DESCRIPTION
I didn't get a reply when asked [about the concept](https://github.com/haml/haml/issues/1041#issuecomment-862531118) so I implemented this experiment. It piggybacks on the existing multiline syntax allowing

```haml
        %h1.mt-2                                            |
           .font-bold.text-2xl.text-grey-600.leading-tight  |
           .transition.duration-150.ease-in-out             |
           .lg:text-4xl.lg:mt-6                             |
           .group-hover:text-black                          |
           .group-focus:text-black                          |
```

to be treated as

```haml
         %h1.font-bold.text-2xl.lg:text-4xl.text-grey-600.mt-2.lg:mt-6.leading-tight.group-hover:text-black.group-focus:text-black.transition.duration-150.ease-in-out
````

I have only two simple tests at the moment so my questions are: 

1. Is this worth pursuing?
2. Are there better approaches to the same problem that I should try?