### PR TITLE
Compile a multi-line attribute hash statically

### DIFF
--- a/benchmark/multiline_attribute.haml
+++ b/benchmark/multiline_attribute.haml
@@ -1,0 +1,5 @@
+%a{ href: '&"\'<>',
+    title: 'x' }
+- href = '&"\'<>'
+%a{ href: href,
+    title: 'x' }

--- a/lib/haml/attribute_compiler.rb
+++ b/lib/haml/attribute_compiler.rb
@@ -3,6 +3,7 @@ require 'set'
 require 'haml/attribute_builder'
 require 'haml/attribute_parser'
 require 'haml/ruby_expression'
+require 'haml/temple_line_counter'
 
 module Haml
   # The set of boolean attributes. You may add custom attributes to this constant.
@@ -24,12 +25,15 @@ module Haml
     def compile(node)
       hashes = []
       return runtime_compile(node) if node.value[:object_ref] != :nil
-      [node.value[:dynamic_attributes].new, node.value[:dynamic_attributes].old].compact.each do |attribute_str|
+      dynamic_attributes = node.value[:dynamic_attributes]
+      [dynamic_attributes.new, dynamic_attributes.old].compact.each do |attribute_str|
         hash = AttributeParser.parse(attribute_str)
         return runtime_compile(node) if hash.nil? || hash.any? { |_key, value| value.empty? }
         hashes << hash
       end
-      static_compile(node.value[:attributes], hashes)
+      temple = static_compile(node.value[:attributes], hashes)
+      restore_newlines!(temple, dynamic_attributes)
+      temple
     end
 
     private
@@ -65,6 +69,13 @@ module Haml
         end
       end
       temple
+    end
+
+    # ChildrenCompiler counts on the tag spanning as many lines as its attribute source does.
+    def restore_newlines!(temple, dynamic_attributes)
+      missing = dynamic_attributes.newline_count
+      missing -= TempleLineCounter.count_lines(temple) if missing > 0
+      missing.times { temple << [:newline] }
     end
 
     def compile_id!(temple, key, values)

--- a/lib/haml/attribute_parser.rb
+++ b/lib/haml/attribute_parser.rb
@@ -15,15 +15,11 @@ module Haml
     end
 
     # @return [Hash,nil] - keys and values are the attribute source as written, or nil if
-    #   the text is not a Hash literal whose keys are all static.
+    #   the text is not a Hash literal whose keys are all static, or if it holds a heredoc.
     def parse(text)
       exp = wrap_bracket(text)
-      # A multi-line hash is left to the runtime, which keeps the [:newline] bookkeeping of
-      # the compiled code correct. Compiling it statically is a separate optimization.
-      return if exp.include?("\n")
-
       node = hash_node(exp)
-      return if node.nil?
+      return if node.nil? || contains_heredoc?(exp, node)
 
       hash = {}
       node.elements.each do |element|
@@ -56,6 +52,12 @@ module Haml
 
       node = statements.first
       node if node.is_a?(Prism::HashNode)
+    end
+
+    # A heredoc's body lies outside its node, so the value's slice would not be the value.
+    # Its opener always spells `<<`, which spares the tree walk for nearly every hash.
+    def contains_heredoc?(exp, node)
+      exp.include?('<<') && !node.breadth_first_search { |n| n.respond_to?(:heredoc?) && n.heredoc? }.nil?
     end
 
     # The key as written between its delimiters, not unescaped: an escape has to reach the

--- a/lib/haml/compiler/children_compiler.rb
+++ b/lib/haml/compiler/children_compiler.rb
@@ -40,9 +40,7 @@ module Haml
         when :script, :silent_script
           @lineno += 1
         when :tag
-          [node.value[:dynamic_attributes].new, node.value[:dynamic_attributes].old].compact.each do |attribute_hash|
-            @lineno += attribute_hash.count("\n")
-          end
+          @lineno += node.value[:dynamic_attributes].newline_count
           @lineno += 1 if node.children.empty? && node.value[:parse]
         end
 

--- a/lib/haml/parser.rb
+++ b/lib/haml/parser.rb
@@ -247,6 +247,12 @@ module Haml
         [new, stripped_old].compact.join(', ')
       end
 
