### PR TITLE
Support Tailwind CSS modifiers in class/id shorthand syntax

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -586,7 +586,7 @@ module Haml
       attributes = {}
       return attributes if list.empty?
 
-      list.scan(/([#.])([-:_a-zA-Z0-9\@]+)/) do |type, property|
+      list.scan(/([#.])(!?[-:_a-zA-Z0-9\@]+(?:\/\d+)?)/) do |type, property|
         case type
         when '.'
           if attributes[CLASS_KEY]
@@ -625,14 +625,15 @@ module Haml
 
     # Parses a line into tag_name, attributes, attributes_hash, object_ref, action, value
     def parse_tag(text)
-      match = text.scan(/%([-:\w]+)([-:\w.#\@]*)(.+)?/)[0]
+      # Check for empty class/id names (e.g., "%p..a", ".{}", ".=", ".")
+      if /%([-:\w]+)(?:[.#][!a-zA-Z0-9_\-:@]*)*[.#](?:[.#\{\}(=~<>\s\/]|\z)/.match?(text)
+        raise SyntaxError.new(Error.message(:illegal_element))
+      end
+
+      match = text.scan(/%([-:\w]+)((?:[.#]!?[-:_a-zA-Z0-9\@]+(?:\/\d+)?)*)(.+)?/)[0]
       raise SyntaxError.new(Error.message(:invalid_tag, text)) unless match
 
       tag_name, attributes, rest = match
-
-      if !attributes.empty? && /[.#](\.|#|\z)/.match?(attributes)
-        raise SyntaxError.new(Error.message(:illegal_element))
-      end
 
       new_attributes_hash = old_attributes_hash = last_line = nil
       object_ref = :nil

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -586,7 +586,7 @@ module Haml
       attributes = {}
       return attributes if list.empty?
 
-      list.scan(/([#.])(!?[-:_a-zA-Z0-9\@]+(?:\/\d+)?)/) do |type, property|
+      list.scan(/([#.])(!?[-:_a-zA-Z0-9\@]+(?:(?<=-)\[[^\]]*\])?(?:\/\d+)?)/) do |type, property|
         case type
         when '.'
           if attributes[CLASS_KEY]
@@ -630,7 +630,7 @@ module Haml
         raise SyntaxError.new(Error.message(:illegal_element))
       end
 
-      match = text.scan(/%([-:\w]+)((?:[.#]!?[-:_a-zA-Z0-9\@]+(?:\/\d+)?)*)(.+)?/)[0]
+      match = text.scan(/%([-:\w]+)((?:[.#]!?[-:_a-zA-Z0-9\@]+(?:(?<=-)\[[^\]]*\])?(?:\/\d+)?)*)(.+)?/)[0]
       raise SyntaxError.new(Error.message(:invalid_tag, text)) unless match
 
       tag_name, attributes, rest = match

--- a/test/haml/engine/tag_test.rb
+++ b/test/haml/engine/tag_test.rb
@@ -198,5 +198,77 @@ describe Haml::Engine do
         %div
       HAML
     end
+
+    it 'supports Tailwind opacity modifier (/) in class shorthand' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div class="bg-primary/5"></div>
+      HTML
+        .bg-primary/5
+      HAML
+    end
+
+    it 'supports Tailwind opacity modifier (/) with multiple classes' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div class="bg-red-500/10 text-white"></div>
+      HTML
+        .bg-red-500/10.text-white
+      HAML
+    end
+
+    it 'supports Tailwind opacity modifier (/) on explicit tag' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <span class="text-black/50">hello</span>
+      HTML
+        %span.text-black/50 hello
+      HAML
+    end
+
+    it 'does not confuse Tailwind opacity with self-closing slash' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent, format: :xhtml)
+        <input class="border" />
+      HTML
+        %input.border/
+      HAML
+    end
+
+    it 'supports Tailwind important modifier (!) in class shorthand' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div class="!font-bold"></div>
+      HTML
+        .!font-bold
+      HAML
+    end
+
+    it 'supports Tailwind important modifier (!) with other classes' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div class="!font-bold text-red-500"></div>
+      HTML
+        .!font-bold.text-red-500
+      HAML
+    end
+
+    it 'supports Tailwind important modifier (!) on explicit tag' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <p class="!text-lg">hello</p>
+      HTML
+        %p.!text-lg hello
+      HAML
+    end
+
+    it 'supports combining Tailwind opacity and important modifiers' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div class="!font-bold bg-primary/5"></div>
+      HTML
+        .!font-bold.bg-primary/5
+      HAML
+    end
+
+    it 'does not confuse Tailwind ! modifier with unescaped output' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div class="base"><b>bold</b></div>
+      HTML
+        .base!= "<b>bold</b>"
+      HAML
+    end
   end
 end

--- a/test/haml/engine/tag_test.rb
+++ b/test/haml/engine/tag_test.rb
@@ -270,5 +270,63 @@ describe Haml::Engine do
         .base!= "<b>bold</b>"
       HAML
     end
+
+    it 'supports Tailwind arbitrary values ([]) in class shorthand' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div class="bg-[#1da1f2]"></div>
+      HTML
+        .bg-[#1da1f2]
+      HAML
+    end
+
+    it 'supports Tailwind arbitrary values ([]) with multiple classes' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div class="text-[14px] font-bold"></div>
+      HTML
+        .text-[14px].font-bold
+      HAML
+    end
+
+    it 'supports Tailwind arbitrary values ([]) on explicit tag' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <span class="w-[320px]">hello</span>
+      HTML
+        %span.w-[320px] hello
+      HAML
+    end
+
+    it 'supports Tailwind arbitrary values with complex expressions' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div class="w-[calc(100%-20px)]"></div>
+      HTML
+        .w-[calc(100%-20px)]
+      HAML
+    end
+
+    it 'supports combining arbitrary values with opacity modifier' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div class="bg-[rgba(0,0,0)]/50"></div>
+      HTML
+        .bg-[rgba(0,0,0)]/50
+      HAML
+    end
+
+    it 'does not consume [] unless preceded by - (leaves object refs intact)' do
+      ::TagTestObject = Struct.new(:id) unless defined?(::TagTestObject)
+      assert_render(
+        %Q|<div class="card tag_test_object" id="tag_test_object_42"></div>\n|,
+        %q|.card[foo]|,
+        locals: { foo: TagTestObject.new(42) },
+      )
+    end
+
+    it 'supports arbitrary value class and object reference on the same element' do
+      ::TagTestObject = Struct.new(:id) unless defined?(::TagTestObject)
+      assert_render(
+        %Q|<div class="bg-[#1da1f2] tag_test_object" id="tag_test_object_42"></div>\n|,
+        %q|.bg-[#1da1f2][foo]|,
+        locals: { foo: TagTestObject.new(42) },
+      )
+    end
   end
 end


### PR DESCRIPTION
## Summary

Tailwind CSS uses several special characters in class names that HAML's shorthand class/id syntax (`.class`, `#id`) previously could not express. This PR adds support for all three:

- **Opacity modifier** (`/`): `.bg-primary/5`, `.text-black/50`
- **Important modifier** (`!`): `.!font-bold`, `.!text-red-500`
- **Arbitrary values** (`-[...]`): `.bg-[#1da1f2]`, `.text-[14px]`, `.w-[calc(100%-20px)]`

Before this change, each of these required a workaround:

```haml
-# workaround needed before
.some-class{ class: "bg-primary/5 !font-bold bg-[#1da1f2]" }
```

After this change, they work directly in shorthand:

```haml
.bg-primary/5.!font-bold.bg-[#1da1f2]
```

## Disambiguation

Each new character is only recognised in the specific position Tailwind uses it, making all changes non-breaking:

- `/` is treated as an opacity modifier only when followed by digits (`/50`). A trailing `/` with no digits remains the self-closing tag marker (`%br/`).
- `!` is treated as an important modifier only when it appears at the very start of a class/id name (immediately after `.` or `#`). `%div.class!= expr` (unescaped output) continues to work.
- `[` is treated as an arbitrary value start only when immediately preceded by `-` (lookbehind assertion). `.card[@user]` is therefore unaffected — `[@user]` is not preceded by `-` and is still parsed as an object reference.

## Implementation

Two methods in `lib/haml/parser.rb` were changed:

- **`parse_tag`**: The attributes capture group was changed from the permissive character class `[-:\w.#\@]*` to a structured pattern `(?:[.#]!?[-:_a-zA-Z0-9\@]+(?:(?<=-)\[[^\]]*\])?(?:\/\d+)?)*` that explicitly models each `.class`/`#id` token. The old post-match validation for empty class names (`.`, `..`, `.{}`) was replaced with a pre-check regex at the top of the method.

- **`parse_class_and_id`**: The scan regex for extracting class/id names was extended with `!?` prefix support and `(?:(?<=-)\[[^\]]*\])?(?:\/\d+)?` suffix support.


Fixes #1170 