### PR TITLE
Remove obsolete TruffleRuby compatibility skips

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ if /java/.match?(RUBY_PLATFORM) # JRuby
 else
   gem 'redcarpet'
 
-  if RUBY_PLATFORM !~ /mswin|mingw/ && RUBY_ENGINE != 'truffleruby'
+  if RUBY_PLATFORM !~ /mswin|mingw/
     gem 'stackprof'
   end
 end

--- a/lib/haml/attribute_parser.rb
+++ b/lib/haml/attribute_parser.rb
@@ -8,8 +8,7 @@ module Haml
 
     # @return [TrueClass, FalseClass] - return true if AttributeParser.parse can be used.
     def self.available?
-      # TruffleRuby doesn't have Ripper.lex
-      defined?(Ripper) && Ripper.respond_to?(:lex) && Temple::StaticAnalyzer.available?
+      Temple::StaticAnalyzer.available?
     end
 
     def self.parse(text)

--- a/lib/haml/compiler/script_compiler.rb
+++ b/lib/haml/compiler/script_compiler.rb
@@ -21,10 +21,6 @@ module Haml
       end
 
       def compile(node, &block)
-        unless Ripper.respond_to?(:lex) # No Ripper.lex in truffleruby
-          return dynamic_compile(node, &block)
-        end
-
         no_children = node.children.empty?
         case
         when no_children && node.value[:escape_interpolation]

--- a/lib/haml/compiler/tag_compiler.rb
+++ b/lib/haml/compiler/tag_compiler.rb
@@ -28,10 +28,8 @@ module Haml
           nil
         when node.value[:parse]
           return compile_interpolated_plain(node) if node.value[:escape_interpolation]
