### PR TITLE
Replace Ripper with Prism

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,10 @@
 
 ## Unreleased
 
-* Interpolate `#@ivar`, `#$gvar` and `#@@cvar` in string literals instead of dropping them
-* Keep an escaped delimiter of a percent literal, so `= %q{a\}b}` renders `a}b`
-* Deprecate `Haml::AttributeParser.available?`, which is now always true and will be removed in the future
+* Replace Ripper with Prism https://github.com/haml/haml/pull/1214
+  * Interpolate `#@ivar`, `#$gvar` and `#@@cvar` in string literals instead of dropping them
+  * Keep an escaped delimiter of a percent literal, so `= %q{a\}b}` renders `a}b`
+  * Deprecate `Haml::AttributeParser.available?`, which is now always true and will be removed in the future
 
 ## 7.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Haml Changelog
 
+## Unreleased
+
+* Interpolate `#@ivar`, `#$gvar` and `#@@cvar` in string literals instead of dropping them
+* Keep an escaped delimiter of a percent literal, so `= %q{a\}b}` renders `a}b`
+* Deprecate `Haml::AttributeParser.available?`, which is now always true and will be removed in the future
+
 ## 7.2.2
 
 * Remove obsolete TruffleRuby compatibility skips https://github.com/haml/haml/pull/1210

--- a/haml.gemspec
+++ b/haml.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.2.0'
 
-  spec.add_dependency 'prism', '>= 1.0.0'
+  spec.add_dependency 'prism', '>= 1.1.0'
   spec.add_dependency 'temple', '>= 0.8.2'
   spec.add_dependency 'thor'
   spec.add_dependency 'tilt'

--- a/haml.gemspec
+++ b/haml.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.2.0'
 
+  spec.add_dependency 'prism', '>= 1.0.0'
   spec.add_dependency 'temple', '>= 0.8.2'
   spec.add_dependency 'thor'
   spec.add_dependency 'tilt'

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -22,9 +22,7 @@ module Haml
 
     def compile(node)
       hashes = []
-      if node.value[:object_ref] != :nil || !AttributeParser.available?
-        return runtime_compile(node)
-      end
+      return runtime_compile(node) if node.value[:object_ref] != :nil
       [node.value[:dynamic_attributes].new, node.value[:dynamic_attributes].old].compact.each do |attribute_str|
         hash = AttributeParser.parse(attribute_str)
         return runtime_compile(node) if hash.nil? || hash.any? { |_key, value| value.empty? }

--- a/lib/haml/attribute_parser.rb
+++ b/lib/haml/attribute_parser.rb
@@ -1,33 +1,40 @@
 # frozen_string_literal: true
-require 'haml/ruby_expression'
+require 'prism'
 
 module Haml
   class AttributeParser
-    class ParseSkip < StandardError
-    end
-
-    # @return [TrueClass, FalseClass] - return true if AttributeParser.parse can be used.
+    # @deprecated Prism is a hard dependency, so this is always true. Haml itself no longer
+    #   asks, and this will be removed in the future.
+    # @return [TrueClass] - return true if AttributeParser.parse can be used.
     def self.available?
-      Temple::StaticAnalyzer.available?
+      true
     end
 
     def self.parse(text)
       self.new.parse(text)
     end
 
+    # @return [Hash,nil] - keys and values are the attribute source as written, or nil if
+    #   the text is not a Hash literal whose keys are all static.
     def parse(text)
       exp = wrap_bracket(text)
-      return if Temple::StaticAnalyzer.syntax_error?(exp)
+      # A multi-line hash is left to the runtime, which keeps the [:newline] bookkeeping of
+      # the compiled code correct. Compiling it statically is a separate optimization.
+      return if exp.include?("\n")
+
+      node = hash_node(exp)
+      return if node.nil?
 
       hash = {}
-      tokens = Ripper.lex(exp)[1..-2] || []
-      each_attr(tokens) do |attr_tokens|
-        key = parse_key!(attr_tokens)
-        hash[key] = attr_tokens.map { |t| t[2] }.join.strip
+      node.elements.each do |element|
+        return unless element.is_a?(Prism::AssocNode)
+
+        key = static_key(element.key)
+        return if key.nil?
+
+        hash[key] = value_source(element.value)
       end
       hash
-    rescue ParseSkip
-      nil
     end
 
     private
@@ -38,78 +45,32 @@ module Haml
       "{#{text}}"
     end
 
-    def parse_key!(tokens)
-      _, type, str = tokens.shift
-      case type
-      when :on_sp
-        parse_key!(tokens)
-      when :on_label
-        str.tr(':', '')
-      when :on_symbeg
-        _, _, key = tokens.shift
-        assert_type!(tokens.shift, :on_tstring_end) if str != ':'
-        skip_until_hash_rocket!(tokens)
-        key
-      when :on_tstring_beg
-        _, _, key = tokens.shift
-        next_token = tokens.shift
-        unless next_token[1] == :on_label_end
-          assert_type!(next_token, :on_tstring_end)
-          skip_until_hash_rocket!(tokens)
-        end
-        key
-      else
-        raise ParseSkip
+    def hash_node(exp)
+      result = Prism.parse(exp)
+      return if result.failure?
+
+      statements = result.value.statements.body
+      return if statements.size != 1
+
+      node = statements.first
+      node if node.is_a?(Prism::HashNode)
+    end
+
+    # The key as written between its delimiters, not unescaped: an escape has to reach the
+    # attribute name as the source spelled it, like the `\0` of `{ "a\0b" => 1 }`.
+    def static_key(key)
+      case key
+      when Prism::SymbolNode then key.value_loc&.slice
+      when Prism::StringNode then key.content_loc&.slice
       end
     end
 
-    def assert_type!(token, type)
-      raise ParseSkip if token[1] != type
-    end
+    def value_source(value)
+      # Ruby 3.1 value omission (`{ foo: }`). An empty value tells AttributeCompiler to
+      # fall back to the runtime, which is what resolves it.
+      return '' if value.is_a?(Prism::ImplicitNode)
 
