### PR TITLE
Add source code URI to gemspec metadata

### DIFF
--- a/haml.gemspec
+++ b/haml.gemspec
@@ -22,6 +22,7 @@ Gem::Specification.new do |spec|
   spec.metadata      = { 'rubygems_mfa_required' => 'true' }
 
   spec.metadata["changelog_uri"] = spec.homepage + "/docs/yardoc/file.CHANGELOG.html"
+  spec.metadata["source_code_uri"] = "https://github.com/haml/haml"
 
   spec.required_ruby_version = '>= 3.2.0'
 


### PR DESCRIPTION
I believe it could be helpful for many people to provide the source code repository link to the RubyGems page: https://rubygems.org/gems/haml/versions/7.0.1

Plus, useful links (e.g. commits) would come on pull requests created by tools such as Dependabot.

---

Currently, there is no "Source Code" link on the Haml gem page:
<img width="205" height="310" alt="image" src="https://github.com/user-attachments/assets/b6d1e595-77a7-4260-987c-e100f7be224d" />

In addition, there are no helpful links to the repository on a pull request created by Dependabot:
<img width="497" height="260" alt="image" src="https://github.com/user-attachments/assets/5de94a2f-b351-445b-86b1-593b0d13bdce" />
