### PR TITLE
Remove references to Hamlit

### DIFF
--- a/benchmark/dynamic_merger/benchmark.rb
+++ b/benchmark/dynamic_merger/benchmark.rb
@@ -7,7 +7,7 @@ Benchmark.driver(repeat_count: 8) do |x|
     require 'action_view'
     require 'string_template'
     StringTemplate::Railtie.run_initializers
-    require 'hamlit'
+    require 'haml'
     Haml::Railtie.run_initializers
     Haml::RailsTemplate.set_options(escape_html: false, generator: Temple::Generators::ArrayBuffer)
     require 'action_view/base'
@@ -20,6 +20,6 @@ Benchmark.driver(repeat_count: 8) do |x|
     view.render(template: hello, handlers: 'haml')
   }
   x.report 'string', %{ view.render(template: hello, handlers: 'string') }
-  x.report 'hamlit', %{ view.render(template: hello, handlers: 'haml') }
+  x.report 'haml', %{ view.render(template: hello, handlers: 'haml') }
   x.loop_count 100_000
 end

--- a/bin/stackprof
+++ b/bin/stackprof
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require 'bundler/setup'
-require 'hamlit'
+require 'haml'
 require 'stackprof'
 
 def open_flamegraph(report)
@@ -20,7 +20,7 @@ end
 
 haml = File.read(ARGV.first)
 StackProf.start(mode: :wall, interval: 1, raw: false)
-Hamlit::Engine.new.call(haml)
+Haml::Engine.new.call(haml)
 StackProf.stop
 
 report = StackProf::Report.new(StackProf.results)

--- a/test/haml/haml-spec/Rakefile
+++ b/test/haml/haml-spec/Rakefile
@@ -12,20 +12,14 @@ def generate_spec(mode)
   spec = <<-SPEC.unindent
     require "minitest/autorun"
     require "haml"
-    require "haml"
 
     # This is a spec converted by haml-spec.
     # See: https://github.com/haml/haml-spec
     class #{mode.capitalize}Test < Minitest::Test
       HAML_DEFAULT_OPTIONS = { ugly: #{mode == :ugly}, escape_html: true }.freeze
-      HAMLIT_DEFAULT_OPTIONS = { escape_html: true }.freeze
 
       def self.haml_result(haml, options, locals)
         Haml::Engine.new(haml, HAML_DEFAULT_OPTIONS.merge(options)).render(Object.new, locals)
-      end
-
-      def self.haml_result(haml, options, locals)
-        eval Haml::Engine.new(haml, HAMLIT_DEFAULT_OPTIONS.merge(options)).render(Object.new, locals)
       end
 
   SPEC


### PR DESCRIPTION
Fixes `bin/stackprof` executable

---

Hello, this is an improvement compared to the current status but I'm uncertain about

- `benchmark/dynamic_merger/benchmark.rb`

and

- `test/haml/haml-spec/Rakefile`

The former appear to be broken, because latest Rails version require different parameters in `ActionView::LookupContext.new('')` but I was not able to make it work.

The latter produces an output which is way different from the current `ugly` test