-    def skip_until_hash_rocket!(tokens)
-      until tokens.empty?
-        _, type, str = tokens.shift
-        break if type == :on_op && str == '=>'
-      end
-    end
-
-    def each_attr(tokens)
-      attr_tokens = []
-      open_tokens = Hash.new { |h, k| h[k] = 0 }
-
-      tokens.each do |token|
-        _, type, _ = token
-        case type
-        when :on_comma
-          if open_tokens.values.all?(&:zero?)
-            yield(attr_tokens)
-            attr_tokens = []
-            next
-          end
-        when :on_lbracket
-          open_tokens[:array] += 1
-        when :on_rbracket
-          open_tokens[:array] -= 1
-        when :on_lbrace
-          open_tokens[:block] += 1
-        when :on_rbrace
-          open_tokens[:block] -= 1
-        when :on_lparen
-          open_tokens[:paren] += 1
-        when :on_rparen
-          open_tokens[:paren] -= 1
-        when :on_embexpr_beg
-          open_tokens[:embexpr] += 1
-        when :on_embexpr_end
-          open_tokens[:embexpr] -= 1
-        when :on_sp
-          next if attr_tokens.empty?
-        end
-
-        attr_tokens << token
-      end
-      yield(attr_tokens) unless attr_tokens.empty?
+      value.slice
     end
   end
 end

--- a/lib/haml/attribute_parser.rb
+++ b/lib/haml/attribute_parser.rb
@@ -46,7 +46,9 @@ module Haml
     end
 
     def hash_node(exp)
-      result = Prism.parse(exp)
+      # partial_script, because an attribute may legitimately call `yield` and the like:
+      # a template is compiled into a method body.
+      result = Prism.parse(exp, partial_script: true)
       return if result.failure?
 
       statements = result.value.statements.body

--- a/lib/haml/compiler/script_compiler.rb
+++ b/lib/haml/compiler/script_compiler.rb
@@ -39,8 +39,13 @@ module Haml
       # String-interpolated plain text must be compiled with this method
       # because we have to escape only interpolated values.
       def compile_interpolated_plain(node)
+        compiled = StringSplitter.try_compile(node.value[:text])
+        # Ruby that does not parse: let the generated code report it, rather than failing
+        # the whole compilation with an error that points at Haml instead of the template.
+        return delegate_optimization(node) if compiled.nil?
+
         temple = [:multi]
-        StringSplitter.compile(node.value[:text]).each do |type, value|
+        compiled.each do |type, value|
           case type
           when :static
             temple << [:static, value]

--- a/lib/haml/compiler/tag_compiler.rb
+++ b/lib/haml/compiler/tag_compiler.rb
@@ -53,8 +53,13 @@ module Haml
 
       # We should handle interpolation here to escape only interpolated values.
       def compile_interpolated_plain(node)
+        compiled = StringSplitter.try_compile(node.value[:value])
+        # Ruby that does not parse: let the generated code report it, rather than failing
+        # the whole compilation with an error that points at Haml instead of the template.
+        return delegate_optimization(node) if compiled.nil?
+
         temple = [:multi]
-        StringSplitter.compile(node.value[:value]).each do |type, value|
+        compiled.each do |type, value|
           case type
           when :static
             temple << [:static, value]

--- a/lib/haml/filters/plain.rb
+++ b/lib/haml/filters/plain.rb
@@ -14,7 +14,12 @@ module Haml
 
       def compile_plain(text)
         string_literal = ::Haml::Util.unescape_interpolation(text)
-        StringSplitter.compile(string_literal).map do |temple|
+        compiled = StringSplitter.try_compile(string_literal)
+        # Ruby that does not parse: let the generated code report it against the template,
+        # rather than failing the whole compilation.
+        return [[:escape, false, [:dynamic, string_literal]]] if compiled.nil?
+
+        compiled.map do |temple|
           type, str = temple
           case type
           when :dynamic

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'ripper'
+require 'prism'
 require 'strscan'
 require 'haml/error'
 require 'haml/util'
@@ -601,8 +601,7 @@ module Haml
       attributes
     end
 
-    # This method doesn't use Haml::HamlAttributeParser because currently it depends on Ripper and Rubinius doesn't provide it.
-    # Ideally this logic should be placed in Haml::HamlAttributeParser instead of here and this method should use it.
+    # Ideally this logic should be placed in Haml::AttributeParser instead of here and this method should use it.
     #
     # @param  [String] text - Hash literal or text inside old attributes
     # @return [Hash,nil] - Return nil if text is not static Hash literal
@@ -686,17 +685,17 @@ module Haml
         # Old attributes often look like a valid Hash literal, but it sometimes allow code like
         # `{ hash, foo: bar }`, which is compiled to `_hamlout.attributes({}, nil, hash, foo: bar)`.
         #
-        # To scan such code correctly, this scans `a( hash, foo: bar }` instead, stops when there is
-        # 1 more :on_embexpr_end (the last '}') than :on_embexpr_beg, and resurrects '{' afterwards.
+        # To scan such code correctly, this scans `a( hash, foo: bar }` instead, stops on the '}'
+        # that closes one more brace than was opened, and resurrects '{' afterwards.
         #
         # Old attributes allow invalid Hash constructs (e.g., `{ hash, foo: bar }`).
         # Replacing the opening `{` with `a(` makes the syntax look like a method call so
