### PR TITLE
Keep Prism-derived fragments in the source encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Haml Changelog
 
+## Unreleased
+
+* Keep Prism-derived fragments in the source encoding, fixing `Encoding::CompatibilityError` on an ASCII-8BIT template source with non-ASCII characters (regression in 7.3.0) https://github.com/haml/haml/issues/1218
+
 ## 7.3.0
 
 * Replace Ripper with Prism https://github.com/haml/haml/pull/1214

--- a/lib/haml/attribute_parser.rb
+++ b/lib/haml/attribute_parser.rb
@@ -32,7 +32,7 @@ module Haml
         key = static_key(element.key)
         return if key.nil?
 
-        hash[key] = value_source(element.value)
+        hash[in_source_encoding(key, exp)] = in_source_encoding(value_source(element.value), exp)
       end
       hash
     end
@@ -73,6 +73,16 @@ module Haml
       return '' if value.is_a?(Prism::ImplicitNode)
 
       value.slice
+    end
+
+    # Prism tags its slices with the encoding it parsed the source under (UTF-8 for a
+    # BINARY source), while the rest of the compiled template stays in the source
+    # encoding. Mixing the two raises Encoding::CompatibilityError once both sides hold
+    # non-ASCII bytes, so bring everything back to the source encoding.
+    def in_source_encoding(string, source)
+      return string if string.encoding == source.encoding
+
+      string.dup.force_encoding(source.encoding)
     end
   end
 end

--- a/lib/haml/string_splitter.rb
+++ b/lib/haml/string_splitter.rb
@@ -10,7 +10,7 @@ module Haml
       def compile(code, node: RubyExpression.string_literal_node(code))
         case node
         when Prism::StringNode
-          node.unescaped.empty? ? [] : [[:static, node.unescaped]]
+          node.unescaped.empty? ? [] : [[:static, in_source_encoding(node.unescaped, code)]]
         when Prism::InterpolatedStringNode
           compile_parts(node.parts, code)
         else
@@ -33,12 +33,12 @@ module Haml
             case part
             when Prism::StringNode
               content = part.unescaped
-              exps << [:static, content] unless content.empty?
+              exps << [:static, in_source_encoding(content, code)] unless content.empty?
             when Prism::EmbeddedStatementsNode
               embedded = embedded_source(part, code)
               exps << [:dynamic, embedded] unless embedded.empty?
             when Prism::EmbeddedVariableNode
-              exps << [:dynamic, part.variable.slice]
+              exps << [:dynamic, in_source_encoding(part.variable.slice, code)]
             else
               # Prism allows more part types than a string literal can currently hold. Dropping
               # one would silently lose content, so fail instead of rendering something wrong.
@@ -53,6 +53,17 @@ module Haml
       def embedded_source(part, code)
         from = part.opening_loc.end_offset
         code.byteslice(from, part.closing_loc.start_offset - from)
+      end
+
+      # Prism tags what it returns with the encoding it parsed `code` under (UTF-8 for
+      # a BINARY source), while the fragments Haml slices out of the source itself keep
+      # the source encoding. The compiled template mixes both kinds, so anything taken
+      # from Prism has to come back to the source encoding, or joining the fragments
+      # raises Encoding::CompatibilityError once both sides hold non-ASCII bytes.
+      def in_source_encoding(string, code)
+        return string if string.encoding == code.encoding
+
+        string.dup.force_encoding(code.encoding)
       end
     end
 

--- a/test/haml/attribute_parser_test.rb
+++ b/test/haml/attribute_parser_test.rb
@@ -115,6 +115,20 @@ describe Haml::AttributeParser do
       it { assert_parse({ 'a b' => '1' }, ':"a b" => 1') }
     end
 
+    # Prism re-tags its slices with the encoding it parsed under (UTF-8 for a BINARY
+    # source), but keys and values must stay in the source encoding: the compiled
+    # template joins them with fragments sliced out of the source itself, and mixed
+    # encodings raise Encoding::CompatibilityError. See haml/haml#1218.
+    describe 'binary source' do
+      it 'keeps keys and values in the source encoding' do
+        hash = Haml::AttributeParser.parse(%q|title: '🍣', '🍺' => beer|.b)
+        assert_equal({ 'title'.b => %q|'🍣'|.b, '🍺'.b => 'beer'.b }, hash)
+        (hash.keys + hash.values).each do |string|
+          assert_equal Encoding::BINARY, string.encoding
+        end
+      end
+    end
+
     # A multi-line hash is deliberately left to the runtime: compiling it statically drops a
     # [:newline] and shifts every __LINE__ after it. See test/haml/line_number_test.rb.
     describe 'multiline' do

