### PR TITLE
Fix .class + nested class array bug

### DIFF
--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -54,7 +54,7 @@ module Haml::AttributeBuilder
         when value.is_a?(String)
           classes += value.split(' ')
         when value.is_a?(Array)
-          classes += value.select { |v| v }
+          classes += value.flatten.select { |v| v }
         when value
           classes << value.to_s
         end

--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -156,6 +156,7 @@ class EngineTest < Haml::TestCase
     assert_equal("<p class='css a b'>foo</p>\n", render("%p.css{:class => %w[a b]} foo")) # merge with css
     assert_equal("<p class='css b'>foo</p>\n", render("%p.css{:class => %w[css b]} foo")) # merge uniquely
     assert_equal("<p class='a b c d'>foo</p>\n", render("%p{:class => [%w[a b], %w[c d]]} foo")) # flatten
+    assert_equal("<p class='css a b'>foo</p>\n", render("%p.css{:class => [%w[a b]]} foo")) # flatten
     assert_equal("<p class='a b'>foo</p>\n", render("%p{:class => [:a, :b] } foo")) # stringify
     # [INCOMPATIBILITY] Haml limits boolean attributes
     # assert_equal("<p>foo</p>\n", render("%p{:class => [nil, false] } foo")) # strip falsey


### PR DESCRIPTION
As the ticket mentions, this worked before 6.2.0 removed the c extension. 

Close #1189