### PR TITLE
Do not rely on Ripper quirk in parsing old-style Haml attributes

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -93,6 +93,9 @@ module Haml
     ID_KEY    = 'id'.freeze
     CLASS_KEY = 'class'.freeze
 
+    # Used for scanning old attributes, substituting the first '{'
+    METHOD_CALL_PREFIX = 'a('
+
     def initialize(options)
       @options = ParserOptions.new(options)
       # Record the indent levels of "if" statements to validate the subsequent
@@ -683,8 +686,19 @@ module Haml
         # Old attributes often look like a valid Hash literal, but it sometimes allow code like
         # `{ hash, foo: bar }`, which is compiled to `_hamlout.attributes({}, nil, hash, foo: bar)`.
         #
-        # Balance Ripper's brace tokens so `{ a: "}" }` is handled correctly.
-        attributes_hash, rest = balance_tokens(text, :on_lbrace, :on_rbrace)
+        # To scan such code correctly, this scans `a( hash, foo: bar }` instead, stops when there is
+        # 1 more :on_embexpr_end (the last '}') than :on_embexpr_beg, and resurrects '{' afterwards.
+        #
+        # Old attributes allow invalid Hash constructs (e.g., `{ hash, foo: bar }`).
+        # Replacing the opening `{` with `a(` makes the syntax look like a method call so
+        # Ripper can lex it reliably.
+
+        attributes_hash, rest = balance_tokens(
+          text.sub(?{, METHOD_CALL_PREFIX),
+          [:on_lbrace, :on_tlambeg, :on_embexpr_beg],
+          [:on_rbrace, :on_embexpr_end],
+          count: 1)
+        attributes_hash = attributes_hash.sub(METHOD_CALL_PREFIX, ?{)
       rescue SyntaxError => e
         if e.message == Error.message(:unbalanced_brackets) && !@template.empty?
           text << "\n#{@next_line.text}"
@@ -845,10 +859,9 @@ module Haml
       text = ''.dup
       Ripper.lex(buf).each do |_, token, str|
         text << str
-        case token
-        when start
+        if start.include?(token)
           count += 1
-        when finish
+        elsif finish.include?(token)
           count -= 1
         end
 

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -93,9 +93,6 @@ module Haml
     ID_KEY    = 'id'.freeze
     CLASS_KEY = 'class'.freeze
 
-    # Used for scanning old attributes, substituting the first '{'
-    METHOD_CALL_PREFIX = 'a('
-
     def initialize(options)
       @options = ParserOptions.new(options)
       # Record the indent levels of "if" statements to validate the subsequent
@@ -686,10 +683,8 @@ module Haml
         # Old attributes often look like a valid Hash literal, but it sometimes allow code like
         # `{ hash, foo: bar }`, which is compiled to `_hamlout.attributes({}, nil, hash, foo: bar)`.
         #
-        # To scan such code correctly, this scans `a( hash, foo: bar }` instead, stops when there is
-        # 1 more :on_embexpr_end (the last '}') than :on_embexpr_beg, and resurrects '{' afterwards.
-        balanced, rest = balance_tokens(text.sub(?{, METHOD_CALL_PREFIX), :on_embexpr_beg, :on_embexpr_end, count: 1)
-        attributes_hash = balanced.sub(METHOD_CALL_PREFIX, ?{)
+        # Balance Ripper's brace tokens so `{ a: "}" }` is handled correctly.
+        attributes_hash, rest = balance_tokens(text, :on_lbrace, :on_rbrace)
       rescue SyntaxError => e
         if e.message == Error.message(:unbalanced_brackets) && !@template.empty?
           text << "\n#{@next_line.text}"

--- a/test/haml/engine/old_attribute_test.rb
+++ b/test/haml/engine/old_attribute_test.rb
@@ -554,5 +554,39 @@ describe Haml::Engine do
         HAML
       end
     end
+
+    describe 'brace balancing' do
+      it "recognizes String interpolation" do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <input value="abc">
+        HTML
+          %input{ value: "a#{'b'}c" }
+        HAML
+      end
+
+      it "recognizes Hash literals" do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <input value="abc">
+        HTML
+          %input{ value: {abc: "abc"}[:abc] }
+        HAML
+      end
+
+      it "recognizes block literals" do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <input value="abc">
+        HTML
+          %input{ value: proc { "abc" }.call }
+        HAML
+      end
+
+      it "recognizes lambda literals" do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <input value="abc">
+        HTML
+          %input{ value: -> { "abc" }.call }
+        HAML
+      end
+    end
   end
 end


### PR DESCRIPTION
## What / Why
This PR makes tag attribute parsing compatible with TruffleRuby by refactoring token balancing, while keeping the syntax valid for Ripper.

### The Problem
Haml extracts old-style (curly brace `{...}`) attributes by lexing them with `Ripper.lex`. Since these attributes can contain invalid Hash syntax (e.g. `{ hash, foo: bar }`), Haml historically replaces the first `{` with `a(` (`METHOD_CALL_PREFIX`) to make the syntax look like a method call so `Ripper` can lex it reliably.

However, this makes the closing `}` unbalanced.
* **On CRuby (parse.y):** Ripper lexes this unbalanced `}` as `:on_embexpr_end` (normally used for string interpolation end).
* **On TruffleRuby (Prism):** Ripper emulation lexes it as `:on_rbrace` or a standard closing token.
Because the previous code searched strictly for `:on_embexpr_end` as the closing token, parsing failed under TruffleRuby.

### The Solution
We keep the `a(` prefix so Ripper parses valid syntax, but generalize `balance_tokens` to match standard braces (`:on_lbrace`, `:on_rbrace`), lambdas (`:on_tlambeg`), and string interpolations (`:on_embexpr_beg`, `:on_embexpr_end`) at the same time.

The fix is extracted from #1210.

cc @eregon
