### PR TITLE
Cut per-render and per-line overhead in the runtime helpers and parser

### DIFF
--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
+require 'set'
 require 'haml/object_ref'
 
 module Haml::AttributeBuilder
+  @boolean_attributes = nil
+  @boolean_attributes_size = nil
+
   class << self
     def build(escape_attrs, quote, format, object_ref, *hashes)
       hashes << Haml::ObjectRef.parse(object_ref) if object_ref
@@ -19,10 +23,12 @@ module Haml::AttributeBuilder
           buf << build_data(escape_attrs, quote, format, *hash[key])
         when 'aria'
           buf << build_aria(escape_attrs, quote, format, *hash[key])
-        when *Haml::BOOLEAN_ATTRIBUTES, /\Adata-/, /\Aaria-/
-          build_boolean!(escape_attrs, quote, format, buf, key, hash[key])
         else
-          buf << " #{key}=#{quote}#{escape_html(escape_attrs, hash[key].to_s)}#{quote}"
+          if boolean_attribute?(key)
+            build_boolean!(escape_attrs, quote, format, buf, key, hash[key])
+          else
+            buf << " #{key}=#{quote}#{escape_html(escape_attrs, hash[key].to_s)}#{quote}"
+          end
         end
       end
       buf.join
@@ -71,6 +77,22 @@ module Haml::AttributeBuilder
     end
 
     private
+
+    # Haml::BOOLEAN_ATTRIBUTES is public API and documented as mutable, so the Set has to
+    # be derived lazily and rebuilt when the Array changes. The guard is the Array's size:
+    # an in-place mutation that keeps the size (BOOLEAN_ATTRIBUTES[0] = 'x') is not picked
+    # up, but adding attributes -- the documented usage -- always changes it. The Set is
+    # published before the size so a concurrent reader either sees the old size and
+    # rebuilds, or sees the new size with the new Set already visible.
+    def boolean_attribute?(key)
+      attributes = Haml::BOOLEAN_ATTRIBUTES
+      size = attributes.size
+      if @boolean_attributes_size != size
+        @boolean_attributes = Set.new(attributes)
+        @boolean_attributes_size = size
+      end
+      @boolean_attributes.include?(key) || key.start_with?('data-', 'aria-')
+    end
 
     def build_data_attribute(key, escape_attrs, quote, format, *hashes)
       attrs = []

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -144,7 +144,9 @@ module Haml::AttributeBuilder
           raise ArgumentError, "Non-hash object is given to attributes!"
         end
         hash.each do |key, value|
-          key = key.to_s
+          # Hands back the interned frozen String instead of allocating a
+          # fresh one per render.
+          key = key.is_a?(Symbol) ? key.name : key.to_s
           case key
           when 'id', 'class', 'data', 'aria'
             merged[key] ||= []

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -120,14 +120,18 @@ module Haml::AttributeBuilder
       flattened = {}
 
       attributes.each do |key, value|
+        # Stops a hash which contains itself from recursing forever.
+        next if value.equal?(attributes)
+
         case value
-        when attributes
         when Hash
           flatten_attributes(value).each do |k, v|
             if k.nil?
               flattened[key] = v
             else
-              flattened["#{key}-#{k.to_s.tr('_', '-')}"] = v
+              k = k.is_a?(Symbol) ? k.name : k.to_s
+              k = k.tr('_', '-') if k.include?('_')
+              flattened["#{key}-#{k}"] = v
             end
           end
         else

--- a/lib/haml/compiler/script_compiler.rb
+++ b/lib/haml/compiler/script_compiler.rb
@@ -1,14 +1,14 @@
 # frozen_string_literal: true
 require 'temple/static_analyzer'
+require 'haml/helpers'
 require 'haml/ruby_expression'
 require 'haml/string_splitter'
 
 module Haml
   class Compiler
     class ScriptCompiler
