### PR TITLE
Enable frozen string literal in tests

### DIFF
--- a/test/haml/attribute_parser_test.rb
+++ b/test/haml/attribute_parser_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::AttributeParser do
   describe '.parse' do
     def assert_parse(expected, haml)

--- a/test/haml/cli_test.rb
+++ b/test/haml/cli_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'haml/cli'
 
 describe Haml::CLI do

--- a/test/haml/dynamic_merger_test.rb
+++ b/test/haml/dynamic_merger_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::DynamicMerger do
   describe '#call' do
     def assert_compile(expected, input)

--- a/test/haml/engine/attributes_test.rb
+++ b/test/haml/engine/attributes_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../test_helper'
 
 describe Haml::Engine do

--- a/test/haml/engine/comment_test.rb
+++ b/test/haml/engine/comment_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   include RenderHelper
 

--- a/test/haml/engine/doctype_test.rb
+++ b/test/haml/engine/doctype_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   include RenderHelper
 

--- a/test/haml/engine/indent_test.rb
+++ b/test/haml/engine/indent_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   include RenderHelper
 

--- a/test/haml/engine/multiline_test.rb
+++ b/test/haml/engine/multiline_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   include RenderHelper
 

--- a/test/haml/engine/new_attribute_test.rb
+++ b/test/haml/engine/new_attribute_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   include RenderHelper
 

--- a/test/haml/engine/old_attribute_test.rb
+++ b/test/haml/engine/old_attribute_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../../test_helper'
 
 describe Haml::Engine do

--- a/test/haml/engine/script_test.rb
+++ b/test/haml/engine/script_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   include RenderHelper
 

--- a/test/haml/engine/silent_script_test.rb
+++ b/test/haml/engine/silent_script_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   include RenderHelper
 

--- a/test/haml/engine/tag_test.rb
+++ b/test/haml/engine/tag_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   include RenderHelper
 

--- a/test/haml/engine/text_test.rb
+++ b/test/haml/engine/text_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   include RenderHelper
 

--- a/test/haml/engine/whitespace_test.rb
+++ b/test/haml/engine/whitespace_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   include RenderHelper
 

--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $:.unshift __dir__
 
 require_relative '../test_helper'

--- a/test/haml/error_test.rb
+++ b/test/haml/error_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Engine do
   describe 'Error' do
     it 'raises an error when Haml::Parser is used independently' do

--- a/test/haml/filters/cdata_test.rb
+++ b/test/haml/filters/cdata_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Filters do
   include RenderHelper
 

--- a/test/haml/filters/coffee_test.rb
+++ b/test/haml/filters/coffee_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Filters do
   include RenderHelper
 

--- a/test/haml/filters/css_test.rb
+++ b/test/haml/filters/css_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Filters do
   include RenderHelper
 

--- a/test/haml/filters/erb_test.rb
+++ b/test/haml/filters/erb_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Filters do
   include RenderHelper
 

--- a/test/haml/filters/javascript_test.rb
+++ b/test/haml/filters/javascript_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Filters do
   include RenderHelper
 

--- a/test/haml/filters/markdown_test.rb
+++ b/test/haml/filters/markdown_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Filters do
   include RenderHelper
 

--- a/test/haml/filters/plain_test.rb
+++ b/test/haml/filters/plain_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Filters do
   include RenderHelper
 

--- a/test/haml/filters/ruby_test.rb
+++ b/test/haml/filters/ruby_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Filters do
   include RenderHelper
 

--- a/test/haml/filters/sass_test.rb
+++ b/test/haml/filters/sass_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Filters do
   include RenderHelper
 

--- a/test/haml/filters/scss_test.rb
+++ b/test/haml/filters/scss_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Filters do
   include RenderHelper
 

--- a/test/haml/filters_test.rb
+++ b/test/haml/filters_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class FiltersTest < Haml::TestCase

--- a/test/haml/haml-spec/ugly_test.rb
+++ b/test/haml/haml-spec/ugly_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $:.unshift File.expand_path('../../test', __dir__)
 
 require 'test_helper'

--- a/test/haml/helper_test.rb
+++ b/test/haml/helper_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require "active_model/naming"
 

--- a/test/haml/helpers_test.rb
+++ b/test/haml/helpers_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::Helpers do
   describe '.preserve' do
     it 'works without block' do

--- a/test/haml/line_number_test.rb
+++ b/test/haml/line_number_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../test_helper'
 
 describe Haml::Engine do

--- a/test/haml/mocks/article.rb
+++ b/test/haml/mocks/article.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Article
   attr_accessor :id, :title, :body
   def initialize

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative '../test_helper'
 
 describe 'optimization' do

--- a/test/haml/rails_template_test.rb
+++ b/test/haml/rails_template_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Explicitly requiring rails_template because rails initializers is not executed here.
 require 'haml/rails_template'
 

--- a/test/haml/ruby_expression_test.rb
+++ b/test/haml/ruby_expression_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::RubyExpression do
   describe '.syntax_error?' do
     it { assert_equal(true,  Haml::RubyExpression.syntax_error?('{ hash }')) }

--- a/test/haml/string_splitter_test.rb
+++ b/test/haml/string_splitter_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Haml::StringSplitter do
   describe '.compile' do
     def assert_compile(expected, code)

--- a/test/haml/template_test.rb
+++ b/test/haml/template_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'haml/mocks/article'
 

--- a/test/haml/tilt_test.rb
+++ b/test/haml/tilt_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe Tilt::HamlTemplate do
   describe '#render' do
     def suppress_warning(&block)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'unindent'
 require 'bundler/setup'
 require 'minitest/autorun'


### PR DESCRIPTION
Eliminate a warning in Ruby >= 3.4

Close #1179

Required:
- [x] #1178