-        # Ripper can lex it reliably.
+        # it can be lexed reliably.
 
         attributes_hash, rest = balance_tokens(
           text.sub(?{, METHOD_CALL_PREFIX),
-          [:on_lbrace, :on_tlambeg, :on_embexpr_beg],
-          [:on_rbrace, :on_embexpr_end],
+          [:BRACE_LEFT, :LAMBDA_BEGIN, :EMBEXPR_BEGIN],
+          [:BRACE_RIGHT, :EMBEXPR_END],
           count: 1)
         attributes_hash = attributes_hash.sub(METHOD_CALL_PREFIX, ?{)
       rescue SyntaxError => e
@@ -854,19 +853,23 @@ module Haml
       Haml::Util.balance(*args) or raise(SyntaxError.new(Error.message(:unbalanced_brackets)))
     end
 
-    # Unlike #balance, this balances Ripper tokens to balance something like `{ a: "}" }` correctly.
+    # Unlike #balance, this balances lexed tokens to balance something like `{ a: "}" }` correctly.
     def balance_tokens(buf, start, finish, count: 0)
-      text = ''.dup
-      Ripper.lex(buf).each do |_, token, str|
-        text << str
-        if start.include?(token)
+      Prism.lex(buf).value.each do |token, _|
+        type = token.type
+        next if type == :EOF
+
+        if start.include?(type)
           count += 1
-        elsif finish.include?(token)
+        elsif finish.include?(type)
           count -= 1
         end
 
         if count == 0
-          return text, buf.sub(text, '')
+          # Splitting on the offset instead of the tokens seen so far: whitespace and comments
+          # are not tokens, so the text cannot be rebuilt by concatenating them.
+          offset = token.location.end_offset
+          return buf.byteslice(0, offset), buf.byteslice(offset..)
         end
       end
       raise SyntaxError.new(Error.message(:unbalanced_brackets))

--- a/lib/haml/ruby_expression.rb
+++ b/lib/haml/ruby_expression.rb
@@ -1,32 +1,31 @@
 # frozen_string_literal: true
-require 'ripper'
+require 'prism'
 
 module Haml
-  class RubyExpression < Ripper
-    class ParseError < StandardError; end
+  class RubyExpression
+    # A character literal (`?a`) is a StringNode for Prism, but it has no quotes
+    # to split on, so it must not be reported as a string literal.
+    CHAR_LITERAL_OPENING = '?'
 
     def self.syntax_error?(code)
-      self.new(code).parse
-      false
-    rescue ParseError
-      true
+      Prism.parse_failure?(code)
     end
 
     def self.string_literal?(code)
-      return false if syntax_error?(code)
+      result = Prism.parse(code)
+      return false if result.failure?
 
-      type, instructions = Ripper.sexp(code)
-      return false if type != :program
-      return false if instructions.size > 1
+      statements = result.value.statements.body
+      return false if statements.size > 1
 
-      type, _ = instructions.first
-      type == :string_literal
-    end
-
-    private
-
-    def on_parse_error(*)
-      raise ParseError
+      case (node = statements.first)
+      when Prism::StringNode, Prism::InterpolatedStringNode
+        # Adjacent concatenation (`"a" "b"`) is one node without an opening
+        # delimiter of its own, and each of its parts keeps its own quotes.
+        !node.opening.nil? && node.opening != CHAR_LITERAL_OPENING
+      else
+        false
+      end
     end
   end
 end

--- a/lib/haml/ruby_expression.rb
+++ b/lib/haml/ruby_expression.rb
@@ -7,8 +7,12 @@ module Haml
     # to split on, so it must not be reported as a string literal.
     CHAR_LITERAL_OPENING = '?'
 
+    # A template is compiled into a method body, so a jump like `yield` is valid here even
+    # though it would not be at the top level of a script.
+    PARSE_OPTIONS = { partial_script: true }.freeze
+
     def self.syntax_error?(code)
-      Prism.parse_failure?(code)
+      Prism.parse_failure?(code, **PARSE_OPTIONS)
     end
 
     def self.string_literal?(code)
@@ -18,7 +22,7 @@ module Haml
     # @return [Prism::Node, nil] - the node of a string literal StringSplitter can split, if any.
     #   Its locations are byte offsets into `code` as given, so `code` must not be stripped here.
     def self.string_literal_node(code)
-      result = Prism.parse(code)
+      result = Prism.parse(code, **PARSE_OPTIONS)
       return if result.failure?
 
       statements = result.value.statements.body

--- a/lib/haml/ruby_expression.rb
+++ b/lib/haml/ruby_expression.rb
@@ -12,19 +12,23 @@ module Haml
     end
 
     def self.string_literal?(code)
+      !string_literal_node(code).nil?
+    end
+
+    # @return [Prism::Node, nil] - the node of a string literal StringSplitter can split, if any.
+    #   Its locations are byte offsets into `code` as given, so `code` must not be stripped here.
+    def self.string_literal_node(code)
       result = Prism.parse(code)
-      return false if result.failure?
+      return if result.failure?
 
       statements = result.value.statements.body
-      return false if statements.size > 1
+      return if statements.size > 1
 
       case (node = statements.first)
       when Prism::StringNode, Prism::InterpolatedStringNode
         # Adjacent concatenation (`"a" "b"`) is one node without an opening
         # delimiter of its own, and each of its parts keeps its own quotes.
-        !node.opening.nil? && node.opening != CHAR_LITERAL_OPENING
-      else
-        false
+        node if !node.opening.nil? && node.opening != CHAR_LITERAL_OPENING
       end
     end
   end

--- a/lib/haml/string_splitter.rb
+++ b/lib/haml/string_splitter.rb
@@ -1,93 +1,62 @@
 # frozen_string_literal: true
-require 'ripper'
+require 'prism'
 require 'haml/ruby_expression'
 
 module Haml
   # Compile [:dynamic, "foo#{bar}"] to [:multi, [:static, 'foo'], [:dynamic, 'bar']]
   class StringSplitter < Temple::Filter
     class << self
-      # `code` param must be valid string literal
-      def compile(code)
-        [].tap do |exps|
-          tokens = Ripper.lex(code.strip)
-          tokens.pop while tokens.last && [:on_comment, :on_sp].include?(tokens.last[1])
-
-          if tokens.size < 2
-            raise(Haml::InternalError, "Expected token size >= 2 but got: #{tokens.size}")
-          end
-          compile_tokens!(exps, tokens)
+      # `code` param must be a string literal, as RubyExpression.string_literal? defines it.
+      def compile(code, node: RubyExpression.string_literal_node(code))
+        case node
+        when Prism::StringNode
+          node.unescaped.empty? ? [] : [[:static, node.unescaped]]
+        when Prism::InterpolatedStringNode
+          compile_parts(node.parts, code)
+        else
+          raise(Haml::InternalError, "Expected a string literal but got: #{code}")
         end
       end
 
       private
 
-      def strip_quotes!(tokens)
-        _, type, beg_str = tokens.shift
-        if type != :on_tstring_beg
-          raise(Haml::InternalError, "Expected :on_tstring_beg but got: #{type}")
-        end
-
-        _, type, end_str = tokens.pop
-        if type != :on_tstring_end
-          raise(Haml::InternalError, "Expected :on_tstring_end but got: #{type}")
-        end
-
-        [beg_str, end_str]
-      end
-
-      def compile_tokens!(exps, tokens)
-        beg_str, end_str = strip_quotes!(tokens)
-
-        until tokens.empty?
-          _, type, str = tokens.shift
-
-          case type
-          when :on_tstring_content
-            beg_str, end_str = escape_quotes(beg_str, end_str)
-            exps << [:static, eval("#{beg_str}#{str}#{end_str}").to_s]
-          when :on_embexpr_beg
-            embedded = shift_balanced_embexpr(tokens)
-            exps << [:dynamic, embedded] unless embedded.empty?
-          end
-        end
-      end
-
-      # Some quotes are split-unsafe. Replace such quotes with null characters.
-      def escape_quotes(beg_str, end_str)
-        case [beg_str[-1], end_str]
-        when ['(', ')'], ['[', ']'], ['{', '}']
-          [beg_str.sub(/.\z/) { "\0" }, "\0"]
-        else
-          [beg_str, end_str]
-        end
-      end
-
-      def shift_balanced_embexpr(tokens)
-        String.new.tap do |embedded|
-          embexpr_open = 1
-
-          until tokens.empty?
-            _, type, str = tokens.shift
-            case type
-            when :on_embexpr_beg
-              embexpr_open += 1
-            when :on_embexpr_end
-              embexpr_open -= 1
-              break if embexpr_open == 0
+      def compile_parts(parts, code)
+        [].tap do |exps|
+          parts.each do |part|
+            case part
+            when Prism::StringNode
+              content = part.unescaped
+              exps << [:static, content] unless content.empty?
+            when Prism::EmbeddedStatementsNode
+              embedded = embedded_source(part, code)
+              exps << [:dynamic, embedded] unless embedded.empty?
+            when Prism::EmbeddedVariableNode
+              exps << [:dynamic, part.variable.slice]
+            else
+              # Prism allows more part types than a string literal can currently hold. Dropping
+              # one would silently lose content, so fail instead of rendering something wrong.
+              raise(Haml::InternalError, "Unexpected #{part.class} in string literal: #{code}")
             end
-
-            embedded << str
           end
         end
+      end
+
+      # The source between `#{` and `}`, kept verbatim. Slicing `code` rather than
+      # using the statements' own source preserves the whitespace around them.
+      def embedded_source(part, code)
+        from = part.opening_loc.end_offset
+        code.byteslice(from, part.closing_loc.start_offset - from)
       end
     end
 
     def on_dynamic(code)
-      return [:dynamic, code] unless RubyExpression.string_literal?(code)
       return [:dynamic, code] if code.include?("\n")
 
+      node = RubyExpression.string_literal_node(code)
+      return [:dynamic, code] if node.nil?
+
       temple = [:multi]
-      StringSplitter.compile(code).each do |type, content|
+      StringSplitter.compile(code, node: node).each do |type, content|
         case type
         when :static
           temple << [:static, content]

--- a/lib/haml/string_splitter.rb
+++ b/lib/haml/string_splitter.rb
@@ -18,6 +18,13 @@ module Haml
         end
       end
 
+      # Like compile, but nil instead of raising, for callers that built `code` themselves
+      # and would rather emit it untouched than fail the whole compilation.
+      def try_compile(code)
+        node = RubyExpression.string_literal_node(code)
+        compile(code, node: node) unless node.nil?
+      end
+
       private
 
       def compile_parts(parts, code)

--- a/lib/haml/string_splitter.rb
+++ b/lib/haml/string_splitter.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'ripper'
+require 'haml/ruby_expression'
 
 module Haml
   # Compile [:dynamic, "foo#{bar}"] to [:multi, [:static, 'foo'], [:dynamic, 'bar']]
@@ -82,7 +83,7 @@ module Haml
     end
 
     def on_dynamic(code)
-      return [:dynamic, code] unless string_literal?(code)
+      return [:dynamic, code] unless RubyExpression.string_literal?(code)
       return [:dynamic, code] if code.include?("\n")
 
       temple = [:multi]
@@ -95,36 +96,6 @@ module Haml
         end
       end
       temple
-    end
-
-    private
-
-    def string_literal?(code)
-      return false if SyntaxChecker.syntax_error?(code)
-
-      type, instructions = Ripper.sexp(code)
-      return false if type != :program
-      return false if instructions.size > 1
-
-      type, _ = instructions.first
-      type == :string_literal
-    end
-
-    class SyntaxChecker < Ripper
-      class ParseError < StandardError; end
-
-      def self.syntax_error?(code)
-        self.new(code).parse
-        false
-      rescue ParseError
-        true
-      end
-
-      private
-
-      def on_parse_error(*)
-        raise ParseError
-      end
     end
   end
 end

--- a/test/haml/attribute_parser_test.rb
+++ b/test/haml/attribute_parser_test.rb
@@ -97,5 +97,33 @@ describe Haml::AttributeParser do
       it { assert_parse({ 'foo' => 'bar(a, b)', 'hoge' => 'piyo(a, b,)' }, 'foo: bar(a, b), hoge: piyo(a, b,),') }
       it { assert_parse({ 'foo' => 'bar(a, b)', 'hoge' => 'piyo(a, b,)' }, ' { foo: bar(a, b), hoge: piyo(a, b,), } ') }
     end
+
+    describe 'splat' do
+      it { assert_parse(nil, '**foo') }
+      it { assert_parse(nil, 'foo: bar, **baz') }
+    end
+
+    describe 'value omission' do
+      it { assert_parse({ 'foo' => '' }, 'foo:') }
+      it { assert_parse({ 'foo' => '', 'bar' => '1' }, 'foo:, bar: 1') }
+    end
+
+    describe 'escape in key' do
+      # The key reaches the attribute name as the source spelled it, unescaped.
+      it { assert_parse({ 'a\0b' => '1' }, '"a\0b" => 1') }
+      it { assert_parse({ 'a\tb' => '1' }, '"a\tb" => 1') }
+      it { assert_parse({ 'a b' => '1' }, ':"a b" => 1') }
+    end
+
+    # A multi-line hash is deliberately left to the runtime: compiling it statically drops a
+    # [:newline] and shifts every __LINE__ after it. See test/haml/line_number_test.rb.
+    describe 'multiline' do
+      it { assert_parse(nil, "foo: 1,\n  bar: 2") }
+      it { assert_parse(nil, " { foo: 1,\n  bar: 2 } ") }
+    end
+  end
+
+  describe '.available?' do
+    it { assert_equal(true, Haml::AttributeParser.available?) }
   end
 end

--- a/test/haml/engine/old_attribute_test.rb
+++ b/test/haml/engine/old_attribute_test.rb
@@ -55,6 +55,14 @@ describe Haml::Engine do
       HAML
     end
 
+    it 'renders an instance variable interpolated without braces' do
+      scope = Object.new
+      scope.instance_variable_set(:@who, 'world')
+
+      assert_equal(%Q|<span title="world"></span>\n|,
+                   Haml::Template.new({}) { %q|%span{ title: "#@who" }| }.render(scope))
+    end
+
     it 'accepts method call including comma' do
       assert_render(<<-HTML.unindent, <<-'HAML'.unindent)
         <body class="bb" data-confirm="really?" data-disabled id="a"></body>
@@ -131,10 +139,6 @@ describe Haml::Engine do
       end
 
       it 'does not crash when nil is given' do
-        if /java/.match?(RUBY_PLATFORM)
-          skip 'maybe due to Ripper of JRuby'
-        end
-
         assert_raises ArgumentError do
           render_haml("%div{ nil }")
         end
@@ -585,6 +589,39 @@ describe Haml::Engine do
           <input value="abc">
         HTML
           %input{ value: -> { "abc" }.call }
+        HAML
+      end
+
+      it "recognizes block arguments" do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <input value="12">
+        HTML
+          %input{ value: [1, 2].map { |i| i }.join }
+        HAML
+      end
+
+      it "ignores a brace inside a String" do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <input value="}">
+        HTML
+          %input{ value: "}" }
+        HAML
+      end
+
+      it "ignores a brace of a character literal" do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <input value="}">
+        HTML
+          %input{ value: ?} }
+        HAML
+      end
+
+      it "ignores a brace inside a comment" do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <input a="1" b="2">
+        HTML
+          %input{ a: 1, # }
+            b: 2 }
         HAML
       end
     end

--- a/test/haml/engine/script_test.rb
+++ b/test/haml/engine/script_test.rb
@@ -144,5 +144,23 @@ describe Haml::Engine do
     it 'renders inline script with comment' do
       assert_render(%Q|<span>3</span>\n|, %q|%span= 1 + 2 # comments|)
     end
+
+    it 'renders an escaped delimiter of a percent literal' do
+      assert_render(%Q|a}b\n|, %q|= %q{a\}b}|)
+    end
+
+    it 'renders an instance variable interpolated without braces' do
+      scope = Object.new
+      scope.instance_variable_set(:@who, 'world')
+
+      assert_equal(%Q|hello world\n|, Haml::Template.new({}) { %q|= "hello #@who"| }.render(scope))
+    end
+
+    it 'renders a global variable interpolated without braces' do
+      $global_var_for_testing = 'world'
+      assert_render(%Q|hello world\n|, %q|= "hello #$global_var_for_testing"|)
+    ensure
+      $global_var_for_testing = nil
+    end
   end
 end