-      def self.find_and_preserve(input, tags)
-        tags = tags.map { |tag| Regexp.escape(tag) }.join('|')
-        re = /<(#{tags})([^>]*)>(.*?)(<\/\1>)/im
+      def self.find_and_preserve(input, tags = ::Haml::Helpers::DEFAULT_PRESERVE_TAGS)
+        re = ::Haml::Helpers.preserve_regex(tags)
         input.to_s.gsub(re) do |s|
           s =~ re # Can't rely on $1, etc. existing since Rails' SafeBuffer#gsub is incompatible
           "<#{$1}#{$2}>#{Haml::Helpers.preserve($3)}</#{$1}>"
@@ -69,7 +69,7 @@ module Haml
         if node.value[:escape_html]
           str = Haml::Util.escape_html(str)
         elsif node.value[:preserve]
-          str = ScriptCompiler.find_and_preserve(str, %w(textarea pre code))
+          str = ScriptCompiler.find_and_preserve(str)
         end
         [:multi, [:static, str], [:newline]]
       end
@@ -104,7 +104,7 @@ module Haml
       end
 
       def find_and_preserve(code)
-        %Q[::Haml::Compiler::ScriptCompiler.find_and_preserve(#{code}, %w(textarea pre code))]
+        %Q[::Haml::Compiler::ScriptCompiler.find_and_preserve(#{code}, ::Haml::Helpers::DEFAULT_PRESERVE_TAGS)]
       end
 
       def escape_html(temple)

--- a/lib/haml/escape_any.rb
+++ b/lib/haml/escape_any.rb
@@ -12,10 +12,30 @@ module Haml
 
   # Unlike Haml::Escape, this calls to_s when not escaped.
   class EscapeAny < Escape
-    alias_method :on_escapeany, :on_escape
+    def initialize(opts = {})
+      super
+      @to_s = false
+    end
 
+    def on_escapeany(flag, exp)
+      old_escape, old_to_s = @escape, @to_s
+      @escape = flag && !options[:disable_escape]
+      @to_s = !@escape
+      compile(exp)
+    ensure
+      @escape, @to_s = old_escape, old_to_s
+    end
+
+    # to_s is appended only inside :escapeany. Every other [:dynamic] in the tree
+    # belongs to somebody else -- the Escape pass already turned it into an
+    # escape_html call, or it ends up in an interpolation or in the generator's
+    # own `(...).to_s` -- so wrapping it here would just duplicate that call.
     def on_dynamic(value)
-      [:dynamic, @escape ? @escape_code % value : "(#{value}).to_s"]
+      if @escape
+        [:dynamic, @escape_code % value]
+      else
+        [:dynamic, @to_s ? "(#{value}).to_s" : value]
+      end
     end
   end
 end

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -1,9 +1,53 @@
 # frozen_string_literal: true
 module Haml
   module Helpers
+    # Referenced by name from the Ruby the compiler emits, so `~` does not rebuild the list
+    # per render, and the default of RailsHelpers#find_and_preserve, so both paths hand
+    # preserve_regex the same object.
+    DEFAULT_PRESERVE_TAGS = %w[textarea pre code].freeze
+
+    def self.build_preserve_regex(tags)
+      pattern = tags.map { |tag| Regexp.escape(tag) }.join('|')
+      /<(#{pattern})([^>]*)>(.*?)(<\/\1>)/im
+    end
+    private_class_method :build_preserve_regex
+
+    DEFAULT_PRESERVE_REGEX = build_preserve_regex(DEFAULT_PRESERVE_TAGS)
+    private_constant :DEFAULT_PRESERVE_REGEX
+
+    # Past this many distinct tag lists we stop caching and pay what find_and_preserve paid
+    # before, rather than letting a caller that derives tags from its input grow the cache
+    # without bound -- the copy below makes that quadratic.
+    MAX_PRESERVE_REGEXES = 64
+    private_constant :MAX_PRESERVE_REGEXES
+
+    @preserve_regexes = { DEFAULT_PRESERVE_TAGS => DEFAULT_PRESERVE_REGEX }.freeze
+
+    # Building this regex costs far more than matching with it, and a template renders with
+    # the same tags every time. The cache is replaced, never mutated in place, so a reader
+    # only ever sees a frozen Hash and needs no lock on JRuby or TruffleRuby either; the
+    # worst a racing writer can do is rebuild a regex another thread already built.
+    #
+    # @api private
+    def self.preserve_regex(tags)
+      return DEFAULT_PRESERVE_REGEX if tags.equal?(DEFAULT_PRESERVE_TAGS)
+
+      cache = @preserve_regexes
+      cache[tags] || begin
+        regex = build_preserve_regex(tags)
+        if cache.size < MAX_PRESERVE_REGEXES
+          # Keyed by content, so a %w[...] literal rebuilt per call still hits; dup (not map)
+          # keeps a caller that mutates its own list from stranding the entry, without
+          # forcing the key to an Array.
+          @preserve_regexes = cache.merge(tags.dup.freeze => regex).freeze
+        end
+        regex
+      end
+    end
+
     def self.preserve(input)
       s = input.to_s.chomp("\n")
-      s.gsub!(/\n/, '&#x000A;')
+      s.gsub!("\n", '&#x000A;')
       s.delete!("\r")
       s
     end

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -102,6 +102,18 @@ module Haml
     # Used for scanning old attributes, substituting the first '{'
     METHOD_CALL_PREFIX = 'a('
 
+    # The characters after '#' that start an interpolation rather than a div id
+    INTERPOLATION_CHARS = %w[{ @ $].freeze
+
+    # The keywords @script_level_stack tracks. Narrower than the block keyword lists above,
+    # which also build the block regexes.
+    SCRIPT_STACK_KEYWORDS     = %w[if case unless].freeze
+    SCRIPT_STACK_MID_KEYWORDS = %w[else elsif when].freeze
+
+    # The lexer token types that open and close an old-syntax attribute hash
+    OLD_ATTRIBUTE_OPEN_TOKENS  = %i[BRACE_LEFT LAMBDA_BEGIN EMBEXPR_BEGIN].freeze
+    OLD_ATTRIBUTE_CLOSE_TOKENS = %i[BRACE_RIGHT EMBEXPR_END].freeze
+
     def initialize(options)
       @options = ParserOptions.new(options)
       # Record the indent levels of "if" statements to validate the subsequent
@@ -289,7 +301,7 @@ module Haml
       case line.text[0]
       when DIV_CLASS; push div(line)
       when DIV_ID
-        return push plain(line) if %w[{ @ $].include?(line.text[1])
+        return push plain(line) if INTERPOLATION_CHARS.include?(line.text[1])
         push div(line)
       when ELEMENT; push tag(line)
       when COMMENT; push comment(line.text[1..-1].lstrip)
@@ -371,7 +383,7 @@ module Haml
 
       check_push_script_stack(keyword)
 
-      if ["else", "elsif", "when"].include?(keyword)
+      if SCRIPT_STACK_MID_KEYWORDS.include?(keyword)
         if @script_level_stack.empty?
           raise Haml::SyntaxError.new(Error.message(:missing_if, keyword), @line.index)
         end
@@ -394,7 +406,7 @@ module Haml
     end
 
     def check_push_script_stack(keyword)
-      if ["if", "case", "unless"].include?(keyword)
+      if SCRIPT_STACK_KEYWORDS.include?(keyword)
         # @script_level_stack contents are arrays of form
         # [:keyword, stack_level, other_info]
         @script_level_stack.push([keyword.to_sym, @line.tabs])
@@ -570,7 +582,7 @@ module Haml
     end
 
     def close_silent_script(node)
-      @script_level_stack.pop if ["if", "case", "unless"].include? node.value[:keyword]
+      @script_level_stack.pop if SCRIPT_STACK_KEYWORDS.include? node.value[:keyword]
 
       # Post-process case statements to normalize the nesting of "when" clauses
       return unless node.value[:keyword] == "case"
@@ -703,8 +715,8 @@ module Haml
 
         attributes_hash, rest = balance_tokens(
           text.sub(?{, METHOD_CALL_PREFIX),
-          [:BRACE_LEFT, :LAMBDA_BEGIN, :EMBEXPR_BEGIN],
-          [:BRACE_RIGHT, :EMBEXPR_END],
+          OLD_ATTRIBUTE_OPEN_TOKENS,
+          OLD_ATTRIBUTE_CLOSE_TOKENS,
           count: 1)
         attributes_hash = attributes_hash.sub(METHOD_CALL_PREFIX, ?{)
       rescue SyntaxError => e

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -90,6 +90,12 @@ module Haml
     # The Regex that matches a literal string or symbol value
     LITERAL_VALUE_REGEX = /:(\w*)|(["'])((?!\\|\#\{|\#@|\#\$|\2).|\\.)*\2/
 
+    # The Regexes that scan a quoted new-syntax attribute value
+    NEW_ATTRIBUTE_VALUE_REGEX = {
+      '"' => /((?:\\.|\#(?!\{)|[^"\\#])*)("|#\{)/,
+      "'" => /((?:\\.|\#(?!\{)|[^'\\#])*)('|#\{)/,
+    }.freeze
+
     ID_KEY    = 'id'.freeze
     CLASS_KEY = 'class'.freeze
 
@@ -125,6 +131,7 @@ module Haml
 
       @root = @parent = ParseNode.new(:root)
       @flat = false
+      @flat_spaces = ''
       @filter_buffer = nil
       @indentation = nil
       @line = next_line
@@ -138,7 +145,9 @@ module Haml
 
         if flat?
           text = @line.full.dup
-          text = "" unless text.gsub!(/^#{@flat_spaces}/, '')
+          # An empty @flat_spaces means the indentation is not known yet: keep the line,
+          # as the /^/ this replaces did by matching the empty prefix.
+          text = "" unless text.delete_prefix!(@flat_spaces) || @flat_spaces.empty?
           @filter_buffer << "#{text}\n"
           @line = @next_line
           next
@@ -182,7 +191,7 @@ module Haml
 
       tabs = line.whitespace.length / @indentation.length
       return tabs if line.whitespace == @indentation * tabs
-      return @template_tabs + 1 if flat? && /^#{@flat_spaces}/.match?(line.whitespace)
+      return @template_tabs + 1 if flat? && line.whitespace.start_with?(@flat_spaces)
 
       message = Error.message(:inconsistent_indentation,
         human_indentation(line.whitespace),
@@ -556,7 +565,7 @@ module Haml
 
     def close_flat_section
       @flat = false
-      @flat_spaces = nil
+      @flat_spaces = ''
       @filter_buffer = nil
     end
 
@@ -771,7 +780,7 @@ module Haml
         return name, [:dynamic, var]
       end
 
-      re = /((?:\\.|\#(?!\{)|[^#{quote}\\#])*)(#{quote}|#\{)/
+      re = NEW_ATTRIBUTE_VALUE_REGEX[quote]
       content = []
       loop do
         return false unless scanner.scan(re)
@@ -794,7 +803,7 @@ module Haml
       line_defined = instance_variable_defined?(:@line)
       @line.tabs if line_defined
       unless (flat? && !closes_flat?(line) && !closes_flat?(@line)) ||
-          (line_defined && @line.text[0] == ?: && %r[^#{@line.full[/^\s+/]}\s].match?(line.full))
+          (line_defined && @line.text[0] == ?: && indented_under_line?(line))
         return next_line if line.text.empty?
 
         handle_multiline(line)
@@ -804,7 +813,16 @@ module Haml
     end
 
     def closes_flat?(line)
-      line && !line.text.empty? && !(/^#{@flat_spaces}/.match?(line.full))
+      line && !line.text.empty? && !line.full.start_with?(@flat_spaces)
+    end
+
+    # Whether `line` repeats @line's indentation and then indents further.
+    def indented_under_line?(line)
+      indent = @line.full[/^\s+/] || ''
+      return false unless line.full.start_with?(indent)
+
+      char = line.full[indent.length]
+      !char.nil? && /\s/.match?(char)
     end
 
     def handle_multiline(line)
@@ -882,7 +900,11 @@ module Haml
     # Same semantics as block_opened?, except that block_opened? uses Line#tabs,
     # which doesn't interact well with filter lines
     def filter_opened?
-      (@indentation ? /^#{@indentation * (@template_tabs + 1)}/ : /^\s/).match?(@next_line.full)
+      if @indentation
+        @next_line.full.start_with?(@indentation * (@template_tabs + 1))
+      else
+        /^\s/.match?(@next_line.full)
+      end
     end
 
     def flat?

--- a/lib/haml/rails_helpers.rb
+++ b/lib/haml/rails_helpers.rb
@@ -7,17 +7,13 @@ module Haml
     include Helpers
     extend self
 
-    DEFAULT_PRESERVE_TAGS = %w[textarea pre code].freeze
+    # Same object as the compiler emits, so the default takes preserve_regex's fast path.
+    DEFAULT_PRESERVE_TAGS = Helpers::DEFAULT_PRESERVE_TAGS
 
     def find_and_preserve(input = nil, tags = DEFAULT_PRESERVE_TAGS, &block)
       return find_and_preserve(capture_haml(&block), input || tags) if block
 
-      tags = tags.each_with_object('') do |t, s|
-        s << '|' unless s.empty?
-        s << Regexp.escape(t)
-      end
-
-      re = /<(#{tags})([^>]*)>(.*?)(<\/\1>)/im
+      re = Helpers.preserve_regex(tags)
       input.to_s.gsub(re) do |s|
         s =~ re # Can't rely on $1, etc. existing since Rails' SafeBuffer#gsub is incompatible
         "<#{$1}#{$2}>#{preserve($3)}</#{$1}>"

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -164,6 +164,14 @@ MSG
       scan.rest
     end
 
+    # The Regexes #balance scans with, for the delimiter pairs this codebase uses
+    BALANCE_REGEXES = {
+      '{' => { '}' => /(.*?)[\{\}]/m }.freeze,
+      '[' => { ']' => /(.*?)[\[\]]/m }.freeze,
+      '(' => { ')' => /(.*?)[\(\)]/m }.freeze,
+    }.freeze
+    private_constant :BALANCE_REGEXES
+
     # Moves a scanner through a balanced pair of characters.
     # For example:
     #
@@ -182,7 +190,8 @@ MSG
     def balance(scanner, start, finish, count = 0)
       str = ''.dup
       scanner = StringScanner.new(scanner) unless scanner.is_a? StringScanner
-      regexp = Regexp.new("(.*?)[\\#{start.chr}\\#{finish.chr}]", Regexp::MULTILINE)
+      regexp = BALANCE_REGEXES.dig(start, finish) ||
+        Regexp.new("(.*?)[\\#{start.chr}\\#{finish.chr}]", Regexp::MULTILINE)
       while scanner.scan(regexp)
         str << scanner.matched
         count += 1 if scanner.matched[-1] == start

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -26,10 +26,20 @@ module Haml
       end
     end
 
-    # TODO: Remove unescape_interpolation's workaround and get rid of `respond_to?`.
-    def self.escape_html_safe(html)
-      html = html.to_s
-      (html.respond_to?(:html_safe?) && html.html_safe?) ? html : escape_html(html)
+    # ActiveSupport defines html_safe? on Object, so once it is loaded the guard can never
+    # be false. Without it this is still reachable, because unescape_interpolation below
+    # hard-codes the call outside the use_html_safe decision; fix that and the guarded
+    # variant can go too.
+    if ''.respond_to?(:html_safe?)
+      def self.escape_html_safe(html)
+        html = html.to_s
+        html.html_safe? ? html : escape_html(html)
+      end
+    else
+      def self.escape_html_safe(html)
+        html = html.to_s
+        (html.respond_to?(:html_safe?) && html.html_safe?) ? html : escape_html(html)
+      end
     end
 
     # Silence all output to STDERR within a block.

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -218,7 +218,7 @@ MSG
     end
 
     def contains_interpolation?(str)
-      /#[\{$@]/ === str
+      /#[\{$@]/.match?(str)
     end
 
     def unescape_interpolation(str, escape_html = nil)

--- a/test/haml/engine/attributes_test.rb
+++ b/test/haml/engine/attributes_test.rb
@@ -132,8 +132,9 @@ describe Haml::Engine do
   describe 'data attributes' do
     # TODO: assert_haml tests nothing since migration to haml repository. Use assert_render instead.
     it { assert_haml(%q|#foo.bar{ data: { disabled: val } }|, locals: { val: false }) }
-    it { skip; assert_haml(%q|%div{:data => hash}|, locals: { hash: { :a => { :b => 'c' } }.tap { |h| h[:d] = h } }) }
-    it { skip; assert_haml(%q|%div{ hash }|, locals: { hash: { data: { :a => { :b => 'c' } }.tap { |h| h[:d] = h } } }) }
+    # A hash which contains itself.
+    it { assert_render(%Q|<div data-a-b="c"></div>\n|, %q|%div{:data => hash}|, locals: { hash: { :a => { :b => 'c' } }.tap { |h| h[:d] = h } }) }
+    it { assert_render(%Q|<div data-a-b="c"></div>\n|, %q|%div{ hash }|, locals: { hash: { data: { :a => { :b => 'c' } }.tap { |h| h[:d] = h } } }) }
     it { assert_haml(%q|%div{:data => {:foo_bar => 'blip', :baz => 'bang'}}|) }
     it { assert_haml(%q|%div{ data: { raw_src: 'foo' } }|) }
     it { assert_haml(%q|%a{ data: { value: [count: 1] } }|) }

--- a/test/haml/helpers_test.rb
+++ b/test/haml/helpers_test.rb
@@ -6,5 +6,30 @@ describe Haml::Helpers do
       result = Haml::Helpers.preserve("hello\nworld")
       assert_equal 'hello&#x000A;world', result
     end
+
+    it 'chomps a single trailing newline' do
+      assert_equal 'a&#x000A;', Haml::Helpers.preserve("a\n\n")
+      assert_equal 'a&#x000A;b', Haml::Helpers.preserve("a\nb\n")
+      assert_equal 'no newline', Haml::Helpers.preserve('no newline')
+    end
+
+    it 'deletes carriage returns' do
+      assert_equal 'a&#x000A;b', Haml::Helpers.preserve("a\r\nb")
+      assert_equal 'ab', Haml::Helpers.preserve("a\rb")
+    end
+
+    it 'converts whatever it is given to a String' do
+      assert_equal '13', Haml::Helpers.preserve(13)
+      assert_equal '', Haml::Helpers.preserve(nil)
+      assert_equal 'a&#x000A;b', Haml::Helpers.preserve("a\nb".html_safe)
+    end
+
+    it 'still rejects a broken byte sequence' do
+      # gsub! with a String pattern would substitute where the Regexp raised, but delete!
+      # on the next line raises the same error, so the method is unchanged end to end.
+      broken = (+"a\xFFb\nc").force_encoding('UTF-8')
+      error = assert_raises(ArgumentError) { Haml::Helpers.preserve(broken) }
+      assert_equal 'invalid byte sequence in UTF-8', error.message
+    end
   end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -528,4 +528,72 @@ describe 'optimization' do
       assert_operator per_line, :<, 20
     end
   end
+
+  # Util.balance built its scanning Regexp on every call, and it is called once per
+  # interpolation, per object reference and per conditional comment.
+  describe 'balance regexes' do
+    BALANCES = 1000
+
+    def balance(*args)
+      Haml::Util.balance(*args)
+    end
+
+    def allocations
+      GC.start
+      before = GC.stat(:total_allocated_objects)
+      BALANCES.times { yield }
+      GC.stat(:total_allocated_objects) - before
+    end
+
+    it 'keeps the regex it used to build per call' do
+      regexes = Haml::Util.const_get(:BALANCE_REGEXES)
+      [['{', '}'], ['[', ']'], ['(', ')']].each do |start, finish|
+        assert_equal Regexp.new("(.*?)[\\#{start}\\#{finish}]", Regexp::MULTILINE),
+                     regexes.dig(start, finish)
+      end
+      # Interpolation and new attribute values use {}, object references and conditional
+      # comments use [], and parse_new_attributes uses () on its way to raising.
+      assert_equal ['(', '[', '{'], regexes.keys.sort
+    end
+
+    it 'stops rebuilding the regex per call' do
+      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      balance('a} b', '{', '}', 1)
+      balance('a> b', '<', '>', 1)
+
+      cached   = allocations { balance('a} b', '{', '}', 1) }
+      fallback = allocations { balance('a> b', '<', '>', 1) }
+      # Was the same on both: every pair went through Regexp.new, 6 objects a call.
+      assert_operator fallback - cached, :>, BALANCES * 5
+    end
+
+    it 'keeps working for a pair it has no regex for' do
+      assert_equal ['<a>', ' rest'], balance('<a> rest', '<', '>')
+      # A mismatched pair has to fall back rather than pick up the regex for '{'.
+      assert_equal ['a]', ' rest'],  balance('a] rest', '{', ']', 1)
+    end
+
+    it 'balances the same pairs as before' do
+      assert_equal ['a}', ' rest'],        balance('a} rest', '{', '}', 1)
+      assert_equal ['[@user]', ' text'],   balance('[@user] text', '[', ']')
+      assert_equal ['(a (b) c)', ' rest'], balance('(a (b) c) rest', '(', ')')
+      assert_nil                           balance('no delimiters here', '{', '}', 1)
+      assert_nil                           balance('a { b { c } d } e', '{', '}', 1)
+
+      # A StringScanner receiver is moved in place; a String is wrapped in a fresh one.
+      scanner = StringScanner.new('user.id} and more')
+      assert_equal ['user.id}', ' and more'], balance(scanner, '{', '}', 1)
+      assert_equal ' and more', scanner.rest
+    end
+
+    it 'renders the shapes that reach balance' do
+      assert_render %Q{<p>1</p>\n},                     %q[%p #{1}]
+      assert_render %Q{<p>1</p>\n},                     %q[%p #{ {a: 1}[:a] }]
+      assert_render %Q{<p>[1, 2]</p>\n},                %q[%p #{ [1,2].map { |i| i } }]
+      assert_render %Q{<p>\#{not_interp}</p>\n},        %q[%p \#{not_interp}]
+      assert_render %Q{<p>[not an object ref]</p>\n},   %q[%p [not an object ref]]
+      assert_render %Q{<!--[if IE]> hi <![endif]-->\n}, %q[/[if IE] hi]
+      assert_render %Q{<a href="/u/1"></a>\n},          %Q{- v = 1\n%a(href="/u/\#{v}")}
+    end
+  end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -596,4 +596,110 @@ describe 'optimization' do
       assert_render %Q{<a href="/u/1"></a>\n},          %Q{- v = 1\n%a(href="/u/\#{v}")}
     end
   end
+
+  # contains_interpolation? ran Regexp#=== once per line of text, attribute value, comment and
+  # filter body, and the lookup tables around it were Array literals rebuilt per line.
+  describe 'interpolation and keyword lookups' do
+    CHECKS = 1000
+
+    PER_LINE_ARRAY_METHODS = %i[
+      process_line silent_script check_push_script_stack close_silent_script parse_old_attributes
+    ].freeze
+
+    def parse(haml)
+      Haml::Parser.new({}).call(haml)
+    end
+
+    def allocations
+      GC.start
+      before = GC.stat(:total_allocated_objects)
+      CHECKS.times { yield }
+      GC.stat(:total_allocated_objects) - before
+    end
+
+    it 'stops allocating a MatchData per interpolation check' do
+      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      hit  = %q{text #{value} more}
+      miss = 'text with none of it'
+      [hit, miss].each { |s| Haml::Util.contains_interpolation?(s) }
+
+      # Regexp#=== cost 3 objects on a match and 1-2 on a miss, for a $~ nothing reads.
+      assert_operator allocations { Haml::Util.contains_interpolation?(hit) },  :<, CHECKS
+      assert_operator allocations { Haml::Util.contains_interpolation?(miss) }, :<, CHECKS
+    end
+
+    it 'keeps the lookup tables it used to rebuild per line' do
+      assert_equal %w[{ @ $],           Haml::Parser::INTERPOLATION_CHARS
+      assert_equal %w[if case unless],  Haml::Parser::SCRIPT_STACK_KEYWORDS
+      assert_equal %w[else elsif when], Haml::Parser::SCRIPT_STACK_MID_KEYWORDS
+      assert_equal %i[BRACE_LEFT LAMBDA_BEGIN EMBEXPR_BEGIN], Haml::Parser::OLD_ATTRIBUTE_OPEN_TOKENS
+      assert_equal %i[BRACE_RIGHT EMBEXPR_END], Haml::Parser::OLD_ATTRIBUTE_CLOSE_TOKENS
+
+      %i[INTERPOLATION_CHARS SCRIPT_STACK_KEYWORDS SCRIPT_STACK_MID_KEYWORDS
+         OLD_ATTRIBUTE_OPEN_TOKENS OLD_ATTRIBUTE_CLOSE_TOKENS].each do |name|
+        assert_predicate Haml::Parser.const_get(name), :frozen?, name
+      end
+
+      # Narrower than the block-keyword lists, which also build the block regexes.
+      refute_equal Haml::Parser::START_BLOCK_KEYWORDS, Haml::Parser::SCRIPT_STACK_KEYWORDS
+      refute_equal Haml::Parser::MID_BLOCK_KEYWORDS,   Haml::Parser::SCRIPT_STACK_MID_KEYWORDS
+    end
+
+    it 'builds no Array literal in the per-line lookups' do
+      skip 'iseq introspection is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      # Both opcodes: Ruby <= 3.3 emits duparray, 4.0 folds `[...].include?` into
+      # opt_newarray_send. newarray is excluded, its arrays carry data, not lookups.
+      building = PER_LINE_ARRAY_METHODS.select do |name|
+        disasm = RubyVM::InstructionSequence.of(Haml::Parser.instance_method(name)).disasm
+        disasm.include?('duparray') || disasm.include?('opt_newarray_send')
+      end
+      assert_empty building
+    end
+
+    it 'reports interpolation for the same strings as before' do
+      [%q{a #{1}}, 'a #@ivar', 'a #$global', '#{', '#@', '#$', %q{\#{x}}].each do |str|
+        assert Haml::Util.contains_interpolation?(str), str.inspect
+      end
+      ['a # b', 'plain', '', '#', nil].each do |str|
+        refute Haml::Util.contains_interpolation?(str), str.inspect
+      end
+    end
+
+    it 'still tells a div id from an interpolated line' do
+      assert_render %Q{<div id="main">content</div>\n},          %q{#main content}
+      assert_render %Q{<div class="wide" id="main">x</div>\n},   %q{#main.wide x}
+      assert_render %Q{2\n},                                     %q{#{1 + 1}}
+      assert_render %Q{<p>text 2 more</p>\n},                    %q{%p text #{1 + 1} more}
+      assert_render %Q{<p>a # b</p>\n},                          %q{%p a # b}
+      assert_render %Q{<p>x</p>\n},                              %Q{-# hidden\n%p x}
+      assert_raises(Haml::SyntaxError) { parse(%q{#}) }
+    end
+
+    it 'nests silent scripts against the same keyword sets' do
+      assert_render %Q{<p>b</p>\n}, %Q{- if false\n  %p a\n- elsif true\n  %p b\n}
+      assert_render %Q{<p>c</p>\n}, %Q{- if false\n  %p a\n- elsif false\n  %p b\n- else\n  %p c\n}
+      assert_render %Q{<p>a</p>\n}, %Q{- unless false\n  %p a\n- else\n  %p b\n}
+      assert_render %Q{<p>b</p>\n}, %Q{- case 2\n- when 1\n  %p a\n- when 2\n  %p b\n}
+      assert_render %Q{<p>c</p>\n}, %Q{- case 3\n- when 1\n  %p a\n- else\n  %p c\n}
+      assert_render %Q{<p>a</p>\n}, %Q{- case 1\n  - when 1\n    %p a\n}
+      assert_render %Q{<p>a</p>\n}, %Q{- begin\n  %p a\n- rescue\n  %p b\n}
+      assert_render %Q{<p>a</p>\n<p>c</p>\n}, %Q{- if true\n  - case 1\n  - when 1\n    %p a\n- if true\n  %p c\n}
+
+      # Reusing START_BLOCK_KEYWORDS here would make this shape a Ruby SyntaxError, not a Haml one.
+      assert_raises(Haml::SyntaxError) { parse(%Q{- begin\n  %p a\n- else\n  %p b\n}) }
+      assert_raises(Haml::SyntaxError) { parse(%Q{- else\n  %p a\n}) }
+      assert_raises(Haml::SyntaxError) { parse(%Q{- when 1\n  %p a\n}) }
+      assert_raises(Haml::SyntaxError) { parse(%Q{- if true\n  %p a\n  - else\n    %p b\n}) }
+    end
+
+    it 'balances an old-syntax attribute hash against the same token lists' do
+      assert_render %Q[<p title="a } b">x</p>\n],  %q[%p{ title: "a } b" } x]
+      assert_render %Q{<p title="a 1 b">x</p>\n},  %q{%p{ title: "a #{1} b" } x}
+      assert_render %Q{<p v="[1, 2]">x</p>\n},     %q{%p{ v: [1,2].map { |i| i } } x}
+      assert_render %Q{<p a="1" b="2">x</p>\n},    %Q{%p{ a: 1,\n    b: 2 } x}
+      assert_render %Q{<p data-a="1">x</p>\n},     %q{%p{ data: { a: 1 } } x}
+      assert_render %Q{<p class="a" id="b">x</p>\n}, %q{%p{ class: 'a' }(id='b') x}
+      assert_raises(Haml::SyntaxError) { parse(%q[%p{ class: 'a' x]) }
+    end
+  end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -198,4 +198,77 @@ describe 'optimization' do
       assert_operator extra, :<, BUILDS / 10
     end
   end
+
+  # The nested keys of data:/aria:, flattened and hyphenated by
+  # AttributeBuilder.flatten_attributes.
+  describe 'nested attribute keys' do
+    def build(*hashes)
+      Haml::AttributeBuilder.build(true, '"', :html, nil, *hashes)
+    end
+
+    def allocations
+      GC.start
+      before = GC.stat(:total_allocated_objects)
+      BUILDS.times { yield }
+      GC.stat(:total_allocated_objects) - before
+    end
+
+    it 'skips a hash which contains itself instead of recursing into it' do
+      data = { a: { b: 'c' } }
+      data[:d] = data
+      assert_equal ' data-a-b="c"', build(data: data)
+
+      aria = { a: { b: 'c' } }
+      aria[:d] = aria
+      assert_equal ' aria-a-b="c"', build(aria: aria)
+    end
+
+    it 'changes underscores in a nested key to hyphens' do
+      assert_equal ' data-raw-src="foo"', build(data: { raw_src: 'foo' })
+      assert_equal ' data-raw-src="foo"', build('data' => { 'raw_src' => 'foo' })
+      assert_equal ' data-a-b-c="1"',     build(data: { a_b_c: 1 })
+      assert_equal ' aria-raw-src="foo"', build(aria: { raw_src: 'foo' })
+    end
+
+    it 'leaves a nested key without an underscore alone' do
+      assert_equal ' data-src="foo"',     build(data: { src: 'foo' })
+      assert_equal ' data-raw-src="foo"', build('data' => { 'raw-src' => 'foo' })
+    end
+
+    it 'hyphenates every level of a nested hash' do
+      assert_equal ' data-raw-src-url="foo"', build(data: { raw_src: { url: 'foo' } })
+      assert_equal ' data-a-b-c-d="1"',       build(data: { a_b: { c_d: 1 } })
+    end
+
+    it 'keeps stringifying a nested key which is neither Symbol nor String' do
+      assert_equal ' data-1="2"',    build(data: { 1 => 2 })
+      assert_equal ' data-false',    build(data: { false => true })
+      # A nil key names the prefix itself rather than a suffix of it.
+      assert_equal ' data="3"',      build(data: { nil => 3 })
+    end
+
+    it 'allocates no more for a Symbol nested key than for the equivalent String key' do
+      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      symbol_key = { 'data' => { ab: 1 } }
+      string_key = { 'data' => { 'ab' => 1 } }
+      build(symbol_key)
+      build(string_key)
+
+      extra = allocations { build(symbol_key) } - allocations { build(string_key) }
+      # Was BUILDS: k.to_s allocated one String per Symbol key per build.
+      assert_operator extra, :<, BUILDS / 10
+    end
+
+    it 'allocates less for a nested key with no underscore to convert' do
+      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      without_underscore = { 'data' => { 'ab' => 1 } }
+      with_underscore    = { 'data' => { 'a_b' => 1 } }
+      build(without_underscore)
+      build(with_underscore)
+
+      saved = allocations { build(with_underscore) } - allocations { build(without_underscore) }
+      # Was 0: tr allocated a String per key per build even with nothing to replace.
+      assert_operator saved, :>, BUILDS / 2
+    end
+  end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -5,6 +5,10 @@ require_relative '../test_helper'
 describe 'optimization' do
   include RenderHelper
 
+  # Iterations of an allocation measurement, and the yardstick its assertions are written
+  # against: "fewer than RUNS objects" reads as "no longer one per call".
+  RUNS = 1000
+
   def compiled_code(haml, options = {})
     Haml::Engine.new(options).call(haml)
   end
@@ -17,6 +21,32 @@ describe 'optimization' do
       buffer_class:    'ActionView::OutputBuffer',
       disable_capture: true,
     })
+  end
+
+  def parse(haml)
+    Haml::Parser.new({}).call(haml)
+  end
+
+  # The runtime attribute path: what AttributeCompiler#runtime_compile emits for hashes it
+  # cannot resolve at compile time. No keyword parameter here, or a bare `build(href: 'x')`
+  # would arrive as keywords instead of as the Hash under test.
+  def build(*hashes)
+    build_as(:html, *hashes)
+  end
+
+  def build_as(format, *hashes)
+    Haml::AttributeBuilder.build(true, '"', format, nil, *hashes)
+  end
+
+  def allocations(runs = RUNS)
+    GC.start
+    before = GC.stat(:total_allocated_objects)
+    runs.times { yield }
+    GC.stat(:total_allocated_objects) - before
+  end
+
+  def skip_unless_cruby(subject)
+    skip "#{subject} is CRuby-specific" unless RUBY_ENGINE == 'ruby'
   end
 
   describe 'static analysis' do
@@ -107,13 +137,7 @@ describe 'optimization' do
     end
   end
 
-  # The runtime path: what AttributeCompiler#runtime_compile emits for hashes it cannot
-  # resolve at compile time.
   describe 'boolean attributes' do
-    def build(hash, format = :html)
-      Haml::AttributeBuilder.build(true, '"', format, nil, hash)
-    end
-
     def with_custom_attributes(*attributes)
       old_attributes = Haml::BOOLEAN_ATTRIBUTES.dup
       Haml::BOOLEAN_ATTRIBUTES.push(*attributes)
@@ -126,7 +150,7 @@ describe 'optimization' do
       assert_equal ' disabled', build('disabled' => true)
       assert_equal '', build('disabled' => false)
       assert_equal '', build('disabled' => nil)
-      assert_equal ' disabled="disabled"', build({ 'disabled' => true }, :xhtml)
+      assert_equal ' disabled="disabled"', build_as(:xhtml, 'disabled' => true)
     end
 
     it 'treats data- and aria- prefixed attributes as boolean' do
@@ -155,19 +179,6 @@ describe 'optimization' do
   end
 
   describe 'attribute keys' do
-    BUILDS = 1000
-
-    def build(*hashes)
-      Haml::AttributeBuilder.build(true, '"', :html, nil, *hashes)
-    end
-
-    def allocations
-      GC.start
-      before = GC.stat(:total_allocated_objects)
-      BUILDS.times { yield }
-      GC.stat(:total_allocated_objects) - before
-    end
-
     it 'treats a Symbol key the same as the equivalent String key' do
       assert_equal build('href' => '/x'), build(href: '/x')
       assert_equal build('id' => 'a'),    build(id: 'a')
@@ -187,32 +198,21 @@ describe 'optimization' do
     end
 
     it 'allocates no more for Symbol keys than for the equivalent String keys' do
-      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('allocation counting')
       symbol_keys = { href: '/x', title: 't' }
       string_keys = { 'href' => '/x', 'title' => 't' }
       build(symbol_keys)
       build(string_keys)
 
       extra = allocations { build(symbol_keys) } - allocations { build(string_keys) }
-      # Was 2 * BUILDS: key.to_s allocated one String per Symbol key per build.
-      assert_operator extra, :<, BUILDS / 10
+      # Was 2 * RUNS: key.to_s allocated one String per Symbol key per build.
+      assert_operator extra, :<, RUNS / 10
     end
   end
 
   # The nested keys of data:/aria:, flattened and hyphenated by
   # AttributeBuilder.flatten_attributes.
   describe 'nested attribute keys' do
-    def build(*hashes)
-      Haml::AttributeBuilder.build(true, '"', :html, nil, *hashes)
-    end
-
-    def allocations
-      GC.start
-      before = GC.stat(:total_allocated_objects)
-      BUILDS.times { yield }
-      GC.stat(:total_allocated_objects) - before
-    end
-
     it 'skips a hash which contains itself instead of recursing into it' do
       data = { a: { b: 'c' } }
       data[:d] = data
@@ -248,19 +248,19 @@ describe 'optimization' do
     end
 
     it 'allocates no more for a Symbol nested key than for the equivalent String key' do
-      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('allocation counting')
       symbol_key = { 'data' => { ab: 1 } }
       string_key = { 'data' => { 'ab' => 1 } }
       build(symbol_key)
       build(string_key)
 
       extra = allocations { build(symbol_key) } - allocations { build(string_key) }
-      # Was BUILDS: k.to_s allocated one String per Symbol key per build.
-      assert_operator extra, :<, BUILDS / 10
+      # Was RUNS: k.to_s allocated one String per Symbol key per build.
+      assert_operator extra, :<, RUNS / 10
     end
 
     it 'allocates less for a nested key with no underscore to convert' do
-      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('allocation counting')
       without_underscore = { 'data' => { 'ab' => 1 } }
       with_underscore    = { 'data' => { 'a_b' => 1 } }
       build(without_underscore)
@@ -268,7 +268,7 @@ describe 'optimization' do
 
       saved = allocations { build(with_underscore) } - allocations { build(without_underscore) }
       # Was 0: tr allocated a String per key per build even with nothing to replace.
-      assert_operator saved, :>, BUILDS / 2
+      assert_operator saved, :>, RUNS / 2
     end
   end
 
@@ -300,7 +300,7 @@ describe 'optimization' do
     end
 
     it 'does not ask respond_to? per value when html_safe? is available' do
-      skip 'iseq introspection is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('iseq introspection')
       disasm = RubyVM::InstructionSequence.of(Haml::Util.method(:escape_html_safe)).disasm
       # The guard used to run on every escaped value, though html_safe? is on Object
       # as soon as ActiveSupport is loaded, so it could never be false here.
@@ -309,7 +309,7 @@ describe 'optimization' do
     end
 
     it 'keeps the guard when ActiveSupport is not loaded' do
-      skip 'subprocess test is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('subprocess test')
       script = <<~RUBY
         require 'haml'
         abort 'ActiveSupport leaked into the child' if ''.respond_to?(:html_safe?)
@@ -331,17 +331,8 @@ describe 'optimization' do
   # `~` (preserve) used to rebuild its tag regex on every call, and the code the compiler
   # emits carried the tag list as a literal, reallocated per render.
   describe 'preserve regexes' do
-    CALLS = 1000
-
     def find_and_preserve(*args)
       Haml::Compiler::ScriptCompiler.find_and_preserve(*args)
-    end
-
-    def allocations
-      GC.start
-      before = GC.stat(:total_allocated_objects)
-      CALLS.times { yield }
-      GC.stat(:total_allocated_objects) - before
     end
 
     it 'emits a reference to the tag list instead of a literal' do
@@ -363,18 +354,18 @@ describe 'optimization' do
     end
 
     it 'stops rebuilding the regex per call' do
-      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('allocation counting')
       tags = Haml::Helpers::DEFAULT_PRESERVE_TAGS
       Haml::Helpers.preserve_regex(tags)
 
       cached = allocations { Haml::Helpers.preserve_regex(tags) }
       built  = allocations { Haml::Helpers.send(:build_preserve_regex, tags) }
       # Was what building costs: map + Regexp.escape per tag + join + Regexp, ~14 objects.
-      assert_operator built - cached, :>, CALLS * 5
+      assert_operator built - cached, :>, RUNS * 5
     end
 
     it 'renders a preserved value with only haml/engine required' do
-      skip 'subprocess test is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('subprocess test')
       # haml/helpers is loaded by haml/template and haml/rails_helpers, neither of which
       # haml/engine pulls in, so this used to raise NameError at render time.
       script = <<~'RUBY'
@@ -426,10 +417,6 @@ describe 'optimization' do
   describe 'parser regexes' do
     COMPILES = 20
 
-    def parse(haml)
-      Haml::Parser.new({}).call(haml)
-    end
-
     # The text a filter or -# block collected, wherever it sits in the tree.
     def flat_text(haml)
       find = lambda do |node|
@@ -442,14 +429,11 @@ describe 'optimization' do
 
     def compile_allocations(haml)
       Haml::Engine.new.call(haml)
-      GC.start
-      before = GC.stat(:total_allocated_objects)
-      COMPILES.times { Haml::Engine.new.call(haml) }
-      (GC.stat(:total_allocated_objects) - before) / COMPILES.to_f
+      allocations(COMPILES) { Haml::Engine.new.call(haml) } / COMPILES.to_f
     end
 
     it 'compiles no regex while parsing' do
-      skip 'iseq introspection is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('iseq introspection')
       names = Haml::Parser.instance_methods(false) + Haml::Parser.private_instance_methods(false)
       interpolating = names.select do |name|
         iseq = RubyVM::InstructionSequence.of(Haml::Parser.instance_method(name))
@@ -518,7 +502,7 @@ describe 'optimization' do
     end
 
     it 'stops allocating a regex per line of a filter body' do
-      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('allocation counting')
       short = ":plain\n" + "  content line\n" * 10
       long  = ":plain\n" + "  content line\n" * 110
 
@@ -532,17 +516,8 @@ describe 'optimization' do
   # Util.balance built its scanning Regexp on every call, and it is called once per
   # interpolation, per object reference and per conditional comment.
   describe 'balance regexes' do
-    BALANCES = 1000
-
     def balance(*args)
       Haml::Util.balance(*args)
-    end
-
-    def allocations
-      GC.start
-      before = GC.stat(:total_allocated_objects)
-      BALANCES.times { yield }
-      GC.stat(:total_allocated_objects) - before
     end
 
     it 'keeps the regex it used to build per call' do
@@ -557,14 +532,14 @@ describe 'optimization' do
     end
 
     it 'stops rebuilding the regex per call' do
-      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('allocation counting')
       balance('a} b', '{', '}', 1)
       balance('a> b', '<', '>', 1)
 
       cached   = allocations { balance('a} b', '{', '}', 1) }
       fallback = allocations { balance('a> b', '<', '>', 1) }
       # Was the same on both: every pair went through Regexp.new, 6 objects a call.
-      assert_operator fallback - cached, :>, BALANCES * 5
+      assert_operator fallback - cached, :>, RUNS * 5
     end
 
     it 'keeps working for a pair it has no regex for' do
@@ -600,32 +575,19 @@ describe 'optimization' do
   # contains_interpolation? ran Regexp#=== once per line of text, attribute value, comment and
   # filter body, and the lookup tables around it were Array literals rebuilt per line.
   describe 'interpolation and keyword lookups' do
-    CHECKS = 1000
-
     PER_LINE_ARRAY_METHODS = %i[
       process_line silent_script check_push_script_stack close_silent_script parse_old_attributes
     ].freeze
 
-    def parse(haml)
-      Haml::Parser.new({}).call(haml)
-    end
-
-    def allocations
-      GC.start
-      before = GC.stat(:total_allocated_objects)
-      CHECKS.times { yield }
-      GC.stat(:total_allocated_objects) - before
-    end
-
     it 'stops allocating a MatchData per interpolation check' do
-      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('allocation counting')
       hit  = %q{text #{value} more}
       miss = 'text with none of it'
       [hit, miss].each { |s| Haml::Util.contains_interpolation?(s) }
 
       # Regexp#=== cost 3 objects on a match and 1-2 on a miss, for a $~ nothing reads.
-      assert_operator allocations { Haml::Util.contains_interpolation?(hit) },  :<, CHECKS
-      assert_operator allocations { Haml::Util.contains_interpolation?(miss) }, :<, CHECKS
+      assert_operator allocations { Haml::Util.contains_interpolation?(hit) },  :<, RUNS
+      assert_operator allocations { Haml::Util.contains_interpolation?(miss) }, :<, RUNS
     end
 
     it 'keeps the lookup tables it used to rebuild per line' do
@@ -646,7 +608,7 @@ describe 'optimization' do
     end
 
     it 'builds no Array literal in the per-line lookups' do
-      skip 'iseq introspection is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      skip_unless_cruby('iseq introspection')
       # Both opcodes: Ruby <= 3.3 emits duparray, 4.0 folds `[...].include?` into
       # opt_newarray_send. newarray is excluded, its arrays carry data, not lookups.
       building = PER_LINE_ARRAY_METHODS.select do |name|

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -327,4 +327,96 @@ describe 'optimization' do
       assert_equal '&lt;b&gt;|<b>', out
     end
   end
+
+  # `~` (preserve) used to rebuild its tag regex on every call, and the code the compiler
+  # emits carried the tag list as a literal, reallocated per render.
+  describe 'preserve regexes' do
+    CALLS = 1000
+
+    def find_and_preserve(*args)
+      Haml::Compiler::ScriptCompiler.find_and_preserve(*args)
+    end
+
+    def allocations
+      GC.start
+      before = GC.stat(:total_allocated_objects)
+      CALLS.times { yield }
+      GC.stat(:total_allocated_objects) - before
+    end
+
+    it 'emits a reference to the tag list instead of a literal' do
+      # Only `!~` and escape_html: false reach find_and_preserve; a plain `~` under the
+      # default escape_html: true is escaped instead.
+      [compiled_code(%Q{- x = 1\n!~ x}), rails_compiled_code(%Q{- x = 1\n!~ x})].each do |code|
+        assert_includes code, '::Haml::Helpers::DEFAULT_PRESERVE_TAGS'
+        refute_includes code, '%w(textarea pre code)'
+      end
+    end
+
+    it 'builds one regex per tag list' do
+      default = Haml::Helpers::DEFAULT_PRESERVE_TAGS
+      assert_same Haml::Helpers.preserve_regex(default), Haml::Helpers.preserve_regex(default)
+      # A literal spelled out by a caller is the same list, so it must hit the same entry.
+      assert_same Haml::Helpers.preserve_regex(default), Haml::Helpers.preserve_regex(%w[textarea pre code])
+      assert_same Haml::Helpers.preserve_regex(%w[b]), Haml::Helpers.preserve_regex(%w[b])
+      refute_same Haml::Helpers.preserve_regex(%w[b]), Haml::Helpers.preserve_regex(%w[i])
+    end
+
+    it 'stops rebuilding the regex per call' do
+      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      tags = Haml::Helpers::DEFAULT_PRESERVE_TAGS
+      Haml::Helpers.preserve_regex(tags)
+
+      cached = allocations { Haml::Helpers.preserve_regex(tags) }
+      built  = allocations { Haml::Helpers.send(:build_preserve_regex, tags) }
+      # Was what building costs: map + Regexp.escape per tag + join + Regexp, ~14 objects.
+      assert_operator built - cached, :>, CALLS * 5
+    end
+
+    it 'renders a preserved value with only haml/engine required' do
+      skip 'subprocess test is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      # haml/helpers is loaded by haml/template and haml/rails_helpers, neither of which
+      # haml/engine pulls in, so this used to raise NameError at render time.
+      script = <<~'RUBY'
+        require 'haml/engine'
+        haml = %Q{- x = ["<pre>a\\nb</pre>"].first\n~ x\n}
+        print eval(Haml::Engine.new(escape_html: false).call(haml))
+      RUBY
+      lib = File.expand_path('../../lib', __dir__)
+      out = IO.popen([RbConfig.ruby, '-I', lib, '-e', script], &:read)
+
+      assert_predicate $?, :success?
+      assert_equal %Q{<pre>a&#x000A;b</pre>\n}, out
+    end
+
+    it 'preserves newlines inside the default tags' do
+      assert_render(%Q{<pre>a&#x000A;b</pre>\n}, %Q{- x = ["<pre>a\\nb</pre>"].first\n!~ x})
+      assert_render(%Q{<textarea>a&#x000A;b</textarea>\n},
+                    %Q{- x = ["<textarea>a\\nb</textarea>"].first\n!~ x})
+      # Compiled away by static_compile rather than emitted, but through the same method.
+      assert_render(%Q{<pre>a&#x000A;b</pre>\n}, %Q{~ ["<pre>a\\nb</pre>"][0]}, escape_html: false)
+    end
+
+    it 'matches the same tags as before' do
+      assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", %w[b])
+      assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", [:b])
+      assert_equal "<b>a\nb</b>",       find_and_preserve("<b>a\nb</b>")
+      assert_equal '<PRE>a&#x000A;b</PRE>', find_and_preserve("<PRE>a\nb</PRE>")
+      assert_equal '<pre class="x">a&#x000A;b</pre>', find_and_preserve(%Q{<pre class="x">a\nb</pre>})
+      # An empty list still builds a regex, one that needs a </> to close.
+      assert_equal "<pre>a\nb</pre>", find_and_preserve("<pre>a\nb</pre>", [])
+      # Regexp.escape still applies to a tag carrying regex syntax.
+      assert_equal '<a.b>a&#x000A;b</a.b>', find_and_preserve("<a.b>a\nb</a.b>", ['a.b'])
+      assert_equal '13', find_and_preserve(13)
+      assert_equal '',   find_and_preserve(nil)
+    end
+
+    it 'keeps a cached list working after the caller mutates its own array' do
+      tags = %w[b]
+      assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", tags)
+      tags << 'i'
+      assert_equal '<i>a&#x000A;b</i>', find_and_preserve("<i>a\nb</i>", tags)
+      assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", %w[b])
+    end
+  end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -153,4 +153,49 @@ describe 'optimization' do
       assert_equal ' custom="false"', build('custom' => false)
     end
   end
+
+  describe 'attribute keys' do
+    BUILDS = 1000
+
+    def build(*hashes)
+      Haml::AttributeBuilder.build(true, '"', :html, nil, *hashes)
+    end
+
+    def allocations
+      GC.start
+      before = GC.stat(:total_allocated_objects)
+      BUILDS.times { yield }
+      GC.stat(:total_allocated_objects) - before
+    end
+
+    it 'treats a Symbol key the same as the equivalent String key' do
+      assert_equal build('href' => '/x'), build(href: '/x')
+      assert_equal build('id' => 'a'),    build(id: 'a')
+      assert_equal build('class' => 'a'), build(class: 'a')
+      assert_equal build('data' => { 'book_id' => 5432 }), build(data: { book_id: 5432 })
+      assert_equal build('aria' => { 'label' => 'x' }),    build(aria: { label: 'x' })
+    end
+
+    it 'merges Symbol and String spellings of the same key' do
+      assert_equal ' href="/y"',   build({ href: '/x' }, { 'href' => '/y' })
+      assert_equal ' id="a_b"',    build({ id: 'a' }, { 'id' => 'b' })
+      assert_equal ' class="a b"', build({ class: 'a' }, { 'class' => 'b' })
+    end
+
+    it 'stringifies a key which is neither Symbol nor String' do
+      assert_equal ' 1="2"', build(1 => 2)
+    end
+
+    it 'allocates no more for Symbol keys than for the equivalent String keys' do
+      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      symbol_keys = { href: '/x', title: 't' }
+      string_keys = { 'href' => '/x', 'title' => 't' }
+      build(symbol_keys)
+      build(string_keys)
+
+      extra = allocations { build(symbol_keys) } - allocations { build(string_keys) }
+      # Was 2 * BUILDS: key.to_s allocated one String per Symbol key per build.
+      assert_operator extra, :<, BUILDS / 10
+    end
+  end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -271,4 +271,60 @@ describe 'optimization' do
       assert_operator saved, :>, BUILDS / 2
     end
   end
+
+  # Whatever Escape emits for `=` when use_html_safe is on, which is the default whenever
+  # ActiveSupport is loaded. test_helper requires rails before haml, so these run against
+  # the variant Util picks when html_safe? exists.
+  describe 'html safe escaping' do
+    class ::TosSafeBufferObject
+      def to_s
+        '<hr>'.html_safe
+      end
+    end
+
+    it 'escapes a value which is not html_safe' do
+      assert_equal '&lt;b&gt;', Haml::Util.escape_html_safe('<b>')
+      assert_equal '', Haml::Util.escape_html_safe(nil)
+      assert_equal '1/1', Haml::Util.escape_html_safe(1.to_r)
+    end
+
+    it 'passes an html_safe value through untouched' do
+      safe = '<b>'.html_safe
+      assert_equal '<b>', Haml::Util.escape_html_safe(safe)
+      assert_same safe, Haml::Util.escape_html_safe(safe)
+    end
+
+    it 'asks html_safe? of to_s, not of the object' do
+      # Kaminari-style object: not html_safe itself, but its to_s is.
+      assert_equal '<hr>', Haml::Util.escape_html_safe(::TosSafeBufferObject.new)
+    end
+
+    it 'does not ask respond_to? per value when html_safe? is available' do
+      skip 'iseq introspection is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      disasm = RubyVM::InstructionSequence.of(Haml::Util.method(:escape_html_safe)).disasm
+      # The guard used to run on every escaped value, though html_safe? is on Object
+      # as soon as ActiveSupport is loaded, so it could never be false here.
+      refute_includes disasm, 'respond_to?'
+      assert_includes disasm, 'html_safe?'
+    end
+
+    it 'keeps the guard when ActiveSupport is not loaded' do
+      skip 'subprocess test is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      script = <<~RUBY
+        require 'haml'
+        abort 'ActiveSupport leaked into the child' if ''.respond_to?(:html_safe?)
+        print Haml::Util.escape_html_safe('<b>')
+        print '|'
+        require 'active_support/core_ext/string/output_safety'
+        print Haml::Util.escape_html_safe('<b>'.html_safe)
+      RUBY
+      lib = File.expand_path('../../lib', __dir__)
+      out = IO.popen([RbConfig.ruby, '-I', lib, '-e', script], &:read)
+
+      assert_predicate $?, :success?
+      # Escapes without ActiveSupport, and still adapts if it shows up later, which is
+      # the only reason the guarded variant exists.
+      assert_equal '&lt;b&gt;|<b>', out
+    end
+  end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -106,4 +106,51 @@ describe 'optimization' do
       assert_render(%|<a href="1/1"></a>\n|, %Q|- href = 1.to_r\n%a{ href: href }|)
     end
   end
+
+  # The runtime path: what AttributeCompiler#runtime_compile emits for hashes it cannot
+  # resolve at compile time.
+  describe 'boolean attributes' do
+    def build(hash, format = :html)
+      Haml::AttributeBuilder.build(true, '"', format, nil, hash)
+    end
+
+    def with_custom_attributes(*attributes)
+      old_attributes = Haml::BOOLEAN_ATTRIBUTES.dup
+      Haml::BOOLEAN_ATTRIBUTES.push(*attributes)
+      yield
+    ensure
+      Haml::BOOLEAN_ATTRIBUTES.replace(old_attributes)
+    end
+
+    it 'omits a known boolean attribute whose value is false or nil' do
+      assert_equal ' disabled', build('disabled' => true)
+      assert_equal '', build('disabled' => false)
+      assert_equal '', build('disabled' => nil)
+      assert_equal ' disabled="disabled"', build({ 'disabled' => true }, :xhtml)
+    end
+
+    it 'treats data- and aria- prefixed attributes as boolean' do
+      assert_equal ' data-foo', build('data-foo' => true)
+      assert_equal ' aria-foo', build('aria-foo' => true)
+      assert_equal '', build('data-foo' => false)
+      assert_equal '', build('aria-foo' => false)
+    end
+
+    it 'keeps other attributes non-boolean' do
+      assert_equal ' href="true"', build('href' => true)
+      assert_equal ' href="false"', build('href' => false)
+      # The prefixes are anchored: only a leading data-/aria- counts.
+      assert_equal ' datax="false"', build('datax' => false)
+      assert_equal ' x-data-foo="false"', build('x-data-foo' => false)
+    end
+
+    it 'picks up attributes added to BOOLEAN_ATTRIBUTES after the first build' do
+      assert_equal ' custom="false"', build('custom' => false)
+      with_custom_attributes('custom') do
+        assert_equal '', build('custom' => false)
+        assert_equal ' custom', build('custom' => true)
+      end
+      assert_equal ' custom="false"', build('custom' => false)
+    end
+  end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -419,4 +419,113 @@ describe 'optimization' do
       assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", %w[b])
     end
   end
+
+  # The parser interpolated the flat-block indentation, the current line's indentation and
+  # the attribute quote character straight into regex literals, inside loops that run once
+  # per template line. Compiling benchmark/etc/real_sample.haml built 1200+ Regexps.
+  describe 'parser regexes' do
+    COMPILES = 20
+
+    def parse(haml)
+      Haml::Parser.new({}).call(haml)
+    end
+
+    # The text a filter or -# block collected, wherever it sits in the tree.
+    def flat_text(haml)
+      find = lambda do |node|
+        return node if node.type == :filter || node.type == :haml_comment
+        node.children.each { |child| (found = find.call(child)) and return found }
+        nil
+      end
+      find.call(parse(haml))&.value&.[](:text)
+    end
+
+    def compile_allocations(haml)
+      Haml::Engine.new.call(haml)
+      GC.start
+      before = GC.stat(:total_allocated_objects)
+      COMPILES.times { Haml::Engine.new.call(haml) }
+      (GC.stat(:total_allocated_objects) - before) / COMPILES.to_f
+    end
+
+    it 'compiles no regex while parsing' do
+      skip 'iseq introspection is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      names = Haml::Parser.instance_methods(false) + Haml::Parser.private_instance_methods(false)
+      interpolating = names.select do |name|
+        iseq = RubyVM::InstructionSequence.of(Haml::Parser.instance_method(name))
+        iseq&.disasm&.include?('toregexp')
+      end
+      # toregexp builds a Regexp at runtime. call, compute_tabs, closes_flat?, next_line,
+      # filter_opened? and parse_new_attribute each had one, all of them inside a loop.
+      assert_empty interpolating
+    end
+
+    it 'keeps a whitespace-only line in a filter whose indentation is not known yet' do
+      # Nothing has established the template's indentation when this filter opens, so
+      # @flat_spaces is still empty. The regex was /^/ there: it matched the empty prefix,
+      # so gsub! reported a substitution and the line survived. delete_prefix! reports
+      # nothing for an empty argument, which would have emptied the line instead.
+      assert_equal " \nfoo\n", flat_text(":plain\n \n  foo\n")
+      # Once the indentation is known the same line no longer carries it and is emptied.
+      assert_equal "a\n\nb\n", flat_text("%p\n  :plain\n    a\n \n    b\n")
+    end
+
+    it 'strips the same flat-block indentation as the interpolated anchor did' do
+      assert_equal "a\n\nb\n",        flat_text(":plain\n  a\n\n  b\n")
+      assert_equal "a\n    b\nc\n",   flat_text(":plain\n  a\n      b\n  c\n")
+      assert_equal "a\n\t\tb\n",      flat_text(":plain\n\ta\n\t\t\tb\n")
+      assert_equal "a  \nb\n",        flat_text(":plain\n  a  \n  b\n")
+      assert_equal "%p not haml\n",   flat_text(":plain\n  %p not haml\n")
+      assert_equal "a\nb\n",          flat_text("%div\n  %p\n    :plain\n      a\n      b\n")
+      assert_equal "a\n",             flat_text("%div\n  :plain\n    a\n  %p x\n%p y\n")
+      assert_equal "a\n      b\n",    flat_text("%div\n  :plain\n    a\n          b\n")
+      assert_nil                      flat_text("%p x\n:plain\n%p y\n")
+      # -# runs the same code, without the special case that keeps a blank line after a filter.
+      assert_equal "foo\n",           flat_text("-#\n \n  foo\n%p y\n")
+      assert_equal "a\n\nb\n",        flat_text("-#\n  a\n\n  b\n")
+      assert_equal " text\na\nb\n",   flat_text("-# text\n  a\n  b\n")
+    end
+
+    it 'resets the flat indentation between two blocks' do
+      # close_flat_section clears @flat_spaces, which is now '' rather than nil.
+      assert_equal ["a\n", "b\n"], parse(":plain\n  a\n:plain\n  b\n").children.map { |c| c.value[:text] }
+    end
+
+    it 'keeps the scanner regex it used to interpolate per attribute value' do
+      %w[" '].each do |quote|
+        assert_equal(/((?:\\.|\#(?!\{)|[^#{quote}\\#])*)(#{quote}|#\{)/,
+                     Haml::Parser::NEW_ATTRIBUTE_VALUE_REGEX[quote])
+      end
+      # parse_new_attribute reaches this after scanner.scan(/["']/), so there is no third key.
+      assert_equal ['"', "'"], Haml::Parser::NEW_ATTRIBUTE_VALUE_REGEX.keys.sort
+    end
+
+    it 'scans a quoted attribute value the same for both quote characters' do
+      assert_render %Q{<a href="x"></a>\n},              %q{%a(href="x")}
+      assert_render %Q{<a href="x"></a>\n},              %q{%a(href='x')}
+      assert_render %Q{<a title="it&#39;s"></a>\n},      %q{%a(title="it's")}
+      assert_render %Q{<a title="say &quot;hi&quot;"></a>\n}, %q{%a(title='say "hi"')}
+      assert_render %Q{<a title="a&quot;b"></a>\n},      %q{%a(title="a\\"b")}
+      assert_render %Q{<a title="a&#39;b"></a>\n},       %q{%a(title='a\\'b')}
+      assert_render %Q{<a href="#"></a>\n},              %q{%a(href="#")}
+      assert_render %Q{<a href="#top"></a>\n},           %q{%a(href="#top")}
+      assert_render %Q{<a href=""></a>\n},               %q{%a(href="")}
+      assert_render %Q{<a href="x" title="y"></a>\n},    %q{%a(href="x" title='y')}
+      assert_render %Q{<a title="héllo ☃"></a>\n},       %q{%a(title="héllo ☃")}
+      assert_render %Q{<a href="/u/1"></a>\n},           %Q{- v = 1\n%a(href="/u/\#{v}")}
+      assert_render %Q{<a href="/u/1"></a>\n},           %Q{- v = 1\n%a(href='/u/\#{v}')}
+      assert_render %Q{<a href="#1"></a>\n},             %Q{- v = 1\n%a(href="\#\#{v}")}
+    end
+
+    it 'stops allocating a regex per line of a filter body' do
+      skip 'allocation counting is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      short = ":plain\n" + "  content line\n" * 10
+      long  = ":plain\n" + "  content line\n" * 110
+
+      per_line = (compile_allocations(long) - compile_allocations(short)) / 100.0
+      # Was 34: an interpolated Regexp and its source String for the body line, another
+      # pair for closes_flat?, and what gsub! allocates on top of them. Now 10.
+      assert_operator per_line, :<, 20
+    end
+  end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -5,8 +5,18 @@ require_relative '../test_helper'
 describe 'optimization' do
   include RenderHelper
 
-  def compiled_code(haml)
-    Haml::Engine.new.call(haml)
+  def compiled_code(haml, options = {})
+    Haml::Engine.new(options).call(haml)
+  end
+
+  # Mirrors Haml::RailsTemplate.options without depending on the railtie being loaded.
+  def rails_compiled_code(haml)
+    compiled_code(haml, {
+      generator:       Temple::Generators::RailsOutputBuffer,
+      use_html_safe:   true,
+      buffer_class:    'ActionView::OutputBuffer',
+      disable_capture: true,
+    })
   end
 
   describe 'static analysis' do
@@ -55,6 +65,45 @@ describe 'optimization' do
 
     it 'leaves adjacent string concatenation alone' do
       assert_render(%|<span>hello world</span>\n|, %q|%span= "hello" " world"|)
+    end
+  end
+
+  describe 'to_s' do
+    it 'emits a single to_s per dynamic output' do
+      assert_equal 1, compiled_code(%|%p= @content|).scan('.to_s').size
+      assert_equal 1, compiled_code(%|%p!= @content|).scan('.to_s').size
+    end
+
+    it 'emits a single to_s per dynamic output in rails mode' do
+      code = rails_compiled_code(%|%p= @content|)
+      assert_equal true, code.include?('safe_concat')
+      assert_equal 1, code.scan('.to_s').size
+    end
+
+    it 'does not append to_s to an interpolated attribute value' do
+      code = compiled_code(<<-HAML.unindent)
+        - href = 1
+        %a{ href: href }
+      HAML
+      assert_equal true, code.include?('#{::Haml::Util.escape_html((href))}')
+    end
+
+    it 'appends to_s only to :escapeany nodes' do
+      filter = Haml::EscapeAny.new(use_html_safe: false)
+      assert_equal [:dynamic, '::Haml::Util.escape_html((foo))'],
+                   filter.call([:escapeany, true, [:dynamic, 'foo']])
+      assert_equal [:dynamic, '(foo).to_s'],
+                   filter.call([:escapeany, false, [:dynamic, 'foo']])
+      # An already-escaped node, i.e. what the Escape pass leaves behind.
+      assert_equal [:dynamic, '::Haml::Util.escape_html((foo))'],
+                   filter.call([:dynamic, '::Haml::Util.escape_html((foo))'])
+    end
+
+    it 'still stringifies values which are not String' do
+      assert_render(%|<p>1/1</p>\n|, %|%p= 1.to_r|)
+      assert_render(%|<p>1/1</p>\n|, %|%p!= 1.to_r|)
+      assert_render(%|1/1\n|, %|!= 1.to_r|)
+      assert_render(%|<a href="1/1"></a>\n|, %Q|- href = 1.to_r\n%a{ href: href }|)
     end
   end
 end

--- a/test/haml/rails_template_test.rb
+++ b/test/haml/rails_template_test.rb
@@ -95,6 +95,24 @@ describe Haml::RailsTemplate do
     HAML
   end
 
+  # The regex is cached per tag list, so lists have to stay apart from each other.
+  specify 'find_and_preserve with custom tags' do
+    assert_equal <<-HTML.unindent, render(<<-'HAML'.unindent)
+      &lt;b&gt;a&amp;#x000A;b&lt;/b&gt;
+      &lt;i&gt;a&amp;#x000A;b&lt;/i&gt;
+      &lt;b&gt;c&amp;#x000A;d&lt;/b&gt;
+      &lt;pre&gt;e&amp;#x000A;f&lt;/pre&gt;
+      &lt;pre&gt;g
+      h&lt;/pre&gt;
+    HTML
+      = find_and_preserve("<b>a\nb</b>", %w[b])
+      = find_and_preserve("<i>a\nb</i>", %w[i])
+      = find_and_preserve("<b>c\nd</b>", %w[b])
+      = find_and_preserve("<pre>e\nf</pre>")
+      = find_and_preserve("<pre>g\nh</pre>", [])
+    HAML
+  end
+
   specify 'capture_haml' do
     assert_equal <<-HTML.unindent, render(<<-'HAML'.unindent)
       <div class="capture"><span>


### PR DESCRIPTION
Nine self-contained micro-optimizations to the render hot paths (duplicate `to_s` in every dynamic output, attribute classification, attribute key handling, `escape_html_safe`, `find_and_preserve`) and to the parser (regexes rebuilt per line, per interpolation and per attribute value). No public API changes; rendered HTML is byte-identical throughout.

## Changes

One commit each, in this order:

- [x] Stop `EscapeAny` from appending a duplicate `to_s` to every dynamic output
- [x] Classify boolean attributes with a Set instead of a `case`/`when` splat
- [x] Look up Symbol attribute keys with `Symbol#name` instead of `to_s`
- [x] Flatten nested attributes without `Hash#==` or an unconditional `tr`
- [x] Pick the `html_safe` escaper once at load instead of `respond_to?` per value
- [x] Build the preserve regex once per tag list instead of per call
- [x] Build the parser's per-line regexes once instead of per line
- [x] Build the `Util.balance` scanner regex once per pair instead of per call
- [x] Match interpolation without a MatchData and hoist the parser's lookup tables

## How to review

**One commit per optimization, in sequence — please review commit by commit.** Each commit message carries the motivation, the equivalence argument and the measured result for that change alone, and each commit is green in isolation, so any item can be reverted independently.

## Method

- 3 alternated rounds (`main` ↔ branch) per benchmark, median, `benchmark-ips`;
  both sides pinned to the same `Gemfile.lock` (temple 0.10.4), Ruby 4.0.2.
- Render allocations counted with `GC.stat(:total_allocated_objects)`.
- Rendered HTML of all 21 `benchmark/` templates diffed against `main`: byte-identical.
- Full suite green, including haml-spec: 1212 runs, 0 failures (49 tests added).

## Results

Control templates (untouched code paths) stay within ±1.6%; erubi in the slim benchmark, same gem on both sides, sits at +0.0%.

| benchmark                                      |         main |       branch |           Δ |
| ---------------------------------------------- | -----------: | -----------: | ----------: |
| render `dynamic_attributes/common_attribute`   |     556k ips |     891k ips |    **+60%** |
| render `data:`/`aria:` templates (3)           | 173–195k ips | 192–221k ips | **+11–13%** |
| render `dynamic_merger/hello` (interpolation)  |     276k ips |     307k ips |    **+11%** |
| render `slim/view`                             |     679k ips |     706k ips |     **+4%** |
| compile `etc/real_sample` (filters)            |     43.2 ips |     48.3 ips |    **+12%** |
| slim benchmark, haml row (erubi control +0.0%) |     661k ips |     690k ips |   **+4.3%** |

Allocations per render only go down (e.g. `data_attribute` 40 → 33, `etc/attribute_builder` 55 → 48); no template allocates more. The `escape_html_safe` gain doesn't show above because the bench doesn't load ActiveSupport — measured separately with AS loaded: +5.6% to +33%.

## Known trade-off and behavior notes

- `etc/string_interpolation` renders −5%: without the redundant `to_s`, `escape_html` now receives non-String values raw and pays C-side conversion. A `String === v` guard was evaluated and rejected (taxes the common path); candidate for a follow-up.
- Mutually-cyclic `data:` hashes now raise `SystemStackError` like every other cycle already did on `main`; the old deep `Hash#==` caught one narrow shape by accident. Directly self-referencing hashes keep working.
- `BOOLEAN_ATTRIBUTES` stays a public mutable Array; the derived Set rebuilds on size change, so same-size in-place edits and non-String elements (which the old splat matched via `===`) are no longer picked up — neither is documented usage.
- Fixed on the way: rendering `~` over `<pre>` content with only `haml/engine` required raised `NameError` (`Haml::Helpers` was never loaded).
