### PR TITLE
Use `Regexp#match?` predicate where possible

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,7 @@ gem 'base64'
 gem 'bigdecimal'
 gem 'mutex_m'
 
-if /java/ === RUBY_PLATFORM # JRuby
+if /java/.match?(RUBY_PLATFORM) # JRuby
   gem 'pandoc-ruby'
 else
   gem 'redcarpet'

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -236,7 +236,7 @@ module Haml
     DynamicAttributes = Struct.new(:new, :old) do
       undef :old=
       def old=(value)
-        unless value =~ /\A{.*}\z/m
+        unless /\A{.*}\z/m.match?(value)
           raise ArgumentError.new('Old attributes must start with "{" and end with "}"')
         end
         self[:old] = value
@@ -528,7 +528,7 @@ module Haml
     end
 
     def filter(name)
-      raise Error.new(Error.message(:invalid_filter_name, name)) unless name =~ /^\w+$/
+      raise Error.new(Error.message(:invalid_filter_name, name)) unless /^\w+$/.match?(name)
 
       if filter_opened?
         @flat = true

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -69,7 +69,7 @@ module Haml
         # Shortcut for UTF-8 which might be the majority case
         if str.encoding == Encoding::UTF_8
           return str.gsub(/\A\uFEFF/, '')
-        elsif str.encoding.name =~ /^UTF-(16|32)(BE|LE)?$/
+        elsif /^UTF-(16|32)(BE|LE)?$/.match?(str.encoding.name)
           return str.gsub(Regexp.new("\\A\uFEFF".encode(str.encoding)), '')
         else
           return str

--- a/test/haml/engine/old_attribute_test.rb
+++ b/test/haml/engine/old_attribute_test.rb
@@ -131,7 +131,7 @@ describe Haml::Engine do
       end
 
       it 'does not crash when nil is given' do
-        if /java/ === RUBY_PLATFORM
+        if /java/.match?(RUBY_PLATFORM)
           skip 'maybe due to Ripper of JRuby'
         end
 

--- a/test/haml/filters/coffee_test.rb
+++ b/test/haml/filters/coffee_test.rb
@@ -60,5 +60,5 @@ describe Haml::Filters do
             alert("#{'<&>'}")
       HAML
     end
-  end unless /java/ === RUBY_PLATFORM # execjs is not working with Travis JRuby environment
+  end unless /java/.match?(RUBY_PLATFORM) # execjs is not working with Travis JRuby environment
 end

--- a/test/haml/line_number_test.rb
+++ b/test/haml/line_number_test.rb
@@ -149,7 +149,7 @@ describe Haml::Engine do
           = __LINE__
         HAML
       end
-    end unless /java/ === RUBY_PLATFORM # execjs is not working with Travis JRuby environment
+    end unless /java/.match?(RUBY_PLATFORM) # execjs is not working with Travis JRuby environment
 
     describe 'css filter' do
       it 'renders static filter' do
@@ -244,7 +244,7 @@ describe Haml::Engine do
           = __LINE__
         HAML
       end
-    end unless /java/ === RUBY_PLATFORM # execjs is not working with Travis JRuby environment
+    end unless /java/.match?(RUBY_PLATFORM) # execjs is not working with Travis JRuby environment
 
     describe 'plain filter' do
       it 'renders line numbers with an empty line correctly' do

--- a/test/haml/string_splitter_test.rb
+++ b/test/haml/string_splitter_test.rb
@@ -40,7 +40,7 @@ describe Haml::StringSplitter do
       end
 
       it 'raises internal error' do
-        if /java/ === RUBY_PLATFORM
+        if /java/.match?(RUBY_PLATFORM)
           skip 'Ripper of JRuby is behaving in a different way'
         end
 


### PR DESCRIPTION
Support for Ruby versions earlier than 3.2 has been dropped, ensuring that `Regexp#match?`, introduced in Ruby 2.4, is available on all supported Rubies.

This commit uses `match?` for more efficient regular expression checks.

Automatically corrected via

```
rubocop --plugin rubocop-performance --only Performance/RegexpMatch -a
```

Follow up of #1176

---

## Benchmarks

Slightly modified `bin/bench` with `benchmark-memory`.

### `data attributes`

#### Before
```
$ ./bin/bench compile benchmark/data_attribute.haml 
=================================================
 Compilation: benchmark/data_attribute.haml
=================================================
Calculating -------------------------------------
         haml v7.0.0   148.000  i/100ms
-------------------------------------------------
         haml v7.0.0      1.500k i/s (0.667ms) -     15.096k
Calculating -------------------------------------
         haml v7.0.0   171.077k memsize (     0.000  retained)
                         2.155k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
```

#### After
```
$ ./bin/bench compile benchmark/data_attribute.haml 
=================================================
 Compilation: benchmark/data_attribute.haml
=================================================
Calculating -------------------------------------
     haml v7.0.0-dev   150.000  i/100ms
-------------------------------------------------
     haml v7.0.0-dev      1.532k i/s (0.653ms) -     15.450k
Calculating -------------------------------------
     haml v7.0.0-dev   170.293k memsize (     0.000  retained)
                         2.149k objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
```

### `filter`

#### Template

```haml
:javascript
  // Hello
:preserve
  Hello
```

#### Before

```
$ bin/bench compile benchmark/filter.haml 
=================================================
 Compilation: benchmark/filter.haml
=================================================
Calculating -------------------------------------
         haml v7.0.0   273.000  i/100ms
-------------------------------------------------
         haml v7.0.0      2.729k i/s (0.366ms) -     27.300k
Calculating -------------------------------------
         haml v7.0.0    69.871k memsize (     0.000  retained)
                       723.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
```

#### After

```
$ ./bin/bench compile benchmark/filter.haml 
=================================================
 Compilation: benchmark/filter.haml
=================================================
Calculating -------------------------------------
     haml v7.0.0-dev   281.000  i/100ms
-------------------------------------------------
     haml v7.0.0-dev      2.731k i/s (0.366ms) -     27.257k
Calculating -------------------------------------
     haml v7.0.0-dev    69.375k memsize (     0.000  retained)
                       719.000  objects (     0.000  retained)
                        50.000  strings (     0.000  retained)
```