--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -1933,6 +1933,17 @@ HTML
 HAML
   end
 
+  def test_binary_source_with_non_ascii_characters # encoding
+    # Rails' ActionView::DependencyTracker compiles template.source as File.binread
+    # returned it, so a BINARY source must compile even when non-ASCII characters
+    # appear both in plain text and in embedded Ruby. See haml/haml#1218.
+    assert_equal(<<HTML, render(<<HAML.b))
+<p title="🍣">🍺</p>
+HTML
+%p{title: '🍣'} 🍺
+HAML
+  end
+
   def test_encoding_error # encoding
     render("foo\nbar\nb\xFEaz".dup.force_encoding("utf-8"))
     assert(false, "Expected exception")

--- a/test/haml/string_splitter_test.rb
+++ b/test/haml/string_splitter_test.rb
@@ -50,6 +50,24 @@ describe Haml::StringSplitter do
       it { assert_compile([[:static, 'a'], [:dynamic, 'next']], %q|"a#{next}"|) }
     end
 
+    # Prism re-tags what it returns with the encoding it parsed under (UTF-8 for a
+    # BINARY source), but the fragments must stay in the source encoding: the compiled
+    # template joins them with fragments sliced out of the source itself, and mixed
+    # encodings raise Encoding::CompatibilityError. See haml/haml#1218.
+    describe 'binary source' do
+      def assert_binary_compile(expected, code)
+        actual = Haml::StringSplitter.compile(code.b)
+        assert_equal expected.map { |type, content| [type, content.b] }, actual
+        actual.each do |_type, content|
+          assert_equal Encoding::BINARY, content.encoding
+        end
+      end
+
+      it { assert_binary_compile([[:static, '🍣']], %q|"🍣"|) }
+      it { assert_binary_compile([[:static, '🍣'], [:dynamic, 'sushi'], [:static, '🍺']], %q|"🍣#{sushi}🍺"|) }
+      it { assert_binary_compile([[:dynamic, '@sushi']], %q|"#@sushi"|) }
+    end
+
     describe 'invalid argument' do
       def assert_internal_error(code)
         assert_raises Haml::InternalError do


### PR DESCRIPTION
Fixes #1218.

## Problem

Since the Ripper -> Prism migration (#1214), compiling a template whose source string is ASCII-8BIT raises `Encoding::CompatibilityError` when non-ASCII characters appear both in plain text and in embedded Ruby code:

```ruby
source = "%p{title: '🍣'} 🍺\n".dup.force_encoding(Encoding::BINARY)
Haml::Template.new { source }.render
# 7.2.2 => <p title="🍣">🍺</p>
# 7.3.0 => Encoding::CompatibilityError: incompatible character encodings: UTF-8 and BINARY (ASCII-8BIT)
```

This hits Rails apps in production: `ActionView::DependencyTracker` compiles `template.source` as `File.binread` returned it (ASCII-8BIT), so any app with non-ASCII templates plus fragment caching gets 500s once `perform_caching` is on, while CI stays green because the test environment defaults to `perform_caching = false`. Details in #1218.

## Cause

Prism tags what it returns with the encoding it parsed the code under — UTF-8 for a BINARY source. That applies both to node/location slices (`Prism::Source.for` re-tags a BINARY source holding valid multibyte UTF-8 as UTF-8) and to `StringNode#unescaped`. Meanwhile the fragments Haml slices out of the source itself (plain text, `byteslice`d interpolation bodies) keep the source encoding. The compiled template mixes the two kinds of fragments, and Temple's `StaticMerger` / `Generator#on_multi` join adjacent static fragments, which raises once both sides hold non-ASCII bytes. Ripper reported everything in the source encoding, which is why 7.2.2 was fine.

## Fix

Force everything taken from Prism back to the source encoding at the two places where Prism-derived text enters the compiled output, `StringSplitter` and `AttributeParser`, restoring the Ripper-era invariant that all fragments share the source encoding. This is a byte-preserving re-tag (`dup.force_encoding`), a no-op whenever the source is already UTF-8.

Tests cover the three Prism-derived paths (`unescaped`, `EmbeddedVariableNode`, attribute keys/values) plus an end-to-end render of the reproduction above; the engine test fails with `Encoding::CompatibilityError` before this change. The full suite passes locally (1161 runs, 0 failures, 0 errors).

Thanks for maintaining haml!

🤖 Generated with [Claude Code](https://claude.com/claude-code)