+      # The lines a tag spans beyond its first because of these attributes, which is what
+      # the compiled tag has to span too for the line numbers after it to hold.
+      def newline_count
+        (new ? new.count("\n") : 0) + (old ? old.count("\n") : 0)
+      end
+
       private
 
       # For `%foo{ { foo: 1 }, bar: 2 }`, :old is "{ { foo: 1 }, bar: 2 }" and this method returns " { foo: 1 }, bar: 2 " for last argument.

--- a/lib/haml/temple_line_counter.rb
+++ b/lib/haml/temple_line_counter.rb
@@ -19,13 +19,27 @@ module Haml
         arg.count("\n") + cases.map do |cond, e|
           (cond == :else ? 0 : cond.count("\n")) + count_lines(e)
         end.reduce(:+)
-      when :escape
+      when :escape, :fescape
         count_lines(args[1])
+      when :html
+        count_html_lines(args)
       when :newline
         1
       else
         raise UnexpectedExpression.new("[HAML BUG] Unexpected Temple expression '#{type}' is given!")
       end
     end
+
+    def self.count_html_lines(args)
+      case args[0]
+      when :attrs
+        args.drop(1).sum { |a| count_lines(a) }
+      when :attr
+        count_lines(args[2])
+      else
+        raise UnexpectedExpression.new("[HAML BUG] Unexpected Temple expression 'html #{args[0]}' is given!")
+      end
+    end
+    private_class_method :count_html_lines
   end
 end

--- a/test/haml/attribute_parser_test.rb
+++ b/test/haml/attribute_parser_test.rb
@@ -129,11 +129,24 @@ describe Haml::AttributeParser do
       end
     end
 
-    # A multi-line hash is deliberately left to the runtime: compiling it statically drops a
-    # [:newline] and shifts every __LINE__ after it. See test/haml/line_number_test.rb.
     describe 'multiline' do
-      it { assert_parse(nil, "foo: 1,\n  bar: 2") }
-      it { assert_parse(nil, " { foo: 1,\n  bar: 2 } ") }
+      it { assert_parse({ 'foo' => '1', 'bar' => '2' }, "foo: 1,\n  bar: 2") }
+      it { assert_parse({ 'foo' => '1', 'bar' => '2' }, " { foo: 1,\n  bar: 2 } ") }
+      it { assert_parse({ 'foo' => '1', 'bar' => '2' }, "{\n  foo: 1,\n  bar: 2\n}") }
+      it { assert_parse({ 'foo' => "[1,\n  2]", 'bar' => '3' }, "foo: [1,\n  2],\n  bar: 3") }
+      it { assert_parse({ 'foo' => "{ a: 1,\n  b: 2 }" }, "foo: { a: 1,\n  b: 2 }") }
+      it { assert_parse({ 'foo' => "\"a\nb\"" }, "foo: \"a\nb\"") }
+      it { assert_parse({ 'foo' => '1', 'bar' => '2' }, "foo: 1, # first\n  bar: 2") }
+
+      # The body of a heredoc lies outside its node, so its slice would not be the value.
+      describe 'heredoc' do
+        it { assert_parse(nil, "foo: <<~X,\n  hi\n  X\n  bar: 2") }
+        it { assert_parse(nil, "foo: <<-X,\n  hi\n  X\n  bar: 2") }
+        it { assert_parse(nil, "foo: <<X,\nhi\nX\n  bar: 2") }
+        it { assert_parse(nil, "foo: 1,\n  bar: [<<~X].first,\n  hi\n  X\n  baz: 3") }
+        it { assert_parse(nil, "foo: <<~X,\n  \#{hi}\n  X\n  bar: 2") }
+        it { assert_parse(nil, "foo: <<~`X`,\n  ls\n  X\n  bar: 2") }
+      end
     end
   end
 

--- a/test/haml/engine/old_attribute_test.rb
+++ b/test/haml/engine/old_attribute_test.rb
@@ -625,5 +625,109 @@ describe Haml::Engine do
         HAML
       end
     end
