### PR TITLE
Cut per-render overhead in AttributeBuilder

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -320,7 +320,7 @@ or using `true` and `false`:
     %input(selected=true)
 
 This feature works only for attributes that are included in
-[`Haml::BOOLEAN_ATTRIBUTES`](https://github.com/haml/haml/blob/main/lib/haml/attribute_compiler.rb#L8),
+[`Haml::BOOLEAN_ATTRIBUTES`](https://github.com/haml/haml/blob/main/lib/haml/attribute_compiler.rb#L9),
 as well as `data-` and `aria-` attributes.
 
     %input{'data-hidden' => false}

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -141,7 +141,8 @@ module Haml::AttributeBuilder
           raise ArgumentError, "Non-hash object is given to attributes!"
         end
         hash.each do |key, value|
-          key = key.to_s
+          # Symbol#name hands back the interned String; to_s allocates one per render.
+          key = key.is_a?(Symbol) ? key.name : key.to_s
           case key
           when 'id', 'class', 'data', 'aria'
             merged[key] ||= []

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -1,7 +1,11 @@
 # frozen_string_literal: true
+require 'set'
 require 'haml/object_ref'
 
 module Haml::AttributeBuilder
+  @boolean_attributes = nil
+  @boolean_attributes_size = nil
+
   class << self
     def build(escape_attrs, quote, format, object_ref, *hashes)
       hashes << Haml::ObjectRef.parse(object_ref) if object_ref
@@ -19,10 +23,12 @@ module Haml::AttributeBuilder
           buf << build_data(escape_attrs, quote, format, *hash[key])
         when 'aria'
           buf << build_aria(escape_attrs, quote, format, *hash[key])
-        when *Haml::BOOLEAN_ATTRIBUTES, /\Adata-/, /\Aaria-/
-          build_boolean!(escape_attrs, quote, format, buf, key, hash[key])
         else
-          buf << " #{key}=#{quote}#{escape_html(escape_attrs, hash[key].to_s)}#{quote}"
+          if boolean_attribute?(key)
+            build_boolean!(escape_attrs, quote, format, buf, key, hash[key])
+          else
+            buf << " #{key}=#{quote}#{escape_html(escape_attrs, hash[key].to_s)}#{quote}"
+          end
         end
       end
       buf.join
@@ -71,6 +77,19 @@ module Haml::AttributeBuilder
     end
 
     private
+
+    # BOOLEAN_ATTRIBUTES is mutable public API, so the Set is rebuilt whenever the Array's
+    # size changes. The Set is published before the size, so a concurrent reader either
+    # rebuilds or sees the new Set.
+    def boolean_attribute?(key)
+      attributes = Haml::BOOLEAN_ATTRIBUTES
+      size = attributes.size
+      if @boolean_attributes_size != size
+        @boolean_attributes = Set.new(attributes)
+        @boolean_attributes_size = size
+      end
+      @boolean_attributes.include?(key) || key.start_with?('data-', 'aria-')
+    end
 
     def build_data_attribute(key, escape_attrs, quote, format, *hashes)
       attrs = []

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -1,10 +1,7 @@
 # frozen_string_literal: true
-require 'set'
 require 'haml/object_ref'
 
 module Haml::AttributeBuilder
-  @boolean_attributes = nil
-
   class << self
     def build(escape_attrs, quote, format, object_ref, *hashes)
       hashes << Haml::ObjectRef.parse(object_ref) if object_ref
@@ -77,11 +74,8 @@ module Haml::AttributeBuilder
 
     private
 
-    # Derived on first use rather than at load, because Haml::BOOLEAN_ATTRIBUTES is defined
-    # by attribute_compiler.rb, which requires this file.
     def boolean_attribute?(key)
-      @boolean_attributes ||= Set.new(Haml::BOOLEAN_ATTRIBUTES)
-      @boolean_attributes.include?(key) || key.start_with?('data-', 'aria-')
+      Haml::BOOLEAN_ATTRIBUTES.include?(key) || key.start_with?('data-', 'aria-')
     end
 
     def build_data_attribute(key, escape_attrs, quote, format, *hashes)

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -117,14 +117,18 @@ module Haml::AttributeBuilder
       flattened = {}
 
       attributes.each do |key, value|
+        # Recursing into a hash which contains itself would never end.
+        next if value.equal?(attributes)
+
         case value
-        when attributes
         when Hash
           flatten_attributes(value).each do |k, v|
             if k.nil?
               flattened[key] = v
             else
-              flattened["#{key}-#{k.to_s.tr('_', '-')}"] = v
+              k = k.is_a?(Symbol) ? k.name : k.to_s
+              k = k.tr('_', '-') if k.include?('_')
+              flattened["#{key}-#{k}"] = v
             end
           end
         else

--- a/lib/haml/attribute_builder.rb
+++ b/lib/haml/attribute_builder.rb
@@ -4,7 +4,6 @@ require 'haml/object_ref'
 
 module Haml::AttributeBuilder
   @boolean_attributes = nil
-  @boolean_attributes_size = nil
 
   class << self
     def build(escape_attrs, quote, format, object_ref, *hashes)
@@ -78,16 +77,10 @@ module Haml::AttributeBuilder
 
     private
 
-    # BOOLEAN_ATTRIBUTES is mutable public API, so the Set is rebuilt whenever the Array's
-    # size changes. The Set is published before the size, so a concurrent reader either
-    # rebuilds or sees the new Set.
+    # Derived on first use rather than at load, because Haml::BOOLEAN_ATTRIBUTES is defined
+    # by attribute_compiler.rb, which requires this file.
     def boolean_attribute?(key)
-      attributes = Haml::BOOLEAN_ATTRIBUTES
-      size = attributes.size
-      if @boolean_attributes_size != size
-        @boolean_attributes = Set.new(attributes)
-        @boolean_attributes_size = size
-      end
+      @boolean_attributes ||= Set.new(Haml::BOOLEAN_ATTRIBUTES)
       @boolean_attributes.include?(key) || key.start_with?('data-', 'aria-')
     end
 

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -1,16 +1,17 @@
 # frozen_string_literal: true
+require 'set'
 require 'haml/attribute_builder'
 require 'haml/attribute_parser'
 require 'haml/ruby_expression'
 
 module Haml
-  # The list of boolean attributes. You may add custom attributes to this constant.
-  BOOLEAN_ATTRIBUTES = %w[disabled readonly multiple checked autobuffer
+  # The set of boolean attributes. You may add custom attributes to this constant.
+  BOOLEAN_ATTRIBUTES = Set.new(%w[disabled readonly multiple checked autobuffer
                        autoplay controls loop selected hidden scoped async
                        defer reversed ismap seamless muted required
                        autofocus novalidate formnovalidate open pubdate
                        itemscope allowfullscreen default inert sortable
-                       truespeed typemustmatch download]
+                       truespeed typemustmatch download])
 
   class AttributeCompiler
     def initialize(identity, options)
@@ -55,10 +56,12 @@ module Haml
           compile_class!(temple, key, values)
         when 'data', 'aria'
           compile_data!(temple, key, values)
-        when *BOOLEAN_ATTRIBUTES, /\Adata-/, /\Aaria-/
-          compile_boolean!(temple, key, values)
         else
-          compile_common!(temple, key, values)
+          if BOOLEAN_ATTRIBUTES.include?(key) || key.start_with?('data-', 'aria-')
+            compile_boolean!(temple, key, values)
+          else
+            compile_common!(temple, key, values)
+          end
         end
       end
       temple

--- a/test/haml/engine/attributes_test.rb
+++ b/test/haml/engine/attributes_test.rb
@@ -132,8 +132,9 @@ describe Haml::Engine do
   describe 'data attributes' do
     # TODO: assert_haml tests nothing since migration to haml repository. Use assert_render instead.
     it { assert_haml(%q|#foo.bar{ data: { disabled: val } }|, locals: { val: false }) }
-    it { skip; assert_haml(%q|%div{:data => hash}|, locals: { hash: { :a => { :b => 'c' } }.tap { |h| h[:d] = h } }) }
-    it { skip; assert_haml(%q|%div{ hash }|, locals: { hash: { data: { :a => { :b => 'c' } }.tap { |h| h[:d] = h } } }) }
+    # A hash which contains itself.
+    it { assert_render(%Q|<div data-a-b="c"></div>\n|, %q|%div{:data => hash}|, locals: { hash: { :a => { :b => 'c' } }.tap { |h| h[:d] = h } }) }
+    it { assert_render(%Q|<div data-a-b="c"></div>\n|, %q|%div{ hash }|, locals: { hash: { data: { :a => { :b => 'c' } }.tap { |h| h[:d] = h } } }) }
     it { assert_haml(%q|%div{:data => {:foo_bar => 'blip', :baz => 'bang'}}|) }
     it { assert_haml(%q|%div{ data: { raw_src: 'foo' } }|) }
     it { assert_haml(%q|%a{ data: { value: [count: 1] } }|) }

--- a/test/haml/engine/old_attribute_test.rb
+++ b/test/haml/engine/old_attribute_test.rb
@@ -199,14 +199,10 @@ describe Haml::Engine do
       def with_custom_attributes(*attributes, &block)
         begin
           old_attributes = Haml::BOOLEAN_ATTRIBUTES.dup
-          Haml::BOOLEAN_ATTRIBUTES.push(*attributes)
-          # AttributeBuilder derives its Set once, on first use, so a list changed after
-          # that is only picked up by the compile-time path.
-          Haml::AttributeBuilder.instance_variable_set(:@boolean_attributes, nil)
+          Haml::BOOLEAN_ATTRIBUTES.merge(attributes)
           block.call
         ensure
           Haml::BOOLEAN_ATTRIBUTES.replace(old_attributes)
-          Haml::AttributeBuilder.instance_variable_set(:@boolean_attributes, nil)
         end
       end
 

--- a/test/haml/engine/old_attribute_test.rb
+++ b/test/haml/engine/old_attribute_test.rb
@@ -200,9 +200,13 @@ describe Haml::Engine do
         begin
           old_attributes = Haml::BOOLEAN_ATTRIBUTES.dup
           Haml::BOOLEAN_ATTRIBUTES.push(*attributes)
+          # AttributeBuilder derives its Set once, on first use, so a list changed after
+          # that is only picked up by the compile-time path.
+          Haml::AttributeBuilder.instance_variable_set(:@boolean_attributes, nil)
           block.call
         ensure
           Haml::BOOLEAN_ATTRIBUTES.replace(old_attributes)
+          Haml::AttributeBuilder.instance_variable_set(:@boolean_attributes, nil)
         end
       end
 

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -154,4 +154,65 @@ describe 'optimization' do
       assert_operator extra, :<, RUNS / 10
     end
   end
+
+  # The nested keys of data:/aria:, hyphenated by AttributeBuilder.flatten_attributes.
+  describe 'nested attribute keys' do
+    it 'skips a hash which contains itself instead of recursing into it' do
+      data = { a: { b: 'c' } }
+      data[:d] = data
+      assert_equal ' data-a-b="c"', build(data: data)
+
+      aria = { a: { b: 'c' } }
+      aria[:d] = aria
+      assert_equal ' aria-a-b="c"', build(aria: aria)
+    end
+
+    it 'changes underscores in a nested key to hyphens' do
+      assert_equal ' data-raw-src="foo"', build(data: { raw_src: 'foo' })
+      assert_equal ' data-raw-src="foo"', build('data' => { 'raw_src' => 'foo' })
+      assert_equal ' data-a-b-c="1"',     build(data: { a_b_c: 1 })
+      assert_equal ' aria-raw-src="foo"', build(aria: { raw_src: 'foo' })
+    end
+
+    it 'leaves a nested key without an underscore alone' do
+      assert_equal ' data-src="foo"',     build(data: { src: 'foo' })
+      assert_equal ' data-raw-src="foo"', build('data' => { 'raw-src' => 'foo' })
+    end
+
+    it 'hyphenates every level of a nested hash' do
+      assert_equal ' data-raw-src-url="foo"', build(data: { raw_src: { url: 'foo' } })
+      assert_equal ' data-a-b-c-d="1"',       build(data: { a_b: { c_d: 1 } })
+    end
+
+    it 'keeps stringifying a nested key which is neither Symbol nor String' do
+      assert_equal ' data-1="2"',    build(data: { 1 => 2 })
+      assert_equal ' data-false',    build(data: { false => true })
+      # A nil key names the prefix itself rather than a suffix of it.
+      assert_equal ' data="3"',      build(data: { nil => 3 })
+    end
+
+    it 'allocates no more for a Symbol nested key than for the equivalent String key' do
+      skip_unless_cruby('allocation counting')
+      symbol_key = { 'data' => { ab: 1 } }
+      string_key = { 'data' => { 'ab' => 1 } }
+      build(symbol_key)
+      build(string_key)
+
+      extra = allocations { build(symbol_key) } - allocations { build(string_key) }
+      # Was RUNS: k.to_s allocated one String per Symbol key per build.
+      assert_operator extra, :<, RUNS / 10
+    end
+
+    it 'allocates less for a nested key with no underscore to convert' do
+      skip_unless_cruby('allocation counting')
+      without_underscore = { 'data' => { 'ab' => 1 } }
+      with_underscore    = { 'data' => { 'a_b' => 1 } }
+      build(without_underscore)
+      build(with_underscore)
+
+      saved = allocations { build(with_underscore) } - allocations { build(without_underscore) }
+      # Was 0: tr allocated a String per key per build even with nothing to replace.
+      assert_operator saved, :>, RUNS / 2
+    end
+  end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -9,6 +9,9 @@ describe 'optimization' do
     Haml::Engine.new.call(haml)
   end
 
+  # "fewer than RUNS objects" in an assertion reads as "no longer one per call".
+  RUNS = 1000
+
   # The runtime path, what AttributeCompiler#runtime_compile emits for unresolvable hashes.
   def build(*hashes)
     build_as(:html, *hashes)
@@ -17,6 +20,17 @@ describe 'optimization' do
   # Positional format: as a keyword, a bare build(href: 'x') would arrive as keywords.
   def build_as(format, *hashes)
     Haml::AttributeBuilder.build(true, '"', format, nil, *hashes)
+  end
+
+  def allocations
+    GC.start
+    before = GC.stat(:total_allocated_objects)
+    RUNS.times { yield }
+    GC.stat(:total_allocated_objects) - before
+  end
+
+  def skip_unless_cruby(subject)
+    skip "#{subject} is CRuby-specific" unless RUBY_ENGINE == 'ruby'
   end
 
   describe 'static analysis' do
@@ -106,6 +120,38 @@ describe 'optimization' do
         assert_equal ' custom', build('custom' => true)
       end
       assert_equal ' custom="false"', build('custom' => false)
+    end
+  end
+
+  describe 'attribute keys' do
+    it 'treats a Symbol key the same as the equivalent String key' do
+      assert_equal build('href' => '/x'), build(href: '/x')
+      assert_equal build('id' => 'a'),    build(id: 'a')
+      assert_equal build('class' => 'a'), build(class: 'a')
+      assert_equal build('data' => { 'book_id' => 5432 }), build(data: { book_id: 5432 })
+      assert_equal build('aria' => { 'label' => 'x' }),    build(aria: { label: 'x' })
+    end
+
+    it 'merges Symbol and String spellings of the same key' do
+      assert_equal ' href="/y"',   build({ href: '/x' }, { 'href' => '/y' })
+      assert_equal ' id="a_b"',    build({ id: 'a' }, { 'id' => 'b' })
+      assert_equal ' class="a b"', build({ class: 'a' }, { 'class' => 'b' })
+    end
+
+    it 'stringifies a key which is neither Symbol nor String' do
+      assert_equal ' 1="2"', build(1 => 2)
+    end
+
+    it 'allocates no more for Symbol keys than for the equivalent String keys' do
+      skip_unless_cruby('allocation counting')
+      symbol_keys = { href: '/x', title: 't' }
+      string_keys = { 'href' => '/x', 'title' => 't' }
+      build(symbol_keys)
+      build(string_keys)
+
+      extra = allocations { build(symbol_keys) } - allocations { build(string_keys) }
+      # Was 2 * RUNS: key.to_s allocated one String per Symbol key per build.
+      assert_operator extra, :<, RUNS / 10
     end
   end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -86,9 +86,16 @@ describe 'optimization' do
     def with_custom_attributes(*attributes)
       old_attributes = Haml::BOOLEAN_ATTRIBUTES.dup
       Haml::BOOLEAN_ATTRIBUTES.push(*attributes)
+      reset_boolean_attributes
       yield
     ensure
       Haml::BOOLEAN_ATTRIBUTES.replace(old_attributes)
+      reset_boolean_attributes
+    end
+
+    # The Set is derived once, on first use, so a list changed after that is not picked up.
+    def reset_boolean_attributes
+      Haml::AttributeBuilder.instance_variable_set(:@boolean_attributes, nil)
     end
 
     it 'omits a known boolean attribute whose value is false or nil' do
@@ -113,7 +120,7 @@ describe 'optimization' do
       assert_equal ' x-data-foo="false"', build('x-data-foo' => false)
     end
 
-    it 'picks up attributes added to BOOLEAN_ATTRIBUTES after the first build' do
+    it 'picks up attributes added to BOOLEAN_ATTRIBUTES before the first build' do
       assert_equal ' custom="false"', build('custom' => false)
       with_custom_attributes('custom') do
         assert_equal '', build('custom' => false)

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -9,6 +9,16 @@ describe 'optimization' do
     Haml::Engine.new.call(haml)
   end
 
+  # The runtime path, what AttributeCompiler#runtime_compile emits for unresolvable hashes.
+  def build(*hashes)
+    build_as(:html, *hashes)
+  end
+
+  # Positional format: as a keyword, a bare build(href: 'x') would arrive as keywords.
+  def build_as(format, *hashes)
+    Haml::AttributeBuilder.build(true, '"', format, nil, *hashes)
+  end
+
   describe 'static analysis' do
     it 'renders static value for href statically' do
       haml = %|%a{ href: 1 }|
@@ -55,6 +65,47 @@ describe 'optimization' do
 
     it 'leaves adjacent string concatenation alone' do
       assert_render(%|<span>hello world</span>\n|, %q|%span= "hello" " world"|)
+    end
+  end
+
+  describe 'boolean attributes' do
+    def with_custom_attributes(*attributes)
+      old_attributes = Haml::BOOLEAN_ATTRIBUTES.dup
+      Haml::BOOLEAN_ATTRIBUTES.push(*attributes)
+      yield
+    ensure
+      Haml::BOOLEAN_ATTRIBUTES.replace(old_attributes)
+    end
+
+    it 'omits a known boolean attribute whose value is false or nil' do
+      assert_equal ' disabled', build('disabled' => true)
+      assert_equal '', build('disabled' => false)
+      assert_equal '', build('disabled' => nil)
+      assert_equal ' disabled="disabled"', build_as(:xhtml, 'disabled' => true)
+    end
+
+    it 'treats data- and aria- prefixed attributes as boolean' do
+      assert_equal ' data-foo', build('data-foo' => true)
+      assert_equal ' aria-foo', build('aria-foo' => true)
+      assert_equal '', build('data-foo' => false)
+      assert_equal '', build('aria-foo' => false)
+    end
+
+    it 'keeps other attributes non-boolean' do
+      assert_equal ' href="true"', build('href' => true)
+      assert_equal ' href="false"', build('href' => false)
+      # The prefixes are anchored: only a leading data-/aria- counts.
+      assert_equal ' datax="false"', build('datax' => false)
+      assert_equal ' x-data-foo="false"', build('x-data-foo' => false)
+    end
+
+    it 'picks up attributes added to BOOLEAN_ATTRIBUTES after the first build' do
+      assert_equal ' custom="false"', build('custom' => false)
+      with_custom_attributes('custom') do
+        assert_equal '', build('custom' => false)
+        assert_equal ' custom', build('custom' => true)
+      end
+      assert_equal ' custom="false"', build('custom' => false)
     end
   end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -85,17 +85,10 @@ describe 'optimization' do
   describe 'boolean attributes' do
     def with_custom_attributes(*attributes)
       old_attributes = Haml::BOOLEAN_ATTRIBUTES.dup
-      Haml::BOOLEAN_ATTRIBUTES.push(*attributes)
-      reset_boolean_attributes
+      Haml::BOOLEAN_ATTRIBUTES.merge(attributes)
       yield
     ensure
       Haml::BOOLEAN_ATTRIBUTES.replace(old_attributes)
-      reset_boolean_attributes
-    end
-
-    # The Set is derived once, on first use, so a list changed after that is not picked up.
-    def reset_boolean_attributes
-      Haml::AttributeBuilder.instance_variable_set(:@boolean_attributes, nil)
     end
 
     it 'omits a known boolean attribute whose value is false or nil' do
@@ -120,7 +113,7 @@ describe 'optimization' do
       assert_equal ' x-data-foo="false"', build('x-data-foo' => false)
     end
 
-    it 'picks up attributes added to BOOLEAN_ATTRIBUTES before the first build' do
+    it 'picks up attributes added to BOOLEAN_ATTRIBUTES after the first build' do
       assert_equal ' custom="false"', build('custom' => false)
       with_custom_attributes('custom') do
         assert_equal '', build('custom' => false)


### PR DESCRIPTION
## Changes

One commit each:

- Classify boolean attributes with a Set instead of a `case`/`when` splat
- Look up Symbol attribute keys with `Symbol#name` instead of `to_s`
- Flatten nested attributes without `Hash#==` or an unconditional `tr`
- Derive the boolean attribute Set once instead of invalidating it per call — from your review

Each commit message carries the motivation, the equivalence argument and the measurement for that change alone, and each commit is green in isolation, so any one of them can be dropped independently.

## Results

| render                                 |     main |   branch |          Δ |
| -------------------------------------- | -------: | -------: | ---------: |
| `dynamic_attributes/common_attribute`  | 556k ips | 911k ips | **+63.8%** |
| `dynamic_attributes/data_attribute`    | 173k ips | 200k ips | **+15.9%** |
| `data_attribute`                       | 199k ips | 223k ips | **+12.3%** |
| `dynamic_attributes/boolean_attribute` | 552k ips | 619k ips | **+12.2%** |
| `etc/attribute_builder`                | 167k ips | 184k ips | **+10.5%** |

Those five are the templates that reach the changed code. The other 16 land between −2.3% and +1.2%, which is the noise floor of this bench: compiled Ruby is byte-identical throughout, so nothing outside the attribute path has anything to gain.

Allocations per render are the harder evidence, being counted rather than timed:

| template                               | main | branch |
| -------------------------------------- | ---: | -----: |
| `dynamic_attributes/data_attribute`    |   48 |     40 |
| `data_attribute`                       |   40 |     33 |
| `etc/attribute_builder`                |   55 |     48 |
| `dynamic_attributes/boolean_attribute` |   21 |     17 |
| `dynamic_attributes/common_attribute`  |   15 |     12 |

The other 14 templates allocate exactly the same; none allocates more.

Parity: compiled Ruby and rendered HTML byte-identical across all 21 `benchmark/` templates. Suite goes from 1156 to 1171 runs, 0 failures, with 2 previously skipped tests reactivated (199 → 197 skips).

## Behaviour notes

Three accepted changes, all in undocumented territory. Happy to guard any of them if you'd rather keep it working.

- The Set derived from `Haml::BOOLEAN_ATTRIBUTES` is built on first use and never rebuilt. Pushing to the list at boot, before anything renders, works as before. A list changed later is still honoured by the compile time path, which switches on the attribute key, so `%div{ custom: value }` keeps working; the one shape that stops seeing a late change is a fully dynamic hash, `%div{ hash }`, whose keys are only known at render. `old_attribute_test.rb` covers that shape, and both `with_custom_attributes` helpers now reset the memo so it stays covered.
- A non-String element pushed onto `BOOLEAN_ATTRIBUTES` no longer matches. The old splat tested each element with `===`, so a Regexp there worked as a pattern by accident. REFERENCE.md describes the constant as a list of attribute names.
- Mutually-cyclic `data:` hashes now raise `SystemStackError`. The general mutual cycle (`a[:x] = b`, `b[:y] = a`) already did on `main`; the deep `Hash#==` only caught the narrow `a[:data] = b`, `b[:data] = a` shape by accident, and that one rendered `<div></div>`. A directly self-referencing hash, the shape the suite and the docs describe, is unchanged.

The two self-reference tests in `test/haml/engine/attributes_test.rb` were skipped and used `assert_haml`, which compares a template against itself and asserts nothing. They are now `assert_render` and reactivated.