### PR TITLE
Remove newlines from template annotation comments

### DIFF
--- a/lib/haml/rails_template.rb
+++ b/lib/haml/rails_template.rb
@@ -40,8 +40,8 @@ module Haml
 
       if ActionView::Base.try(:annotate_rendered_view_with_filenames) && template.format == :html
         options = options.merge(
-          preamble: "<!-- BEGIN #{template.short_identifier} -->\n",
-          postamble: "<!-- END #{template.short_identifier} -->\n",
+          preamble: "<!-- BEGIN #{template.short_identifier} -->",
+          postamble: "<!-- END #{template.short_identifier} -->",
         )
       end
 


### PR DESCRIPTION
This change allows for proper display of the HTML when `annotate_rendered_view_with_filenames` option is used.

Right now this option provides incorrect HTML output in development: adding new lines after each of the HTML comments.

This results in a UI different from production where these comments are not included.

Because `\n` is preserved as whitespace in HTML it can cause issues in inline layout.