+
+    describe 'multi-line hash' do
+      it 'renders a static hash like its single-line form' do
+        assert_equal render_haml(<<-HAML.unindent), render_haml(<<-HAML.unindent)
+          %div{ class: 'card', id: 'main', title: 'hi' } text
+        HAML
+          %div{ class: 'card',
+                id: 'main',
+                title: 'hi' } text
+        HAML
+      end
+
+      it 'renders a hash mixing static and dynamic values' do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <a class="btn" href="/users/1" title="&lt;show&gt;">show</a>
+        HTML
+          - url = '/users/1'
+          - title = '<show>'
+          %a{ href: url,
+              class: 'btn',
+              title: title } show
+        HAML
+      end
+
+      it 'renders a nested hash which spans lines' do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <div data-action="click-&gt;user#show" data-controller="user" data-user-id="1"></div>
+        HTML
+          - id = 1
+          %div{ data: { controller: 'user',
+                        action: 'click->user#show',
+                        user_id: id } }
+        HAML
+      end
+
+      it 'renders a class array which spans lines' do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <div class="a b c"></div>
+        HTML
+          - c = 'c'
+          %div{ class: ['a',
+                        'b',
+                        c] }
+        HAML
+      end
+
+      it 'renders a string literal which spans lines' do
+        assert_render(<<-HTML.unindent, <<-'HAML'.unindent)
+          <div id="1" title="hello
+          world 1"></div>
+        HTML
+          - x = 1
+          %div{ title: "hello
+            world #{x}",
+                id: 1 }
+        HAML
+      end
+
+      it 'renders a boolean attribute' do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <input disabled type="text">
+          <input type="text">
+        HTML
+          - on = true
+          %input{ disabled: on,
+                  type: 'text' }
+          %input{ disabled: !on,
+                  type: 'text' }
+        HAML
+      end
+
+      it 'renders a heredoc value' do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <div a="hi
+          " b="2"></div>
+        HTML
+          %div{ a: <<~X,
+            hi
+            X
+            b: 2 }
+        HAML
+      end
+
+      it 'renders a double splat and an omitted value' do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <div a="1" b="2" c="3"></div>
+        HTML
+          - b = 2
+          - rest = { c: 3 }
+          %div{ a: 1,
+                b:,
+                **rest }
+        HAML
+      end
+
+      it 'escapes attribute values' do
+        assert_render(<<-HTML.unindent, <<-HAML.unindent)
+          <div id="x" title="&amp;&quot;&#39;&lt;&gt;"></div>
+        HTML
+          %div{ title: '&"\\'<>',
+                id: 'x' }
+        HAML
+      end
+    end
   end
 end

--- a/test/haml/line_number_test.rb
+++ b/test/haml/line_number_test.rb
@@ -65,12 +65,53 @@ describe Haml::Engine do
   end
 
   describe 'old attributes' do
+    # The values of a multi-line hash are evaluated on the tag's line, as in a single-line one.
     it 'renders multi-line old attributes' do
       assert_render(<<-HTML.unindent, <<-HAML.unindent)
-        <span a="1" b="2">2</span>
+        <span a="1" b="1">2</span>
         3
       HTML
         %span{ a: __LINE__,
+          b: __LINE__ }= __LINE__
+        = __LINE__
+      HAML
+    end
+
+    it 'renders multi-line old attributes with children' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <div a="1" b="2">
+        3
+        </div>
+        4
+      HTML
+        %div{ a: 1,
+          b: 2 }
+          = __LINE__
+        = __LINE__
+      HAML
+    end
+
+    it 'keeps the lines of a value which spans lines itself' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <span a="[1, 2]" b="3">3</span>
+        4
+      HTML
+        %span{ a: [1,
+          __LINE__],
+          b: 3 }= __LINE__
+        = __LINE__
+      HAML
+    end
+
+    it 'renders multi-line old attributes with a heredoc' do
+      assert_render(<<-HTML.unindent, <<-HAML.unindent)
+        <span a="hi
+        " b="4">4</span>
+        5
+      HTML
+        %span{ a: <<~X,
+          hi
+          X
           b: __LINE__ }= __LINE__
         = __LINE__
       HAML

--- a/test/haml/optimization_test.rb
+++ b/test/haml/optimization_test.rb
@@ -62,6 +62,25 @@ describe 'optimization' do
       haml = %|%span= 1|
       assert_equal true, compiled_code(haml).include?(%|<span>1</span>|)
     end