-          if Ripper.respond_to?(:lex) # No Ripper.lex in truffleruby
-            return delegate_optimization(node) if RubyExpression.string_literal?(node.value[:value])
-            return delegate_optimization(node) if Temple::StaticAnalyzer.static?(node.value[:value])
-          end
+          return delegate_optimization(node) if RubyExpression.string_literal?(node.value[:value])
+          return delegate_optimization(node) if Temple::StaticAnalyzer.static?(node.value[:value])
 
           var = @identity.generate
           [:multi,

--- a/lib/haml/string_splitter.rb
+++ b/lib/haml/string_splitter.rb
@@ -1,139 +1,129 @@
 # frozen_string_literal: true
-begin
-  require 'ripper'
-rescue LoadError
-end
+require 'ripper'
 
 module Haml
   # Compile [:dynamic, "foo#{bar}"] to [:multi, [:static, 'foo'], [:dynamic, 'bar']]
   class StringSplitter < Temple::Filter
-    if defined?(Ripper) && Ripper.respond_to?(:lex)
-      class << self
-        # `code` param must be valid string literal
-        def compile(code)
-          [].tap do |exps|
-            tokens = Ripper.lex(code.strip)
-            tokens.pop while tokens.last && [:on_comment, :on_sp].include?(tokens.last[1])
+    class << self
+      # `code` param must be valid string literal
+      def compile(code)
+        [].tap do |exps|
+          tokens = Ripper.lex(code.strip)
+          tokens.pop while tokens.last && [:on_comment, :on_sp].include?(tokens.last[1])
 
-            if tokens.size < 2
-              raise(Haml::InternalError, "Expected token size >= 2 but got: #{tokens.size}")
-            end
-            compile_tokens!(exps, tokens)
+          if tokens.size < 2
+            raise(Haml::InternalError, "Expected token size >= 2 but got: #{tokens.size}")
           end
+          compile_tokens!(exps, tokens)
         end
-
-        private
-
-        def strip_quotes!(tokens)
-          _, type, beg_str = tokens.shift
-          if type != :on_tstring_beg
-            raise(Haml::InternalError, "Expected :on_tstring_beg but got: #{type}")
-          end
-
-          _, type, end_str = tokens.pop
-          if type != :on_tstring_end
-            raise(Haml::InternalError, "Expected :on_tstring_end but got: #{type}")
-          end
-
-          [beg_str, end_str]
-        end
-
-        def compile_tokens!(exps, tokens)
-          beg_str, end_str = strip_quotes!(tokens)
-
-          until tokens.empty?
-            _, type, str = tokens.shift
-
-            case type
-            when :on_tstring_content
-              beg_str, end_str = escape_quotes(beg_str, end_str)
-              exps << [:static, eval("#{beg_str}#{str}#{end_str}").to_s]
-            when :on_embexpr_beg
-              embedded = shift_balanced_embexpr(tokens)
-              exps << [:dynamic, embedded] unless embedded.empty?
-            end
-          end
-        end
-
-        # Some quotes are split-unsafe. Replace such quotes with null characters.
-        def escape_quotes(beg_str, end_str)
-          case [beg_str[-1], end_str]
-          when ['(', ')'], ['[', ']'], ['{', '}']
-            [beg_str.sub(/.\z/) { "\0" }, "\0"]
-          else
-            [beg_str, end_str]
-          end
-        end
-
-        def shift_balanced_embexpr(tokens)
-          String.new.tap do |embedded|
-            embexpr_open = 1
-
-            until tokens.empty?
-              _, type, str = tokens.shift
-              case type
-              when :on_embexpr_beg
-                embexpr_open += 1
-              when :on_embexpr_end
-                embexpr_open -= 1
-                break if embexpr_open == 0
-              end
-
-              embedded << str
-            end
-          end
-        end
-      end
-
-      def on_dynamic(code)
-        return [:dynamic, code] unless string_literal?(code)
-        return [:dynamic, code] if code.include?("\n")
-
-        temple = [:multi]
-        StringSplitter.compile(code).each do |type, content|
-          case type
-          when :static
-            temple << [:static, content]
-          when :dynamic
-            temple << on_dynamic(content)
-          end
-        end
-        temple
       end
 
       private
 
-      def string_literal?(code)
-        return false if SyntaxChecker.syntax_error?(code)
-
-        type, instructions = Ripper.sexp(code)
-        return false if type != :program
-        return false if instructions.size > 1
-
-        type, _ = instructions.first
-        type == :string_literal
-      end
-
-      class SyntaxChecker < Ripper
-        class ParseError < StandardError; end
-
-        def self.syntax_error?(code)
-          self.new(code).parse
-          false
-        rescue ParseError
-          true
+      def strip_quotes!(tokens)
+        _, type, beg_str = tokens.shift
+        if type != :on_tstring_beg
+          raise(Haml::InternalError, "Expected :on_tstring_beg but got: #{type}")
         end
 
-        private
+        _, type, end_str = tokens.pop
+        if type != :on_tstring_end
+          raise(Haml::InternalError, "Expected :on_tstring_end but got: #{type}")
+        end
 
-        def on_parse_error(*)
-          raise ParseError
+        [beg_str, end_str]
+      end
+
+      def compile_tokens!(exps, tokens)
+        beg_str, end_str = strip_quotes!(tokens)
+
+        until tokens.empty?
+          _, type, str = tokens.shift
+
+          case type
+          when :on_tstring_content
+            beg_str, end_str = escape_quotes(beg_str, end_str)
+            exps << [:static, eval("#{beg_str}#{str}#{end_str}").to_s]
+          when :on_embexpr_beg
+            embedded = shift_balanced_embexpr(tokens)
+            exps << [:dynamic, embedded] unless embedded.empty?
+          end
         end
       end
-    else
-      # Do nothing if ripper is unavailable
-      def call(ast)
-        ast
+
+      # Some quotes are split-unsafe. Replace such quotes with null characters.
+      def escape_quotes(beg_str, end_str)
+        case [beg_str[-1], end_str]
+        when ['(', ')'], ['[', ']'], ['{', '}']
+          [beg_str.sub(/.\z/) { "\0" }, "\0"]
+        else
+          [beg_str, end_str]
+        end
+      end
+
+      def shift_balanced_embexpr(tokens)
+        String.new.tap do |embedded|
+          embexpr_open = 1
+
+          until tokens.empty?
+            _, type, str = tokens.shift
+            case type
+            when :on_embexpr_beg
+              embexpr_open += 1
+            when :on_embexpr_end
+              embexpr_open -= 1
+              break if embexpr_open == 0
+            end
+
+            embedded << str
+          end
+        end
+      end
+    end
+
+    def on_dynamic(code)
+      return [:dynamic, code] unless string_literal?(code)
+      return [:dynamic, code] if code.include?("\n")
+
+      temple = [:multi]
+      StringSplitter.compile(code).each do |type, content|
+        case type
+        when :static
+          temple << [:static, content]
+        when :dynamic
+          temple << on_dynamic(content)
+        end
+      end
+      temple
+    end
+
+    private
+
+    def string_literal?(code)
+      return false if SyntaxChecker.syntax_error?(code)
+
+      type, instructions = Ripper.sexp(code)
+      return false if type != :program
+      return false if instructions.size > 1
+
+      type, _ = instructions.first
+      type == :string_literal
+    end
+
+    class SyntaxChecker < Ripper
+      class ParseError < StandardError; end
+
+      def self.syntax_error?(code)
+        self.new(code).parse
+        false
+      rescue ParseError
+        true
+      end
+
+      private
+
+      def on_parse_error(*)
+        raise ParseError
       end
     end
   end

--- a/test/haml/attribute_parser_test.rb
+++ b/test/haml/attribute_parser_test.rb
@@ -97,5 +97,5 @@ describe Haml::AttributeParser do
       it { assert_parse({ 'foo' => 'bar(a, b)', 'hoge' => 'piyo(a, b,)' }, 'foo: bar(a, b), hoge: piyo(a, b,),') }
       it { assert_parse({ 'foo' => 'bar(a, b)', 'hoge' => 'piyo(a, b,)' }, ' { foo: bar(a, b), hoge: piyo(a, b,), } ') }
     end
-  end if RUBY_ENGINE != 'truffleruby' # truffleruby doesn't have Ripper.lex
+  end
 end

--- a/test/haml/engine/silent_script_test.rb
+++ b/test/haml/engine/silent_script_test.rb
@@ -167,7 +167,6 @@ describe Haml::Engine do
     end
 
     it 'renders case-in' do
-      skip 'pattern-matching not supported' if RUBY_ENGINE == 'truffleruby'
       assert_render(<<-HTML.unindent, <<-'HAML'.unindent)
         ok
       HTML

--- a/test/haml/engine/text_test.rb
+++ b/test/haml/engine/text_test.rb
@@ -5,7 +5,6 @@ describe Haml::Engine do
 
   describe 'text' do
     it 'renders string interpolation' do
-      skip 'escape is not working well in truffleruby' if RUBY_ENGINE == 'truffleruby'
       assert_render(<<-HTML.unindent, <<-'HAML'.unindent)
         a3aa" [&quot;1&quot;, 2] b " !
         a#{render_hash({ a: 3 })}
@@ -31,7 +30,6 @@ describe Haml::Engine do
     end
 
     it 'renders == operator' do
-      skip 'escape is not working well in truffleruby' if RUBY_ENGINE == 'truffleruby'
       assert_render(<<-HTML.unindent, <<-'HAML'.unindent)
         =
         =
@@ -46,7 +44,6 @@ describe Haml::Engine do
     end
 
     it 'renders !== operator' do
-      skip 'escape is not working well in truffleruby' if RUBY_ENGINE == 'truffleruby'
       assert_render(<<-HTML.unindent, <<-'HAML'.unindent)
         &lt;a&gt;
         <a>
@@ -93,7 +90,6 @@ describe Haml::Engine do
       end
 
       it 'renders & operator' do
-        skip 'escape is not working well in truffleruby' if RUBY_ENGINE == 'truffleruby'
         assert_render(<<-HTML.unindent, <<-'HAML'.unindent)
           <span>&lt;nyaa&gt;</span>
           <span>&lt;nyaa&gt;</span>
@@ -176,7 +172,6 @@ describe Haml::Engine do
       end
 
       it 'renders &== operator' do
-        skip 'escape is not working well in truffleruby' if RUBY_ENGINE == 'truffleruby'
         assert_render(<<-HTML.unindent, <<-'HAML'.unindent)
           =
           =
@@ -208,7 +203,7 @@ describe Haml::Engine do
       it { assert_render(%Q{'"!@$%^&*|=1112\n}, %q{'"!@$%^&*|=#{1}1#{1}2}) }
       it { assert_render("あ1\n", 'あ#{1}') }
       it { assert_render("あいう\n", 'あ#{"い"}う') }
-      it { assert_render("a&lt;b&gt;c\n", 'a#{"<b>"}c') } if RUBY_ENGINE != 'truffleruby' # escape is not working in truffleruby
+      it { assert_render("a&lt;b&gt;c\n", 'a#{"<b>"}c') }
     end
   end
 end

--- a/test/haml/filters_test.rb
+++ b/test/haml/filters_test.rb
@@ -121,7 +121,7 @@ class FiltersTest < Haml::TestCase
     assert_haml_ugly(":plain\n  \#{'<script>evil</script>'}")
   end
 
-end if RUBY_ENGINE != 'truffleruby' # truffleruby does not implement Ripper.lex
+end
 
 class ErbFilterTest < Haml::TestCase
   test "multiline expressions should work" do; skip

--- a/test/haml/haml-spec/ugly_test.rb
+++ b/test/haml/haml-spec/ugly_test.rb
@@ -1012,4 +1012,4 @@ world</p>}
       assert_equal html, haml_result
     end
   end
-end if RUBY_ENGINE != 'truffleruby' # truffleruby cannot run Haml
+end

--- a/test/haml/helper_test.rb
+++ b/test/haml/helper_test.rb
@@ -24,8 +24,6 @@ class HelperTest < Haml::TestCase
   end
 
   def setup
-    skip if RUBY_ENGINE == 'truffleruby' # fails with Rails 8.1
-
     template_path = File.expand_path("../templates", __FILE__)
     @base = Class.new(ActionView::Base) do
       def nested_tag

--- a/test/haml/line_number_test.rb
+++ b/test/haml/line_number_test.rb
@@ -355,4 +355,4 @@ describe Haml::Engine do
       HAML
     end
   end
-end if RUBY_ENGINE != 'truffleruby' # negetive line numbers are broken in truffleruby
+end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -51,4 +51,4 @@ describe 'optimization' do
       assert_equal true, compiled_code(haml).include?("value=\\\"hello")
     end
   end
-end if RUBY_ENGINE != 'truffleruby' # truffleruby does not implement major Ripper features
+end

--- a/test/haml/rails_template_test.rb
+++ b/test/haml/rails_template_test.rb
@@ -14,10 +14,6 @@ describe Haml::RailsTemplate do
     base.render(inline: haml, type: :haml)
   end
 
-  before do
-    skip if RUBY_ENGINE == 'truffleruby' # fails with Rails 8.1
-  end
-
   specify 'html escape' do
     assert_equal %Q|&lt;script&gt;alert(&quot;a&quot;);&lt;/script&gt;\n|, render(<<-HAML.unindent)
       = '<script>alert("a");</script>'
@@ -25,7 +21,6 @@ describe Haml::RailsTemplate do
     assert_equal %Q|<script>alert("a");</script>\n|, render(<<-HAML.unindent)
       = '<script>alert("a");</script>'.html_safe
     HAML
-    skip 'escape is not working well in truffleruby' if RUBY_ENGINE == 'truffleruby'
     assert_equal %Q|&lt;script&gt;alert(&quot;a&quot;);&lt;/script&gt;\n|, render(<<-'HAML'.unindent)
       #{'<script>alert("a");</script>'}
     HAML

--- a/test/haml/ruby_expression_test.rb
+++ b/test/haml/ruby_expression_test.rb
@@ -43,4 +43,4 @@ describe Haml::RubyExpression do
       it { assert_literal(false, %Q|''\n''|) }
     end
   end
-end if RUBY_ENGINE != 'truffleruby' # truffleruby doesn't have Ripper.sexp
+end

--- a/test/haml/string_splitter_test.rb
+++ b/test/haml/string_splitter_test.rb
@@ -49,5 +49,5 @@ describe Haml::StringSplitter do
         end
       end
     end
-  end if RUBY_ENGINE != 'truffleruby' # truffleruby doesn't have Ripper.lex
+  end
 end

--- a/test/haml/template_test.rb
+++ b/test/haml/template_test.rb
@@ -55,7 +55,6 @@ class TemplateTest < Haml::TestCase
   ]
 
   def setup
-    skip if RUBY_ENGINE == 'truffleruby' # fails with Rails 8.1
     @base = create_base
 
     # filters template uses :sass

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,9 +41,6 @@ module RenderHelper
   end
 
   def assert_haml(haml, options = {})
-    if RUBY_ENGINE == 'truffleruby'
-      skip 'truffleruby cannot run Haml'
-    end
     expected = render_haml(haml, options)
     actual = render_haml(haml, options)
     assert_equal expected, actual


### PR DESCRIPTION
Removes the historical TruffleRuby short circuits now that TruffleRuby 34 supports the Ripper APIs Haml relies on.

Changes:

- Removed TruffleRuby-specific Ripper.lex / Ripper.sexp runtime guards.
- Removed TruffleRuby-only test skips across parser, compiler, Rails template, interpolation, and optimization tests.
- Enabled stackprof on TruffleRuby by removing the Gemfile exclusion.

Verification:

LANG=en_US.UTF-8 RBENV_VERSION=truffleruby-34.0.1 bundle exec rake test

Result:

1093 runs, 1110 assertions, 0 failures, 0 errors, 199 skips