### PR TITLE
Pick the html_safe escaper once at load instead of per value

### DIFF
--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -444,7 +444,8 @@ module Haml
         end
       else
         if Util.contains_interpolation?(value)
-          value = Util.unescape_interpolation(value, escape_html)
+          value = Util.unescape_interpolation(value)
+          escape_interpolation = true if escape_html
           parse = true
           escape_html = false
         end

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -26,10 +26,9 @@ module Haml
       end
     end
 
-    # TODO: Remove unescape_interpolation's workaround and get rid of `respond_to?`.
     def self.escape_html_safe(html)
       html = html.to_s
-      (html.respond_to?(:html_safe?) && html.html_safe?) ? html : escape_html(html)
+      html.html_safe? ? html : escape_html(html)
     end
 
     # Silence all output to STDERR within a block.
@@ -202,7 +201,7 @@ MSG
       /#[\{$@]/ === str
     end
 
-    def unescape_interpolation(str, escape_html = nil)
+    def unescape_interpolation(str)
       res = ''.dup
       rest = Haml::Util.handle_interpolation str.dump do |scan|
         escapes = (scan[2].size - 1) / 2
@@ -218,7 +217,6 @@ MSG
           end
           content = eval("\"#{interpolated}\"")
           content = "#{char}#{content}" if char == '@' || char == '$'
-          content = "Haml::Util.escape_html_safe((#{content}).to_s)" if escape_html
 
           res << "\#{#{content}}"
         end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -215,4 +215,62 @@ describe 'optimization' do
       assert_operator saved, :>, RUNS / 2
     end
   end
+
+  # test_helper loads rails before haml, so use_html_safe defaults to true here.
+  describe 'html safe escaping' do
+    class ::TosSafeBufferObject
+      def to_s
+        '<hr>'.html_safe
+      end
+    end
+
+    it 'escapes a value which is not html_safe' do
+      assert_equal '&lt;b&gt;', Haml::Util.escape_html_safe('<b>')
+      assert_equal '', Haml::Util.escape_html_safe(nil)
+      assert_equal '1/1', Haml::Util.escape_html_safe(1.to_r)
+    end
+
+    it 'passes an html_safe value through untouched' do
+      safe = '<b>'.html_safe
+      assert_equal '<b>', Haml::Util.escape_html_safe(safe)
+      assert_same safe, Haml::Util.escape_html_safe(safe)
+    end
+
+    it 'asks html_safe? of to_s, not of the object' do
+      # Kaminari-style object: not html_safe itself, but its to_s is.
+      assert_equal '<hr>', Haml::Util.escape_html_safe(::TosSafeBufferObject.new)
+    end
+
+    it 'does not ask respond_to? per value' do
+      skip 'iseq introspection is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      disasm = RubyVM::InstructionSequence.of(Haml::Util.method(:escape_html_safe)).disasm
+      # The guard used to run per value, though the escaper is only compiled in
+      # when use_html_safe is on, and that requires html_safe? to exist.
+      refute_includes disasm, 'respond_to?'
+      assert_includes disasm, 'html_safe?'
+    end
+
+    it 'escapes interpolated tag text with the escaper use_html_safe asks for' do
+      haml = %q|%p hello #{name}|
+      assert_includes Haml::Engine.new(use_html_safe: true).call(haml), 'escape_html_safe'
+      refute_includes Haml::Engine.new(use_html_safe: false).call(haml), 'escape_html_safe'
+    end
+
+    it 'never compiles escape_html_safe in when ActiveSupport is not loaded' do
+      skip 'subprocess test is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      script = <<~'RUBY'
+        require 'haml'
+        abort 'ActiveSupport leaked into the child' if ''.respond_to?(:html_safe?)
+        code = Haml::Engine.new.call('%p hello #{name}')
+        abort "escape_html_safe was compiled in: #{code}" if code.include?('escape_html_safe')
+        name = '<b>'
+        print eval(code)
+      RUBY
+      lib = File.expand_path('../../lib', __dir__)
+      out = IO.popen([RbConfig.ruby, '-I', lib, '-e', script], &:read)
+
+      assert_predicate $?, :success?
+      assert_equal "<p>hello &lt;b&gt;</p>\n", out
+    end
+  end
 end


### PR DESCRIPTION
## Change

`Haml::Util.escape_html_safe` ran `respond_to?(:html_safe?)` on every escaped value, but the
answer never depended on the value. The first line is `html = html.to_s`, so the receiver is
always a String by then, and ActiveSupport defines `html_safe?` on `Object` — it is a
process-global property, checked per call. The escaper is now chosen once, at load, on the same
predicate Temple uses to default `use_html_safe`.

This is not only the Rails path: `Haml::Escape` builds the escaper name from
`options[:use_html_safe]`, so every `=` goes through `escape_html_safe` whenever ActiveSupport
is loaded, Tilt included.

The guarded variant stays for the no-ActiveSupport case, because `unescape_interpolation` bakes
the call into a String literal (`util.rb:221`), outside the temple tree, so it ignores
`use_html_safe` entirely. Both branches are correct on their own, and the unguarded one is only
chosen when ActiveSupport is already loaded, which cannot be undone.

## Benchmark

The call itself, both variants defined side by side in one process (`benchmark-ips`, 2s warmup,
5s measured):

| value        |     before |      after |          |
| ------------ | ---------: | ---------: | -------: |
| plain String |  7.50M ips |  8.95M ips | **1.19x** |
| SafeBuffer   | 15.07M ips | 20.30M ips | **1.35x** |
| Integer      | 10.35M ips | 12.94M ips | **1.25x** |

Render, median of 5 alternating rounds over every `benchmark/` template, ActiveSupport loaded,
with the count of `escape_html_safe` calls in each template's compiled Ruby:

| template                   | calls |      main |    branch |          Δ |
| -------------------------- | ----: | --------: | --------: | ---------: |
| `dynamic_merger/hello`     |    50 |  246k ips |  311k ips | **+26.1%** |
| `plain`                    |     2 | 2.69M ips | 3.03M ips | **+12.7%** |
| `script`                   |     1 | 3.65M ips | 4.03M ips | **+10.6%** |
| `etc/string_interpolation` |     1 | 2.65M ips | 2.88M ips |  **+8.8%** |
| `slim/view`                |     3 |  600k ips |  648k ips |  **+8.0%** |
| `etc/real_sample`          |    59 |   37k ips |   40k ips |  **+7.6%** |

Those six are the templates that reach the code. The other 15 compile to zero calls and are the
control: they land between +0.0% and +10.3%, and that upper end is noise — 13 of the 15 sit at
or below +4.2%, and the two above it are also the two noisiest, at 9.8% and 15.5% per-side
dispersion against 2.4% for `hello`. `etc/real_sample` gains least per call because escaping is
a small share of what it renders.

Rendered HTML byte-identical across all 21 templates. Suite green: 1161 runs, 0 failures.