### PR TITLE
Improve frozen strings management

### DIFF
--- a/lib/haml/dynamic_merger.rb
+++ b/lib/haml/dynamic_merger.rb
@@ -36,7 +36,7 @@ module Haml
         return exps
       end
 
-      strlit_body = String.new
+      strlit_body = +''
       exps.each do |type, arg|
         case type
         when :static

--- a/lib/haml/engine.rb
+++ b/lib/haml/engine.rb
@@ -53,7 +53,7 @@ module Haml
     end
 
     def precompiled_with_ambles(_local_names, after_preamble:)
-      "#{after_preamble.tr("\n", ';')}#{@precompiled}".dup
+      "#{after_preamble.tr("\n", ';')}#{@precompiled}"
     end
   end
 end

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -227,7 +227,7 @@ module Haml
       end
 
       def inspect
-        %Q[(#{type} #{value.inspect}#{children.each_with_object(''.dup) {|c, s| s << "\n#{c.inspect.gsub!(/^/, '  ')}"}})].dup
+        %Q[(#{type} #{value.inspect}#{children.each_with_object((+'')) {|c, s| s << "\n#{c.inspect.gsub!(/^/, '  ')}"}})]
       end
     end
 
@@ -397,7 +397,7 @@ module Haml
     def haml_comment(text)
       if filter_opened?
         @flat = true
-        @filter_buffer = String.new
+        @filter_buffer = +''
         @filter_buffer << "#{text}\n" unless text.empty?
         text = @filter_buffer
         # If we don't know the indentation by now, it'll be set in Line#tabs
@@ -532,7 +532,7 @@ module Haml
 
       if filter_opened?
         @flat = true
-        @filter_buffer = String.new
+        @filter_buffer = +''
         # If we don't know the indentation by now, it'll be set in Line#tabs
         @flat_spaces = @indentation * (@template_tabs+1) if @indentation
       end
@@ -734,7 +734,7 @@ module Haml
       end
 
       static_attributes = {}
-      dynamic_attributes = "{".dup
+      dynamic_attributes = +"{"
       attributes.each do |name, (type, val)|
         if type == :static
           static_attributes[name] = val
@@ -774,7 +774,7 @@ module Haml
 
       return name, [:static, content.first[1]] if content.size == 1
       return name, [:dynamic,
-        %!"#{content.each_with_object(''.dup) {|(t, v), s| s << (t == :str ? Util.inspect_obj(v)[1...-1] : "\#{#{v}}")}}"!]
+        %!"#{content.each_with_object((+'')) {|(t, v), s| s << (t == :str ? Util.inspect_obj(v)[1...-1] : "\#{#{v}}")}}"!]
     end
 
     def next_line
@@ -847,7 +847,7 @@ module Haml
 
     # Unlike #balance, this balances Ripper tokens to balance something like `{ a: "}" }` correctly.
     def balance_tokens(buf, start, finish, count: 0)
-      text = ''.dup
+      text = +''
       Ripper.lex(buf).each do |_, token, str|
         text << str
         case token

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -227,7 +227,7 @@ module Haml
       end
 
       def inspect
-        %Q[(#{type} #{value.inspect}#{children.each_with_object((+'')) {|c, s| s << "\n#{c.inspect.gsub!(/^/, '  ')}"}})]
+        %Q[(#{type} #{value.inspect}#{children.each_with_object(+'') {|c, s| s << "\n#{c.inspect.gsub!(/^/, '  ')}"}})]
       end
     end
 

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -789,7 +789,7 @@ module Haml
 
       return name, [:static, content.first[1]] if content.size == 1
       return name, [:dynamic,
-        %!"#{content.each_with_object((+'')) {|(t, v), s| s << (t == :str ? Util.inspect_obj(v)[1...-1] : "\#{#{v}}")}}"!]
+        %!"#{content.each_with_object(+'') {|(t, v), s| s << (t == :str ? Util.inspect_obj(v)[1...-1] : "\#{#{v}}")}}"!]
     end
 
     def next_line

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -227,7 +227,7 @@ module Haml
       end
 
       def inspect
-        %Q[(#{type} #{value.inspect}#{children.each_with_object(''.dup) {|c, s| s << "\n#{c.inspect.gsub!(/^/, '  ')}"}})].dup
+        %Q[(#{type} #{value.inspect}#{children.each_with_object((+'')) {|c, s| s << "\n#{c.inspect.gsub!(/^/, '  ')}"}})]
       end
     end
 
@@ -403,7 +403,7 @@ module Haml
     def haml_comment(text)
       if filter_opened?
         @flat = true
-        @filter_buffer = String.new
+        @filter_buffer = +''
         @filter_buffer << "#{text}\n" unless text.empty?
         text = @filter_buffer
         # If we don't know the indentation by now, it'll be set in Line#tabs
@@ -539,7 +539,7 @@ module Haml
 
       if filter_opened?
         @flat = true
-        @filter_buffer = String.new
+        @filter_buffer = +''
         # If we don't know the indentation by now, it'll be set in Line#tabs
         @flat_spaces = @indentation * (@template_tabs+1) if @indentation
       end
@@ -749,7 +749,7 @@ module Haml
       end
 
       static_attributes = {}
-      dynamic_attributes = "{".dup
+      dynamic_attributes = +"{"
       attributes.each do |name, (type, val)|
         if type == :static
           static_attributes[name] = val
@@ -789,7 +789,7 @@ module Haml
 
       return name, [:static, content.first[1]] if content.size == 1
       return name, [:dynamic,
-        %!"#{content.each_with_object(''.dup) {|(t, v), s| s << (t == :str ? Util.inspect_obj(v)[1...-1] : "\#{#{v}}")}}"!]
+        %!"#{content.each_with_object((+'')) {|(t, v), s| s << (t == :str ? Util.inspect_obj(v)[1...-1] : "\#{#{v}}")}}"!]
     end
 
     def next_line

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -774,7 +774,7 @@ module Haml
 
       return name, [:static, content.first[1]] if content.size == 1
       return name, [:dynamic,
-        %!"#{content.each_with_object((+'')) {|(t, v), s| s << (t == :str ? Util.inspect_obj(v)[1...-1] : "\#{#{v}}")}}"!]
+        %!"#{content.each_with_object(+'') {|(t, v), s| s << (t == :str ? Util.inspect_obj(v)[1...-1] : "\#{#{v}}")}}"!]
     end
 
     def next_line

--- a/lib/haml/string_splitter.rb
+++ b/lib/haml/string_splitter.rb
@@ -66,7 +66,7 @@ module Haml
         end
 
         def shift_balanced_embexpr(tokens)
-          String.new.tap do |embedded|
+          (+'').tap do |embedded|
             embexpr_open = 1
 
             until tokens.empty?

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -170,7 +170,7 @@ MSG
     #   and the rest of the string.
     #   `["Foo (Bar (Baz bang) bop)", " (Bang (bop bip))"]` in the example above.
     def balance(scanner, start, finish, count = 0)
-      str = ''.dup
+      str = +''
       scanner = StringScanner.new(scanner) unless scanner.is_a? StringScanner
       regexp = Regexp.new("(.*?)[\\#{start.chr}\\#{finish.chr}]", Regexp::MULTILINE)
       while scanner.scan(regexp)
@@ -203,7 +203,7 @@ MSG
     end
 
     def unescape_interpolation(str, escape_html = nil)
-      res = ''.dup
+      res = +''
       rest = Haml::Util.handle_interpolation str.dump do |scan|
         escapes = (scan[2].size - 1) / 2
         char = scan[3] # '{', '@' or '$'

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -168,7 +168,7 @@ MSG
     #   and the rest of the string.
     #   `["Foo (Bar (Baz bang) bop)", " (Bang (bop bip))"]` in the example above.
     def balance(scanner, start, finish, count = 0)
-      str = ''.dup
+      str = +''
       scanner = StringScanner.new(scanner) unless scanner.is_a? StringScanner
       regexp = Regexp.new("(.*?)[\\#{start.chr}\\#{finish.chr}]", Regexp::MULTILINE)
       while scanner.scan(regexp)
@@ -201,7 +201,7 @@ MSG
     end
 
     def unescape_interpolation(str)
-      res = ''.dup
+      res = +''
       rest = Haml::Util.handle_interpolation str.dump do |scan|
         escapes = (scan[2].size - 1) / 2
         char = scan[3] # '{', '@' or '$'


### PR DESCRIPTION
Hello, I was undecided if submit this PR or not, because I couldn't find a benchmark proving actual gain

I'm also unsure if the binary semantics statement in the commit message is correct (there is a "should")

---

This commit replaces occurrences of `''.dup` and `String.new` with `+''`, and avoids using `+""` for interpolated strings.

This change is motivated by both performance and clarity: on Ruby 3.2 (our minimum version), `+''` is significantly faster than `''.dup` or `String.new`.

On 3.3 and later, `+''` and `''.dup` are equivalent, so this is a forward-compatible improvement.

Using `+""` on interpolated strings is also unnecessary, as interpolated strings are mutable by default on Ruby 3.0 and later.

Note on safety: `String.new` yields an ASCII-8BIT (BINARY) empty string, while `+''` yields UTF-8. Haml normalizes template encodings and defaults outputs to UTF-8 (see Util.check_haml_encoding and tests like EngineTest#test_default_encoding). The `String.new` instances touched are not used for byte-level binary processing and do not rely on BINARY semantics. Given Haml's UTF-8 orientation, this change should be safe.

These changes were made automatically with:

```
rubocop --plugin rubocop-performance --only Performance/UnfreezeString lib/**/*.rb -A
rubocop --only Style/RedundantInterpolationUnfreeze lib/**/*.rb -a
```