### PR TITLE
Build the preserve regex once per tag list instead of per call

### DIFF
--- a/lib/haml/compiler/script_compiler.rb
+++ b/lib/haml/compiler/script_compiler.rb
@@ -8,7 +8,8 @@ module Haml
   class Compiler
     class ScriptCompiler
       def self.find_and_preserve(input, tags)
-        tags = tags.map { |tag| Regexp.escape(tag) }.join('|')
+        # An empty entry would add an alternative matching `<>`.
+        tags = tags.reject(&:empty?).map { |tag| Regexp.escape(tag) }.join('|')
         re = /<(#{tags})([^>]*)>(.*?)(<\/\1>)/im
         input.to_s.gsub(re) do |s|
           s =~ re # Can't rely on $1, etc. existing since Rails' SafeBuffer#gsub is incompatible

--- a/lib/haml/compiler/script_compiler.rb
+++ b/lib/haml/compiler/script_compiler.rb
@@ -1,14 +1,15 @@
 # frozen_string_literal: true
 require 'temple/static_analyzer'
 require 'haml/helpers'
+require 'haml/preserver'
 require 'haml/ruby_expression'
 require 'haml/string_splitter'
 
 module Haml
   class Compiler
     class ScriptCompiler
-      def self.find_and_preserve(input, tags = ::Haml::Helpers::DEFAULT_PRESERVE_TAGS)
-        ::Haml::Helpers.find_and_preserve(input, tags)
+      def self.find_and_preserve(input, tags = ::Haml::Preserver::DEFAULT_TAGS)
+        ::Haml::Preserver.find_and_preserve(input, tags) { |content| ::Haml::Helpers.preserve(content) }
       end
 
       def initialize(identity, options)

--- a/lib/haml/compiler/script_compiler.rb
+++ b/lib/haml/compiler/script_compiler.rb
@@ -7,14 +7,8 @@ require 'haml/string_splitter'
 module Haml
   class Compiler
     class ScriptCompiler
-      def self.find_and_preserve(input, tags)
-        # An empty entry would add an alternative matching `<>`.
-        tags = tags.reject(&:empty?).map { |tag| Regexp.escape(tag) }.join('|')
-        re = /<(#{tags})([^>]*)>(.*?)(<\/\1>)/im
-        input.to_s.gsub(re) do |s|
-          s =~ re # Can't rely on $1, etc. existing since Rails' SafeBuffer#gsub is incompatible
-          "<#{$1}#{$2}>#{Haml::Helpers.preserve($3)}</#{$1}>"
-        end
+      def self.find_and_preserve(input, tags = ::Haml::Helpers::DEFAULT_PRESERVE_TAGS)
+        ::Haml::Helpers.find_and_preserve(input, tags)
       end
 
       def initialize(identity, options)

--- a/lib/haml/compiler/script_compiler.rb
+++ b/lib/haml/compiler/script_compiler.rb
@@ -65,7 +65,7 @@ module Haml
         if node.value[:escape_html]
           str = Haml::Util.escape_html(str)
         elsif node.value[:preserve]
-          str = ScriptCompiler.find_and_preserve(str, %w(textarea pre code))
+          str = ScriptCompiler.find_and_preserve(str)
         end
         [:multi, [:static, str], [:newline]]
       end
@@ -100,7 +100,7 @@ module Haml
       end
 
       def find_and_preserve(code)
-        %Q[::Haml::Compiler::ScriptCompiler.find_and_preserve(#{code}, %w(textarea pre code))]
+        %Q[::Haml::Compiler::ScriptCompiler.find_and_preserve(#{code})]
       end
 
       def escape_html(temple)

--- a/lib/haml/compiler/script_compiler.rb
+++ b/lib/haml/compiler/script_compiler.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'temple/static_analyzer'
+require 'haml/helpers'
 require 'haml/ruby_expression'
 require 'haml/string_splitter'
 

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -1,6 +1,24 @@
 # frozen_string_literal: true
 module Haml
   module Helpers
+    DEFAULT_PRESERVE_TAGS = %w[textarea pre code].freeze
+
+    # The two callers differ only in how the preserved content is marked, which is what
+    # the block is for; everything around it, the SafeBuffer workaround included, is here.
+    #
+    # @api private
+    def self.find_and_preserve(input, tags)
+      # An empty entry would add an alternative matching `<>`.
+      pattern = tags.reject(&:empty?).map { |tag| Regexp.escape(tag) }.join('|')
+      re = /<(#{pattern})([^>]*)>(.*?)(<\/\1>)/im
+      input.to_s.gsub(re) do |s|
+        s =~ re # Can't rely on $1, etc. existing since Rails' SafeBuffer#gsub is incompatible
+        name, attributes, content = $1, $2, $3
+        content = block_given? ? yield(content) : preserve(content)
+        "<#{name}#{attributes}>#{content}</#{name}>"
+      end
+    end
+
     def self.preserve(input)
       s = input.to_s.chomp("\n")
       s.gsub!("\n", '&#x000A;')

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -1,63 +1,6 @@
 # frozen_string_literal: true
 module Haml
   module Helpers
-    # Referenced by name from the emitted Ruby, so every render hands preserve_regex the
-    # same object.
-    DEFAULT_PRESERVE_TAGS = %w[textarea pre code].freeze
-
-    def self.build_preserve_regex(tags)
-      # An empty entry would add an alternative matching `<>`.
-      pattern = tags.reject(&:empty?).map { |tag| Regexp.escape(tag) }.join('|')
-      /<(#{pattern})([^>]*)>(.*?)(<\/\1>)/im
-    end
-    private_class_method :build_preserve_regex
-
-    DEFAULT_PRESERVE_REGEX = build_preserve_regex(DEFAULT_PRESERVE_TAGS)
-    private_constant :DEFAULT_PRESERVE_REGEX
-
-    # Past this many lists the copy below turns quadratic, so the cache starts over rather
-    # than leaving every later list uncached for the life of the process.
-    MAX_PRESERVE_REGEXES = 64
-    private_constant :MAX_PRESERVE_REGEXES
-
-    INITIAL_PRESERVE_REGEXES = { DEFAULT_PRESERVE_TAGS => DEFAULT_PRESERVE_REGEX }.freeze
-    private_constant :INITIAL_PRESERVE_REGEXES
-
-    @preserve_regexes = INITIAL_PRESERVE_REGEXES
-
-    # Building this regex costs far more than matching with it. The cache is replaced,
-    # never mutated, so a racing writer at worst rebuilds a regex.
-    #
-    # @api private
-    def self.preserve_regex(tags)
-      return DEFAULT_PRESERVE_REGEX if tags.equal?(DEFAULT_PRESERVE_TAGS)
-
-      cache = @preserve_regexes
-      cache[tags] || begin
-        regex = build_preserve_regex(tags)
-        # Keyed by a copy: a rebuilt %w[...] literal still hits, and a caller mutating its
-        # own list, or a String in it, cannot strand the entry.
-        key = tags.map { |tag| tag.dup.freeze }.freeze
-        cache = INITIAL_PRESERVE_REGEXES if cache.size >= MAX_PRESERVE_REGEXES
-        @preserve_regexes = cache.merge(key => regex).freeze
-        regex
-      end
-    end
-
-    # The two callers differ only in how the preserved content is marked, which is what
-    # the block is for; everything around it, the SafeBuffer workaround included, is here.
-    #
-    # @api private
-    def self.find_and_preserve(input, tags)
-      re = preserve_regex(tags)
-      input.to_s.gsub(re) do |s|
-        s =~ re # Can't rely on $1, etc. existing since Rails' SafeBuffer#gsub is incompatible
-        name, attributes, content = $1, $2, $3
-        content = block_given? ? yield(content) : preserve(content)
-        "<#{name}#{attributes}>#{content}</#{name}>"
-      end
-    end
-
     def self.preserve(input)
       s = input.to_s.chomp("\n")
       s.gsub!("\n", '&#x000A;')

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -1,16 +1,55 @@
 # frozen_string_literal: true
 module Haml
   module Helpers
+    # Referenced by name from the emitted Ruby, so every render hands preserve_regex the
+    # same object.
     DEFAULT_PRESERVE_TAGS = %w[textarea pre code].freeze
+
+    def self.build_preserve_regex(tags)
+      # An empty entry would add an alternative matching `<>`.
+      pattern = tags.reject(&:empty?).map { |tag| Regexp.escape(tag) }.join('|')
+      /<(#{pattern})([^>]*)>(.*?)(<\/\1>)/im
+    end
+    private_class_method :build_preserve_regex
+
+    DEFAULT_PRESERVE_REGEX = build_preserve_regex(DEFAULT_PRESERVE_TAGS)
+    private_constant :DEFAULT_PRESERVE_REGEX
+
+    # Past this many lists the copy below turns quadratic, so the cache starts over rather
+    # than leaving every later list uncached for the life of the process.
+    MAX_PRESERVE_REGEXES = 64
+    private_constant :MAX_PRESERVE_REGEXES
+
+    INITIAL_PRESERVE_REGEXES = { DEFAULT_PRESERVE_TAGS => DEFAULT_PRESERVE_REGEX }.freeze
+    private_constant :INITIAL_PRESERVE_REGEXES
+
+    @preserve_regexes = INITIAL_PRESERVE_REGEXES
+
+    # Building this regex costs far more than matching with it. The cache is replaced,
+    # never mutated, so a racing writer at worst rebuilds a regex.
+    #
+    # @api private
+    def self.preserve_regex(tags)
+      return DEFAULT_PRESERVE_REGEX if tags.equal?(DEFAULT_PRESERVE_TAGS)
+
+      cache = @preserve_regexes
+      cache[tags] || begin
+        regex = build_preserve_regex(tags)
+        # Keyed by a copy: a rebuilt %w[...] literal still hits, and a caller mutating its
+        # own list, or a String in it, cannot strand the entry.
+        key = tags.map { |tag| tag.dup.freeze }.freeze
+        cache = INITIAL_PRESERVE_REGEXES if cache.size >= MAX_PRESERVE_REGEXES
+        @preserve_regexes = cache.merge(key => regex).freeze
+        regex
+      end
+    end
 
     # The two callers differ only in how the preserved content is marked, which is what
     # the block is for; everything around it, the SafeBuffer workaround included, is here.
     #
     # @api private
     def self.find_and_preserve(input, tags)
-      # An empty entry would add an alternative matching `<>`.
-      pattern = tags.reject(&:empty?).map { |tag| Regexp.escape(tag) }.join('|')
-      re = /<(#{pattern})([^>]*)>(.*?)(<\/\1>)/im
+      re = preserve_regex(tags)
       input.to_s.gsub(re) do |s|
         s =~ re # Can't rely on $1, etc. existing since Rails' SafeBuffer#gsub is incompatible
         name, attributes, content = $1, $2, $3

--- a/lib/haml/helpers.rb
+++ b/lib/haml/helpers.rb
@@ -3,7 +3,7 @@ module Haml
   module Helpers
     def self.preserve(input)
       s = input.to_s.chomp("\n")
-      s.gsub!(/\n/, '&#x000A;')
+      s.gsub!("\n", '&#x000A;')
       s.delete!("\r")
       s
     end

--- a/lib/haml/preserver.rb
+++ b/lib/haml/preserver.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+module Haml
+  # find_and_preserve, shared by compiled templates and RailsHelpers.
+  #
+  # @api private
+  module Preserver
+    DEFAULT_TAGS = %w[textarea pre code].freeze
+
+    def self.build_regex(tags)
+      # An empty entry would add an alternative matching `<>`.
+      pattern = tags.reject(&:empty?).map { |tag| Regexp.escape(tag) }.join('|')
+      /<(#{pattern})([^>]*)>(.*?)(<\/\1>)/im
+    end
+    private_class_method :build_regex
+
+    DEFAULT_REGEX = build_regex(DEFAULT_TAGS)
+    private_constant :DEFAULT_REGEX
+
+    # Past this many lists the merge below turns quadratic, so the cache starts over.
+    MAX_REGEXES = 64
+    private_constant :MAX_REGEXES
+
+    INITIAL_REGEXES = { DEFAULT_TAGS => DEFAULT_REGEX }.freeze
+    private_constant :INITIAL_REGEXES
+
+    @regexes = INITIAL_REGEXES
+
+    # The cache is replaced, never mutated, so a racing writer at worst rebuilds a regex.
+    def self.regex(tags)
+      return DEFAULT_REGEX if tags.equal?(DEFAULT_TAGS)
+
+      cache = @regexes
+      cache[tags] || begin
+        regex = build_regex(tags)
+        # Copied so a caller mutating its own list, or a String in it, cannot strand the entry.
+        key = tags.map { |tag| tag.dup.freeze }.freeze
+        cache = INITIAL_REGEXES if cache.size >= MAX_REGEXES
+        @regexes = cache.merge(key => regex).freeze
+        regex
+      end
+    end
+
+    def self.find_and_preserve(input, tags)
+      re = regex(tags)
+      input.to_s.gsub(re) do |s|
+        s =~ re # Can't rely on $1, etc. existing since Rails' SafeBuffer#gsub is incompatible
+        name, attributes, content = $1, $2, $3
+        "<#{name}#{attributes}>#{yield(content)}</#{name}>"
+      end
+    end
+  end
+end

--- a/lib/haml/rails_helpers.rb
+++ b/lib/haml/rails_helpers.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 require 'haml/helpers'
+require 'haml/preserver'
 
 # There are only helpers that depend on ActionView internals.
 module Haml
@@ -7,10 +8,12 @@ module Haml
     include Helpers
     extend self
 
+    DEFAULT_PRESERVE_TAGS = Preserver::DEFAULT_TAGS
+
     def find_and_preserve(input = nil, tags = DEFAULT_PRESERVE_TAGS, &block)
       return find_and_preserve(capture_haml(&block), input || tags) if block
 
-      Helpers.find_and_preserve(input, tags) { |content| preserve(content) }
+      Preserver.find_and_preserve(input, tags) { |content| preserve(content) }
     end
 
     def preserve(input = nil, &block)

--- a/lib/haml/rails_helpers.rb
+++ b/lib/haml/rails_helpers.rb
@@ -12,7 +12,8 @@ module Haml
     def find_and_preserve(input = nil, tags = DEFAULT_PRESERVE_TAGS, &block)
       return find_and_preserve(capture_haml(&block), input || tags) if block
 
-      tags = tags.each_with_object('') do |t, s|
+      # An empty entry would add an alternative matching `<>`.
+      tags = tags.reject(&:empty?).each_with_object('') do |t, s|
         s << '|' unless s.empty?
         s << Regexp.escape(t)
       end

--- a/lib/haml/rails_helpers.rb
+++ b/lib/haml/rails_helpers.rb
@@ -1,4 +1,4 @@
-# frozen_string_literal: false
+# frozen_string_literal: true
 require 'haml/helpers'
 
 # There are only helpers that depend on ActionView internals.
@@ -7,22 +7,10 @@ module Haml
     include Helpers
     extend self
 
-    DEFAULT_PRESERVE_TAGS = %w[textarea pre code].freeze
-
     def find_and_preserve(input = nil, tags = DEFAULT_PRESERVE_TAGS, &block)
       return find_and_preserve(capture_haml(&block), input || tags) if block
 
-      # An empty entry would add an alternative matching `<>`.
-      tags = tags.reject(&:empty?).each_with_object('') do |t, s|
-        s << '|' unless s.empty?
-        s << Regexp.escape(t)
-      end
-
-      re = /<(#{tags})([^>]*)>(.*?)(<\/\1>)/im
-      input.to_s.gsub(re) do |s|
-        s =~ re # Can't rely on $1, etc. existing since Rails' SafeBuffer#gsub is incompatible
-        "<#{$1}#{$2}>#{preserve($3)}</#{$1}>"
-      end
+      Helpers.find_and_preserve(input, tags) { |content| preserve(content) }
     end
 
     def preserve(input = nil, &block)

--- a/test/haml/helpers_test.rb
+++ b/test/haml/helpers_test.rb
@@ -6,5 +6,30 @@ describe Haml::Helpers do
       result = Haml::Helpers.preserve("hello\nworld")
       assert_equal 'hello&#x000A;world', result
     end
+
+    it 'chomps a single trailing newline' do
+      assert_equal 'a&#x000A;', Haml::Helpers.preserve("a\n\n")
+      assert_equal 'a&#x000A;b', Haml::Helpers.preserve("a\nb\n")
+      assert_equal 'no newline', Haml::Helpers.preserve('no newline')
+    end
+
+    it 'deletes carriage returns' do
+      assert_equal 'a&#x000A;b', Haml::Helpers.preserve("a\r\nb")
+      assert_equal 'ab', Haml::Helpers.preserve("a\rb")
+    end
+
+    it 'converts whatever it is given to a String' do
+      assert_equal '13', Haml::Helpers.preserve(13)
+      assert_equal '', Haml::Helpers.preserve(nil)
+      assert_equal 'a&#x000A;b', Haml::Helpers.preserve("a\nb".html_safe)
+    end
+
+    it 'still rejects a broken byte sequence' do
+      skip 'the ArgumentError message is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      # The String pattern would substitute where the Regexp raised, but delete! still raises.
+      broken = (+"a\xFFb\nc").force_encoding('UTF-8')
+      error = assert_raises(ArgumentError) { Haml::Helpers.preserve(broken) }
+      assert_equal 'invalid byte sequence in UTF-8', error.message
+    end
   end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -275,6 +275,10 @@ describe 'optimization' do
   end
 
   describe 'preserve regexes' do
+    def find_and_preserve(*args)
+      Haml::Compiler::ScriptCompiler.find_and_preserve(*args)
+    end
+
     it 'renders a preserved value with only haml/engine required' do
       skip 'subprocess test is CRuby-specific' unless RUBY_ENGINE == 'ruby'
       # haml/engine pulls in neither loader of haml/helpers, so this raised NameError.
@@ -288,6 +292,24 @@ describe 'optimization' do
 
       assert_predicate $?, :success?, out
       assert_equal %Q{<pre>a&#x000A;b</pre>\n}, out
+    end
+
+    it 'matches the same tags as before' do
+      default = %w[textarea pre code]
+      assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", %w[b])
+      assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", [:b])
+      assert_equal "<b>a\nb</b>",       find_and_preserve("<b>a\nb</b>", default)
+      assert_equal '<PRE>a&#x000A;b</PRE>', find_and_preserve("<PRE>a\nb</PRE>", default)
+      assert_equal '<pre class="x">a&#x000A;b</pre>', find_and_preserve(%Q{<pre class="x">a\nb</pre>}, default)
+      # An empty list still builds a regex, one that needs a </> to close.
+      assert_equal "<pre>a\nb</pre>", find_and_preserve("<pre>a\nb</pre>", [])
+      # An empty entry is dropped wherever it sits.
+      assert_equal "<>a\nb</>", find_and_preserve("<>a\nb</>", ['', 'pre'])
+      assert_equal "<>a\nb</>", find_and_preserve("<>a\nb</>", ['pre', ''])
+      # Regexp.escape still applies to a tag carrying regex syntax.
+      assert_equal '<a.b>a&#x000A;b</a.b>', find_and_preserve("<a.b>a\nb</a.b>", ['a.b'])
+      assert_equal '13', find_and_preserve(13, default)
+      assert_equal '',   find_and_preserve(nil, default)
     end
   end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -295,23 +295,23 @@ describe 'optimization' do
     end
 
     it 'builds one regex per tag list' do
-      default = Haml::Helpers::DEFAULT_PRESERVE_TAGS
-      assert_same Haml::Helpers.preserve_regex(default), Haml::Helpers.preserve_regex(default)
+      default = Haml::Preserver::DEFAULT_TAGS
+      assert_same Haml::Preserver.regex(default), Haml::Preserver.regex(default)
       # A literal spelled out by a caller is the same list, so it must hit the same entry.
-      assert_same Haml::Helpers.preserve_regex(default), Haml::Helpers.preserve_regex(%w[textarea pre code])
-      assert_same Haml::Helpers.preserve_regex(%w[b]), Haml::Helpers.preserve_regex(%w[b])
-      refute_same Haml::Helpers.preserve_regex(%w[b]), Haml::Helpers.preserve_regex(%w[i])
+      assert_same Haml::Preserver.regex(default), Haml::Preserver.regex(%w[textarea pre code])
+      assert_same Haml::Preserver.regex(%w[b]), Haml::Preserver.regex(%w[b])
+      refute_same Haml::Preserver.regex(%w[b]), Haml::Preserver.regex(%w[i])
     end
 
     it 'allocates nothing to reach a built regex' do
       skip_unless_cruby('allocation counting')
       custom = %w[b]
-      Haml::Helpers.preserve_regex(custom)
+      Haml::Preserver.regex(custom)
 
       # Steady state is 0, with a few objects on the first pass; building costs 13 a call.
-      assert_operator allocations { Haml::Helpers.preserve_regex(Haml::Helpers::DEFAULT_PRESERVE_TAGS) },
+      assert_operator allocations { Haml::Preserver.regex(Haml::Preserver::DEFAULT_TAGS) },
                       :<, RUNS / 100
-      assert_operator allocations { Haml::Helpers.preserve_regex(custom) }, :<, RUNS / 100
+      assert_operator allocations { Haml::Preserver.regex(custom) }, :<, RUNS / 100
     end
 
     it 'renders a preserved value with only haml/engine required' do
@@ -364,19 +364,19 @@ describe 'optimization' do
 
     it 'keeps a cached list reachable after the caller mutates a tag in place' do
       tag = +'em'
-      Haml::Helpers.preserve_regex([tag])
+      Haml::Preserver.regex([tag])
       tag << 'phasis'
-      assert_same Haml::Helpers.preserve_regex(%w[em]), Haml::Helpers.preserve_regex(%w[em])
+      assert_same Haml::Preserver.regex(%w[em]), Haml::Preserver.regex(%w[em])
       assert_equal '<em>a&#x000A;b</em>', find_and_preserve("<em>a\nb</em>", %w[em])
     end
 
     it 'keeps caching once past the cache limit' do
       # Filling it used to switch caching off for every later list.
-      70.times { |i| Haml::Helpers.preserve_regex(["fill#{i}"]) }
+      70.times { |i| Haml::Preserver.regex(["fill#{i}"]) }
 
-      assert_same Haml::Helpers.preserve_regex(%w[kbd]), Haml::Helpers.preserve_regex(%w[kbd])
-      default = Haml::Helpers::DEFAULT_PRESERVE_TAGS
-      assert_same Haml::Helpers.preserve_regex(default), Haml::Helpers.preserve_regex(%w[textarea pre code])
+      assert_same Haml::Preserver.regex(%w[kbd]), Haml::Preserver.regex(%w[kbd])
+      default = Haml::Preserver::DEFAULT_TAGS
+      assert_same Haml::Preserver.regex(default), Haml::Preserver.regex(%w[textarea pre code])
     end
   end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -273,4 +273,21 @@ describe 'optimization' do
       assert_equal "<p>hello &lt;b&gt;</p>\n", out
     end
   end
+
+  describe 'preserve regexes' do
+    it 'renders a preserved value with only haml/engine required' do
+      skip 'subprocess test is CRuby-specific' unless RUBY_ENGINE == 'ruby'
+      # haml/engine pulls in neither loader of haml/helpers, so this raised NameError.
+      script = <<~'RUBY'
+        require 'haml/engine'
+        haml = %Q{- x = ["<pre>a\\nb</pre>"].first\n~ x\n}
+        print eval(Haml::Engine.new(escape_html: false).call(haml))
+      RUBY
+      lib = File.expand_path('../../lib', __dir__)
+      out = IO.popen([RbConfig.ruby, '-I', lib, '-e', script], err: [:child, :out], &:read)
+
+      assert_predicate $?, :success?, out
+      assert_equal %Q{<pre>a&#x000A;b</pre>\n}, out
+    end
+  end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -295,12 +295,11 @@ describe 'optimization' do
     end
 
     it 'matches the same tags as before' do
-      default = %w[textarea pre code]
       assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", %w[b])
       assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", [:b])
-      assert_equal "<b>a\nb</b>",       find_and_preserve("<b>a\nb</b>", default)
-      assert_equal '<PRE>a&#x000A;b</PRE>', find_and_preserve("<PRE>a\nb</PRE>", default)
-      assert_equal '<pre class="x">a&#x000A;b</pre>', find_and_preserve(%Q{<pre class="x">a\nb</pre>}, default)
+      assert_equal "<b>a\nb</b>",       find_and_preserve("<b>a\nb</b>")
+      assert_equal '<PRE>a&#x000A;b</PRE>', find_and_preserve("<PRE>a\nb</PRE>")
+      assert_equal '<pre class="x">a&#x000A;b</pre>', find_and_preserve(%Q{<pre class="x">a\nb</pre>})
       # An empty list still builds a regex, one that needs a </> to close.
       assert_equal "<pre>a\nb</pre>", find_and_preserve("<pre>a\nb</pre>", [])
       # An empty entry is dropped wherever it sits.
@@ -308,8 +307,8 @@ describe 'optimization' do
       assert_equal "<>a\nb</>", find_and_preserve("<>a\nb</>", ['pre', ''])
       # Regexp.escape still applies to a tag carrying regex syntax.
       assert_equal '<a.b>a&#x000A;b</a.b>', find_and_preserve("<a.b>a\nb</a.b>", ['a.b'])
-      assert_equal '13', find_and_preserve(13, default)
-      assert_equal '',   find_and_preserve(nil, default)
+      assert_equal '13', find_and_preserve(13)
+      assert_equal '',   find_and_preserve(nil)
     end
   end
 end

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -1,12 +1,18 @@
 # frozen_string_literal: true
 
 require_relative '../test_helper'
+# For RailsTemplate.options, since the railtie does not run here.
+require 'haml/rails_template'
 
 describe 'optimization' do
   include RenderHelper
 
-  def compiled_code(haml)
-    Haml::Engine.new.call(haml)
+  def compiled_code(haml, options = {})
+    Haml::Engine.new(options).call(haml)
+  end
+
+  def rails_compiled_code(haml)
+    compiled_code(haml, Haml::RailsTemplate.options)
   end
 
   # "fewer than RUNS objects" in an assertion reads as "no longer one per call".
@@ -278,6 +284,14 @@ describe 'optimization' do
   describe 'preserve regexes' do
     def find_and_preserve(*args)
       Haml::Compiler::ScriptCompiler.find_and_preserve(*args)
+    end
+
+    it 'leaves the tag list out of the emitted call' do
+      # Only `!~` and escape_html: false reach find_and_preserve; plain `~` is escaped.
+      [compiled_code(%Q{- x = 1\n!~ x}), rails_compiled_code(%Q{- x = 1\n!~ x})].each do |code|
+        refute_includes code, '%w(textarea pre code)'
+        assert_match(/ScriptCompiler\.find_and_preserve\([^,)]+\)/, code)
+      end
     end
 
     it 'builds one regex per tag list' do

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -274,9 +274,30 @@ describe 'optimization' do
     end
   end
 
+  # `~` used to rebuild its tag regex per call, and carry the tag list as a per-render literal.
   describe 'preserve regexes' do
     def find_and_preserve(*args)
       Haml::Compiler::ScriptCompiler.find_and_preserve(*args)
+    end
+
+    it 'builds one regex per tag list' do
+      default = Haml::Helpers::DEFAULT_PRESERVE_TAGS
+      assert_same Haml::Helpers.preserve_regex(default), Haml::Helpers.preserve_regex(default)
+      # A literal spelled out by a caller is the same list, so it must hit the same entry.
+      assert_same Haml::Helpers.preserve_regex(default), Haml::Helpers.preserve_regex(%w[textarea pre code])
+      assert_same Haml::Helpers.preserve_regex(%w[b]), Haml::Helpers.preserve_regex(%w[b])
+      refute_same Haml::Helpers.preserve_regex(%w[b]), Haml::Helpers.preserve_regex(%w[i])
+    end
+
+    it 'allocates nothing to reach a built regex' do
+      skip_unless_cruby('allocation counting')
+      custom = %w[b]
+      Haml::Helpers.preserve_regex(custom)
+
+      # Steady state is 0, with a few objects on the first pass; building costs 13 a call.
+      assert_operator allocations { Haml::Helpers.preserve_regex(Haml::Helpers::DEFAULT_PRESERVE_TAGS) },
+                      :<, RUNS / 100
+      assert_operator allocations { Haml::Helpers.preserve_regex(custom) }, :<, RUNS / 100
     end
 
     it 'renders a preserved value with only haml/engine required' do
@@ -294,6 +315,14 @@ describe 'optimization' do
       assert_equal %Q{<pre>a&#x000A;b</pre>\n}, out
     end
 
+    it 'preserves newlines inside the default tags' do
+      assert_render(%Q{<pre>a&#x000A;b</pre>\n}, %Q{- x = ["<pre>a\\nb</pre>"].first\n!~ x})
+      assert_render(%Q{<textarea>a&#x000A;b</textarea>\n},
+                    %Q{- x = ["<textarea>a\\nb</textarea>"].first\n!~ x})
+      # Compiled away by static_compile rather than emitted, but through the same method.
+      assert_render(%Q{<pre>a&#x000A;b</pre>\n}, %Q{~ ["<pre>a\\nb</pre>"][0]}, escape_html: false)
+    end
+
     it 'matches the same tags as before' do
       assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", %w[b])
       assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", [:b])
@@ -309,6 +338,31 @@ describe 'optimization' do
       assert_equal '<a.b>a&#x000A;b</a.b>', find_and_preserve("<a.b>a\nb</a.b>", ['a.b'])
       assert_equal '13', find_and_preserve(13)
       assert_equal '',   find_and_preserve(nil)
+    end
+
+    it 'keeps a cached list working after the caller mutates its own array' do
+      tags = %w[b]
+      assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", tags)
+      tags << 'i'
+      assert_equal '<i>a&#x000A;b</i>', find_and_preserve("<i>a\nb</i>", tags)
+      assert_equal '<b>a&#x000A;b</b>', find_and_preserve("<b>a\nb</b>", %w[b])
+    end
+
+    it 'keeps a cached list reachable after the caller mutates a tag in place' do
+      tag = +'em'
+      Haml::Helpers.preserve_regex([tag])
+      tag << 'phasis'
+      assert_same Haml::Helpers.preserve_regex(%w[em]), Haml::Helpers.preserve_regex(%w[em])
+      assert_equal '<em>a&#x000A;b</em>', find_and_preserve("<em>a\nb</em>", %w[em])
+    end
+
+    it 'keeps caching once past the cache limit' do
+      # Filling it used to switch caching off for every later list.
+      70.times { |i| Haml::Helpers.preserve_regex(["fill#{i}"]) }
+
+      assert_same Haml::Helpers.preserve_regex(%w[kbd]), Haml::Helpers.preserve_regex(%w[kbd])
+      default = Haml::Helpers::DEFAULT_PRESERVE_TAGS
+      assert_same Haml::Helpers.preserve_regex(default), Haml::Helpers.preserve_regex(%w[textarea pre code])
     end
   end
 end

--- a/test/haml/rails_template_test.rb
+++ b/test/haml/rails_template_test.rb
@@ -95,6 +95,24 @@ describe Haml::RailsTemplate do
     HAML
   end
 
+  # The regex is cached per tag list, so lists have to stay apart from each other.
+  specify 'find_and_preserve with custom tags' do
+    assert_equal <<-HTML.unindent, render(<<-'HAML'.unindent)
+      &lt;b&gt;a&amp;#x000A;b&lt;/b&gt;
+      &lt;i&gt;a&amp;#x000A;b&lt;/i&gt;
+      &lt;b&gt;c&amp;#x000A;d&lt;/b&gt;
+      &lt;pre&gt;e&amp;#x000A;f&lt;/pre&gt;
+      &lt;pre&gt;g
+      h&lt;/pre&gt;
+    HTML
+      = find_and_preserve("<b>a\nb</b>", %w[b])
+      = find_and_preserve("<i>a\nb</i>", %w[i])
+      = find_and_preserve("<b>c\nd</b>", %w[b])
+      = find_and_preserve("<pre>e\nf</pre>")
+      = find_and_preserve("<pre>g\nh</pre>", [])
+    HAML
+  end
+
   specify 'capture_haml' do
     assert_equal <<-HTML.unindent, render(<<-'HAML'.unindent)
       <div class="capture"><span>


### PR DESCRIPTION
## Summary

`find_and_preserve` rebuilt its regex on every call: `Regexp.escape` per tag, a join, and a
fresh `Regexp` interpolated from the result. Two copies did it, one in `ScriptCompiler` and
one in `RailsHelpers`, and they had already drifted apart. They are now one implementation in
`Haml::Helpers`, behind a copy-on-write cache keyed by tag list.

Split into small commits, each green on its own, each carrying its own rationale in the
commit message.

## User visible changes

- **A `NameError` is fixed.** `haml/engine.rb` never required `haml/helpers`, so
  `require 'haml/engine'` alone, rendering `~` over content holding a `<pre>`, crashed at
  `script_compiler.rb:14`. Subprocess test included.
- **An empty tag no longer joins the pattern**, where it used to match a literal `<>`. The
  two builders also disagreed about a leading one.
- **`Haml::RailsHelpers::DEFAULT_PRESERVE_TAGS` is no longer declared there.** It still
  resolves, to the same object, through `include Helpers`; only `constants(false)` can tell.
- **`preserve` matches a newline with a String, not a Regexp.** Equivalent except on a broken
  coderange, where the next line, `delete!("\r")`, raises the same error anyway.

## Benchmarks

Ruby 4.0.2, old implementation reproduced verbatim beside the new:

| | before | after | |
|---|---:|---:|---:|
| `find_and_preserve`, no match | 201k ips | 3519k ips | 17.5x |
| `find_and_preserve`, one `<pre>` | 139k ips | 511k ips | 3.66x |
| render of `!~ x`, compiled shape | 140k ips | 512k ips | 3.64x |
| `find_and_preserve`, 20 lines | 76k ips | 147k ips | 1.95x |

The first row is the common case: `~` is often used defensively over content that holds no
preserved tag, and that used to pay full construction to then match nothing. The gain shrinks
as input grows, because then matching dominates. Allocations per call go 20 to 2 with no
match; a cached lookup allocates nothing.

The cache is a frozen Hash replaced on a miss, never mutated, so a racing writer on jruby or
truffleruby at worst rebuilds a regex. Rationale for the key and the size cap is in the
message of the commit that adds it.