### PR TITLE
Keep interpolated text in the source encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Haml Changelog
 
+## Unreleased
+
+* Keep interpolated text in the source encoding, fixing the `Encoding::CompatibilityError` remaining on an ASCII-8BIT template source that mixes plain text and interpolation with non-ASCII characters https://github.com/haml/haml/issues/1218
+
 ## 7.3.1
 
 * Keep Prism-derived fragments in the source encoding, fixing `Encoding::CompatibilityError` on an ASCII-8BIT template source with non-ASCII characters (regression in 7.3.0) https://github.com/haml/haml/issues/1218

--- a/lib/haml/util.rb
+++ b/lib/haml/util.rb
@@ -223,7 +223,13 @@ MSG
           res << "\#{#{content}}"
         end
       end
-      res + rest
+      # The result is rebuilt from `str.dump` fragments and eval'd pieces, so it can
+      # come out tagged with an encoding that differs from `str`'s (e.g. UTF-8 for a
+      # BINARY source). The compiled template joins this string literal's fragments
+      # with fragments sliced out of the source itself, and mixed encodings raise
+      # Encoding::CompatibilityError, so bring it back to the source encoding.
+      # See haml/haml#1218.
+      (res + rest).force_encoding(str.encoding)
     end
 
     private

--- a/test/haml/engine_test.rb
+++ b/test/haml/engine_test.rb
@@ -1944,6 +1944,20 @@ HTML
 HAML
   end
 
+  def test_binary_source_with_interpolation_in_plain_text # encoding
+    # Util.unescape_interpolation rebuilds interpolated text from `str.dump`, which
+    # can re-tag the string literal as UTF-8 for a BINARY source. Its fragments then
+    # mix with plain-text fragments kept in the source encoding and raise
+    # Encoding::CompatibilityError when joined. See haml/haml#1218.
+    assert_equal(<<HTML, render(<<'HAML'.b))
+<h1>🍣</h1>
+<p>🍺1</p>
+HTML
+%h1 🍣
+%p 🍺#{1}
+HAML
+  end
+
   def test_encoding_error # encoding
     render("foo\nbar\nb\xFEaz".dup.force_encoding("utf-8"))
     assert(false, "Expected exception")


### PR DESCRIPTION
Follow-up to #1219 — that fix turned out to be incomplete. Fixes the remaining case of #1218.

## Remaining problem

On 7.3.1, a BINARY template source still raises `Encoding::CompatibilityError` when non-ASCII characters appear both in a plain-text line and in a line that carries interpolation:

```ruby
require 'haml'

source = <<~HAML.force_encoding(Encoding::BINARY)
  %h1 🍣
  %p 🍺#{'#{1}'}
HAML

Haml::Engine.new.call(source)
# => Encoding::CompatibilityError: incompatible character encodings: BINARY (ASCII-8BIT) and UTF-8
```

(Real-world trigger is the same as #1218: Rails' `ActionView::DependencyTracker` compiles `template.source` as `File.binread` returned it.)

## Cause

`Util.unescape_interpolation` rebuilds interpolation-bearing text from `str.dump` and eval'd pieces, so the string literal it returns loses the source encoding: for a BINARY source, `str.dump` escapes non-ASCII bytes as `\xNN` and the rebuilt literal comes out tagged UTF-8. When `StringSplitter` later splits that literal, `in_source_encoding` (#1219) aligns the fragments to the *literal's* encoding — which no longer matches the source. The compiled template then joins those UTF-8 fragments with plain-text fragments sliced out of the source itself (still BINARY), and `Temple::Filters::StaticMerger` raises once both sides hold non-ASCII bytes.

In other words: #1219 aligned Prism-derived fragments to the encoding of the code being split, but interpolation-bearing text had already lost the source encoding one step earlier.

## Fix

Bring the result of `unescape_interpolation` back to the source encoding (a byte-preserving `force_encoding`, same philosophy as #1219). This restores the invariant that everything the compiled template joins stays in the source encoding, for all `unescape_interpolation` callers (plain text, tag text, and the text-based filters).

## Verification

- New regression test fails on 7.3.1 and passes with this change; full suite is green (1162 runs, 0 failures).
- Verified against the Rails app where we hit #1218: brute-force compiling all 370 Haml templates the way `DependencyTracker` does (BINARY source) — 7 templates fail on 7.3.1, 0 fail with this change.