+
+    it 'compiles a multi-line hash without the runtime builder' do
+      haml = "%div{ class: 'card',\n      id: 'main',\n      title: 'hi' }"
+      code = compiled_code(haml)
+      refute_includes code, 'AttributeBuilder.build('
+      assert_includes code, %q|<div class=\"card\" id=\"main\" title=\"hi\">|
+    end
+
+    it 'renders a multi-line hash like its single-line form' do
+      single = "- href = '/x'\n%a{ href: href, class: 'btn' } x"
+      multi = "- href = '/x'\n%a{ href: href,\n    class: 'btn' } x"
+      assert_equal render_haml(single), render_haml(multi)
+      refute_includes compiled_code(multi), 'AttributeBuilder.build('
+    end
+
+    it 'leaves a multi-line hash holding a heredoc to the runtime builder' do
+      haml = "%div{ a: <<~X,\n  hi\n  X\n  b: 2 }"
+      assert_includes compiled_code(haml), 'AttributeBuilder.build('
+    end
   end
 
   describe 'string interpolation' do

--- a/test/haml/temple_line_counter_test.rb
+++ b/test/haml/temple_line_counter_test.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+describe Haml::TempleLineCounter do
+  def count_lines(exp)
+    Haml::TempleLineCounter.count_lines(exp)
+  end
+
+  it 'counts the code inside an fescape like an escape' do
+    assert_equal 1, count_lines([:fescape, true, [:dynamic, "a\nb"]])
+    assert_equal 0, count_lines([:fescape, true, [:static, "a\\nb"]])
+  end
+
+  it 'counts every child of html attrs' do
+    attrs = [:html, :attrs,
+             [:html, :attr, 'a', [:fescape, true, [:dynamic, "x\ny"]]],
+             [:html, :attr, 'b', [:multi]],
+             [:static, ' c="1"'],
+             [:dynamic, "p\nq\nr"],
+             [:case, "(v = (d\ne))", ['true', [:html, :attr, 'd', [:multi]]], [:else, [:multi]]],
+             [:newline]]
+    assert_equal 5, count_lines(attrs)
+  end
+
+  it 'counts the value of an html attr, not its name' do
+    assert_equal 2, count_lines([:html, :attr, "a\nb", [:dynamic, "x\ny\nz"]])
+  end
+
+  it 'refuses an html expression it does not know' do
+    assert_raises(Haml::TempleLineCounter::UnexpectedExpression) do
+      count_lines([:html, :tag, 'p', [:html, :attrs], [:multi]])
+    end
+  end
+end


### PR DESCRIPTION
## Change

`%div{ class: "card", id: "main" }` compiles to one static String, but the same hash broken across two lines called `AttributeBuilder.build` on every render, because `AttributeParser` returned nil on any newline. The guard existed for line numbers: `ChildrenCompiler` advances its line count by the newlines in the attribute source, and the runtime path embeds that source verbatim. The static path now keeps the same contract by asking `TempleLineCounter` how many lines its temple spans and appending the `[:newline]` nodes still missing; a newline inside a value emitted verbatim is counted, not doubled. The count is only taken when the source has a newline, so a single-line hash compiles at the same cost as before. A hash holding a heredoc stays on the runtime, since a heredoc's slice does not include its body.

## Behaviour change

The values of a multi-line hash are evaluated on the tag's first line and in attribute order, exactly as a single-line hash already is. `__LINE__` inside such a value, and the backtrace of an exception raised there, point at the tag; the lines of the tag's content and of everything after it are unchanged (`line_number_test` updated from `b="2"` to `b="1"`). `Haml::AttributeParser.parse` now returns a Hash for a multi-line hash instead of nil.

## Results

Render on ruby 4.0.2, Tilt path, same template files on both sides:

| render | main | branch |
| --- | ---: | ---: |
| `benchmark/multiline_attribute.haml` (new, twin of `common_attribute`) | 305k ips | 2.70M ips (**8.9x**) |
| `benchmark/common_attribute.haml` (its single-line twin) | 2.81M ips | 2.76M ips |
| the 3-line hash of the report, alone | 420k ips | 8.75M ips (**20.8x**) |
| the same hash on one line, alone | 20.4M ips | 19.7M ips |

The remaining gap on the last pair is a Tilt-only artefact: a template that is a single static tag collapses to `_buf = "..."`, and the `[:newline]` nodes keep it from doing so; the Rails generator has no such shortcut, and any template with one more line does not take it either, hence the twins tying. The 21 existing benchmark templates compile to byte-identical Ruby. Suite at 1227 runs, 0 failures.
