### PR TITLE
Remove redundant require and use extend directly

### DIFF
--- a/lib/haml/template.rb
+++ b/lib/haml/template.rb
@@ -16,5 +16,5 @@ module Haml
       "extend Haml::Helpers; #{super}"
     end
   end
-  Template.send(:extend, TemplateExtension)
+  Template.extend TemplateExtension
 end

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -5,7 +5,6 @@ begin
 rescue LoadError
   require 'erb'
 end
-require 'set'
 require 'stringio'
 require 'strscan'
 


### PR DESCRIPTION
Remove the unnecessary `require 'set'` from `lib/haml/util.rb` because `Set` is available in Ruby 3.2 (the project's minimum supported Ruby version), making the explicit require redundant.

Replace `.send(:extend, args)` with `.extend args` in `lib/haml/template.rb` to address `Lint/SendWithMixinArgument` offense. `extend` is a public method and is clearer and more idiomatic.

These are RuboCop-only, behavior-preserving fixes.

Auto-corrected with:
```bash
rubocop --only Lint/SendWithMixinArgument,Lint/RedundantRequireStatement lib/**/*.rb -a
```

References:
- https://github.com/ruby/ruby/blob/master/doc/NEWS/NEWS-3.2.0.md
- https://bugs.ruby-lang.org/issues/16989