--- a/test/haml/engine/script_test.rb
+++ b/test/haml/engine/script_test.rb
@@ -156,6 +156,16 @@ describe Haml::Engine do
       assert_equal(%Q|hello world\n|, Haml::Template.new({}) { %q|= "hello #@who"| }.render(scope))
     end
 
+    it 'renders interpolated plain text calling yield' do
+      haml = <<-'HAML'.unindent
+        %title
+          #{yield(:title)} - #{'ACME'}
+      HAML
+
+      assert_equal(%Q|<title>\nPainel - ACME\n</title>\n|,
+                   Haml::Template.new({}) { haml }.render(Object.new) { |_key| 'Painel' })
+    end
+
     it 'renders a global variable interpolated without braces' do
       $global_var_for_testing = 'world'
       assert_render(%Q|hello world\n|, %q|= "hello #$global_var_for_testing"|)

--- a/test/haml/error_test.rb
+++ b/test/haml/error_test.rb
@@ -26,6 +26,17 @@ describe Haml::Engine do
       end
     end
 
+    describe 'unbalanced brackets' do
+      def assert_unbalanced_brackets(haml)
+        error = assert_raises(Haml::SyntaxError) { Haml::Parser.new({}).call(haml) }
+        assert_equal(Haml::Error.message(:unbalanced_brackets), error.message)
+      end
+
+      it { assert_unbalanced_brackets(%q|%p{'foo => 'bar'}|) }
+      it { assert_unbalanced_brackets(%q|%p{:foo => 'bar}|) }
+      it { assert_unbalanced_brackets(%q|%p{:foo => 'bar"}|) }
+    end
+
     describe 'Haml v1 syntax' do
       it 'returns an error with proper line number' do
         code = Haml::Engine.new.call(<<-HAML.unindent)

--- a/test/haml/filters/plain_test.rb
+++ b/test/haml/filters/plain_test.rb
@@ -13,6 +13,25 @@ describe Haml::Filters do
       HAML
     end
 
+    it 'renders interpolated content calling yield' do
+      haml = <<-'HAML'.unindent
+        :plain
+          #{yield(:title)}!
+      HAML
+
+      assert_equal(%Q|Painel!\n\n|, Haml::Template.new({}) { haml }.render(Object.new) { |_key| 'Painel' })
+    end
+
+    # The template author's mistake belongs to the generated code, not to compilation.
+    it 'compiles interpolated content that does not parse' do
+      haml = <<-'HAML'.unindent
+        :plain
+          #{1 +}
+      HAML
+
+      Haml::Engine.new.call(haml)
+    end
+
     it 'does not escape interpolated content' do
       assert_render(<<-HTML.unindent, <<-'HAML'.unindent)
         <script>

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -3,6 +3,8 @@
 require_relative '../test_helper'
 
 describe 'optimization' do
+  include RenderHelper
+
   def compiled_code(haml)
     Haml::Engine.new.call(haml)
   end
@@ -49,6 +51,10 @@ describe 'optimization' do
     it 'detects a static part recursively' do
       haml = %q|%input{ value: "#{ "hello#{ hello }" }" }|
       assert_equal true, compiled_code(haml).include?("value=\\\"hello")
+    end
+
+    it 'leaves adjacent string concatenation alone' do
+      assert_render(%|<span>hello world</span>\n|, %q|%span= "hello" " world"|)
     end
   end
 end

--- a/test/haml/ruby_expression_test.rb
+++ b/test/haml/ruby_expression_test.rb
@@ -66,4 +66,17 @@ describe Haml::RubyExpression do
       it { assert_literal(false, %Q|''\n''|) }
     end
   end
+
+  describe '.string_literal_node' do
+    it { assert_kind_of(Prism::StringNode, Haml::RubyExpression.string_literal_node(%q|'nya'|)) }
+    it { assert_kind_of(Prism::InterpolatedStringNode, Haml::RubyExpression.string_literal_node(%q|"n#{y}a"|)) }
+    it { assert_nil(Haml::RubyExpression.string_literal_node(%q|?a|)) }
+    it { assert_nil(Haml::RubyExpression.string_literal_node(%q|123|)) }
+
+    # StringSplitter slices the code with this node's offsets, so they must not be shifted.
+    it 'locates the literal in the code as given' do
+      node = Haml::RubyExpression.string_literal_node(%q|  "nya"  |)
+      assert_equal(%q|"nya"|, node.slice)
+    end
+  end
 end

--- a/test/haml/ruby_expression_test.rb
+++ b/test/haml/ruby_expression_test.rb
@@ -4,6 +4,11 @@ describe Haml::RubyExpression do
   describe '.syntax_error?' do
     it { assert_equal(true,  Haml::RubyExpression.syntax_error?('{ hash }')) }
     it { assert_equal(false, Haml::RubyExpression.syntax_error?('{ a: b }')) }
+
+    describe 'invalid expressions' do
+      it { assert_equal(true, Haml::RubyExpression.syntax_error?(%q|"]|)) }
+      it { assert_equal(true, Haml::RubyExpression.syntax_error?(%Q|'' \\ \n ''|)) }
+    end
   end
 
   describe '.string_literal?' do
@@ -28,6 +33,9 @@ describe Haml::RubyExpression do
       it { assert_literal(true, %q|"h#{ %Q[e#{ "llo wor" }l] }d"|) }
       it { assert_literal(true, %q|%Q[nya]|) }
       it { assert_literal(true, %q|%Q[#{123}]|) }
+      it { assert_literal(true, %q|%q(nya)|) }
+      it { assert_literal(true, %q|%(nya)|) }
+      it { assert_literal(true, %Q|<<~TEXT\n  nya\nTEXT|) }
     end
 
     describe 'not string literal' do
@@ -37,6 +45,21 @@ describe Haml::RubyExpression do
       it { assert_literal(false, %Q|'' \\ \n ''|) }
       it { assert_literal(false, %q|['']|) }
       it { assert_literal(false, %q|return ''|) }
+      it { assert_literal(false, %q|:hello|) }
+      it { assert_literal(false, %q|:"hello#{ world }"|) }
+      it { assert_literal(false, %q|/hello/|) }
+      it { assert_literal(false, %q|`hello`|) }
+    end
+
+    # The two cases below are a single String node for Prism, but neither has one
+    # pair of quotes wrapping the whole expression for StringSplitter to split on.
+    describe 'character literal' do
+      it { assert_literal(false, %q|?a|) }
+    end
+
+    describe 'adjacent string concatenation' do
+      it { assert_literal(false, %q|"hello" "world"|) }
+      it { assert_literal(false, %q|"hello#{ world }" "!"|) }
     end
 
     describe 'multiple instructions' do

--- a/test/haml/string_splitter_test.rb
+++ b/test/haml/string_splitter_test.rb
@@ -44,6 +44,12 @@ describe Haml::StringSplitter do
       it { assert_compile([[:static, "nya\n"]], %Q|<<~TEXT\n  nya\nTEXT|) }
     end
 
+    # A template is compiled into a method body, so these are valid where they appear.
+    describe 'jump keyword in interpolation' do
+      it { assert_compile([[:dynamic, 'yield(:title)']], %q|"#{yield(:title)}"|) }
+      it { assert_compile([[:static, 'a'], [:dynamic, 'next']], %q|"a#{next}"|) }
+    end
+
     describe 'invalid argument' do
       def assert_internal_error(code)
         assert_raises Haml::InternalError do
@@ -57,6 +63,12 @@ describe Haml::StringSplitter do
       it { assert_internal_error(%q|?a|) }
       it { assert_internal_error(%q|"a" "b"|) }
       it { assert_internal_error(%q|# comment|) }
+    end
+
+    describe '.try_compile' do
+      it { assert_equal([[:static, 'nya']], Haml::StringSplitter.try_compile(%q|"nya"|)) }
+      it { assert_nil(Haml::StringSplitter.try_compile(%q|"#{1 +}"|)) }
+      it { assert_nil(Haml::StringSplitter.try_compile(%q|1|)) }
     end
   end
 end

--- a/test/haml/string_splitter_test.rb
+++ b/test/haml/string_splitter_test.rb
@@ -26,28 +26,37 @@ describe Haml::StringSplitter do
     it { assert_compile([[:static, '\"']], %q|'\\"'|) }
     it { assert_compile([[:static, '\\"']], %q|'\\\"'|) }
 
+    describe 'paired delimiters' do
+      it { assert_compile([[:static, 'a}b']], %q|%q{a\}b}|) }
+      it { assert_compile([[:static, 'a)b']], %q|%q(a\)b)|) }
+      it { assert_compile([[:static, 'a'], [:dynamic, 'b'], [:static, 'c']], %q|%Q{a#{b}c}|) }
+      it { assert_compile([[:dynamic, ' {x: 1} ']], %q|%Q{#{ {x: 1} }}|) }
+    end
+
+    describe 'interpolated variable' do
+      it { assert_compile([[:dynamic, '@foo']], %q|"#@foo"|) }
+      it { assert_compile([[:dynamic, '$foo']], %q|"#$foo"|) }
+      it { assert_compile([[:dynamic, '@@foo']], %q|"#@@foo"|) }
+      it { assert_compile([[:static, 'a'], [:dynamic, '@foo'], [:static, ' b']], %q|"a#@foo b"|) }
+    end
+
+    describe 'heredoc' do
+      it { assert_compile([[:static, "nya\n"]], %Q|<<~TEXT\n  nya\nTEXT|) }
+    end
+
     describe 'invalid argument' do
-      it 'raises internal error' do
+      def assert_internal_error(code)
         assert_raises Haml::InternalError do
-          Haml::StringSplitter.compile('1')
+          Haml::StringSplitter.compile(code)
         end
       end
 
-      it 'raises internal error' do
-        assert_raises Haml::InternalError do
-          Haml::StringSplitter.compile('[]')
-        end
-      end
-
-      it 'raises internal error' do
-        if /java/.match?(RUBY_PLATFORM)
-          skip 'Ripper of JRuby is behaving in a different way'
-        end
-
-        assert_raises Haml::InternalError do
-          Haml::StringSplitter.compile('"]')
-        end
-      end
+      it { assert_internal_error(%q|1|) }
+      it { assert_internal_error(%q|[]|) }
+      it { assert_internal_error(%q|"]|) }
+      it { assert_internal_error(%q|?a|) }
+      it { assert_internal_error(%q|"a" "b"|) }
+      it { assert_internal_error(%q|# comment|) }
     end
   end
 end


### PR DESCRIPTION
## Summary

This replaces every use of Ripper in `lib/` with [Prism](https://github.com/ruby/prism). After this change `grep -rn Ripper lib/` returns nothing — Ripper still loads transitively through `Temple::StaticAnalyzer`, which is out of scope here (see [Remaining Ripper usage](#remaining-ripper-usage) below).

This follows up on the discussion in #1211, where the suggestion was:

> I've been meaning to replace Ripper with Prism (about every use of Ripper in general, but more so for this static/string literal check), so I would accept a change like that.

The work is split into two commits: the first moves the syntax and string-literal checks, the second moves the three remaining lexing sites.

Beyond the parser swap, the motivation is that Prism is one shared lexer and parser across CRuby, JRuby and TruffleRuby, whereas Ripper's behaviour differs between them. That difference is what produced #1161, the token-shape handling in #1212, and the two JRuby-specific `skip`s this PR deletes.

## What changed

**`Haml::RubyExpression`** no longer subclasses `Ripper`. `syntax_error?` is `Prism.parse_failure?`, and `string_literal?` inspects the AST in a single parse where it previously did a syntax check followed by `Ripper.sexp`. A node counts as a string literal when it is a `StringNode` or an `InterpolatedStringNode` carrying its own opening delimiter. The delimiter check excludes two shapes Prism reports as string nodes but Ripper did not: adjacent concatenation (`"a" "b"`), which has no delimiter wrapping the whole expression, and character literals (`?a`), which have no quotes. Both would otherwise reach `StringSplitter`, which cannot split them. `string_literal_node` was extracted so that rule lives in one place and the literal is parsed once.

All of it parses with Prism's `partial_script` option, because a template is compiled into a method body: `yield`, `break`, `next` and `redo` are valid there even though they are not at the top level of a script, and Prism would otherwise report them as errors. Prism's changelog introduces the option for exactly this, "for parsing things like ERB sources, where you know it will be evaluated in a different context". It does not loosen anything else — an unterminated string is still an error.

**`Haml::StringSplitter.compile`** walks the AST instead of a token stream. That removes `strip_quotes!`, `compile_tokens!`, `shift_balanced_embexpr`, an `eval`, and `escape_quotes`, whose null-character substitution existed only to make re-evaluating a slice of the source safe. The file went from 130 to 66 lines. The source of an interpolation comes from the byte offsets between its `#{` and `}` rather than from the statements it holds, so the whitespace around them survives — `"#{ '}' }"` still yields `[:dynamic, " '}' "]`.

**`Haml::AttributeParser`** walks `Prism::HashNode#elements` instead of counting bracket, brace, paren and interpolation depth to find the commas separating attributes (115 to 76 lines). Keys come from the source between their delimiters rather than from `unescaped`, because Ripper reported raw token text: `{ "a\0b" => 1 }` has to keep spelling the escape the way the template wrote it, or the attribute name changes. Ruby 3.1 value omission (`{ foo: }`) arrives as a `Prism::ImplicitNode` whose `slice` is `"foo:"`, and is mapped to `''` so the existing fallback to `runtime_compile` still fires.

**`Haml::Parser#balance_tokens`** counts Prism tokens and splits the buffer on the offset where it balances. `Prism.lex` emits no whitespace or comment tokens, so the text can no longer be rebuilt by concatenating them; slicing on the offset also fixes the previous `buf.sub(text, '')`, which could match an earlier occurrence of the same text.

## Behaviour changes

Two bugs fall out of the rewrite. No existing test covered either behaviour.

**Interpolating a variable without braces was silently dropped.** `compile_tokens!` only handled `:on_tstring_content` and `:on_embexpr_beg`, so the variable tokens were discarded at compile time:

```ruby
# before
Haml::Engine.new.call(%q[= "#@foo"])
# => "_buf = ''.dup; \n; _buf << (\"\\n\".freeze); _buf"   # the interpolation is gone

# %p= "#@foo"          rendered <p></p>          instead of <p>value</p>
# %p{ title: "#@foo" } rendered title=""         instead of title="value"
```

Plain text was never affected, because `Haml::Util.unescape_interpolation` rewrites `#@foo` into `#{@foo}` before `StringSplitter` sees it — only explicit string literals in scripts and attributes were broken. Worth noting that `Temple::Filters::StringSplitter` has the same bug on released Temple (`compile('"#@foo"')` returns `[]`), and the open Prism port at judofyr/temple#156 fixes it there the same way.

**An escaped delimiter of a percent literal lost its escape.** `= %q{a\}b}` rendered `a\}b` where Ruby's own value is `a}b`. `escape_quotes` swapped the `{`/`}` delimiters for null characters, so `\}` stopped being an escaped delimiter, and `%q` preserves unknown escapes. This one is inseparable from the refactor: using `StringNode#unescaped` fixes it automatically.

## A deliberate non-change

A multi-line old-attribute hash still refuses to compile statically. Today any newline makes the token walker bail, so those hashes always take the runtime path. Prism parses them happily and would silently start optimising them, but doing so drops a `[:newline]` and shifts every `__LINE__` after it:

```
%span{ a: __LINE__,
  b: __LINE__ }= __LINE__
= __LINE__

# today, and with this PR:   <span a="1" b="2">2</span> / 3
# without the guard:         <span a="1" b="1">1</span> / 2
```

The guard is explicit and commented, with a test pinning it, so making the static path newline-correct can be a separate change.

## Deprecation

`Haml::AttributeParser.available?` answered whether Ripper was present. Prism is a hard dependency now, so it is always true and Haml itself no longer asks. It is kept and marked deprecated rather than removed.

## Verification

The full suite passes with 46 new tests and no new skips:

```
1156 runs, 1175 assertions, 0 failures, 0 errors, 199 skips
```

The two skips this PR deletes only ever fired on JRuby, which is why the count is unchanged. New coverage includes the `unbalanced_brackets` contract, which had none — its three expectations live in `engine_test.rb`'s `EXCEPTION_MAP`, but `test_exception_map` is `skip`ped.

Beyond the assertions, I diffed the **compiled output** of every template in `test/haml/templates/` and `benchmark/` across three option sets, against the commit before this branch. All 5616 lines are byte-identical, which is the check that would have caught a silent flip between the static and runtime attribute paths.

Compilation is faster, measured on the same machine with a template exercising both attributes and interpolation:

| | before | after | |
|---|---|---|---|
| `RubyExpression.string_literal?`, non-literal input | 0.154s | 0.051s | 3.0x |
| `Engine#call`, whole template | 2.895s | 2.202s | 24% |

`prism >= 1.1.0` is added to the gemspec — 1.1.0 is where `partial_script` arrived. Every other Prism API used here, including the `Prism.lex` token names, which are the most version-sensitive detail, was verified to exist as far back as 1.0.0.

I also rendered a real Rails application against this branch, which is how the `partial_script` requirement surfaced: a layout doing `%title` over `#{yield(:title)}` compiled fine under Ripper, which only lexed, and failed once the same text was actually parsed. Nothing in this repository's templates uses a jump inside an interpolation, so neither the suite nor the compiled-output diff caught it. There is now a test for it.

Where a caller builds a string literal itself — the two `compile_interpolated_plain` methods and the `:plain` filter — it asks `StringSplitter.try_compile`, which answers nil rather than raising. Ruby that genuinely does not parse, such as a typo inside an interpolation, is then left to the generated code to report against the template, which is what Ripper's purely lexical splitting did, instead of failing the whole compilation.

## Platforms

The whole matrix is green — 3.2, 3.3, 3.4, 4.0, ruby-head, JRuby and TruffleRuby.

JRuby was the part I could not check while writing this, since all three sites now go through the prism gem's non-CRuby backend, and `Prism.lex` in `balance_tokens` is the least-exercised of the APIs used. It passing also means the two deleted `skip`s genuinely pass there rather than merely being absent, which is the evidence that the Ripper differences between implementations are gone. Locally I only had 4.0.1 and 4.0.2 to run against, so 3.2, 3.3 and 3.4 are CI's word.

## Remaining Ripper usage

`Temple::StaticAnalyzer` still requires Ripper, so it keeps loading through `filter :StaticAnalyzer` and the `static?` calls in the attribute and script compilers. There is already an open PR adding a Prism backend to Temple — judofyr/temple#156, by Prism's author — and because it requires prism opportunistically rather than through Temple's gemspec, and Haml now depends on prism directly, merging it would make Temple select Prism automatically with no further change here.
